### PR TITLE
Feature/VDYP-1070

### DIFF
--- a/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/input/HcsvLayerRecordBean.java
+++ b/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/input/HcsvLayerRecordBean.java
@@ -281,6 +281,73 @@ public class HcsvLayerRecordBean {
 	@CsvBindByPosition(position = 37)
 	private String closeUtilizationVolumeLessDecayAndWastagePerHectare125Adjustment;
 
+	// Optional: age and height for species 3-6
+	@PreAssignmentProcessor(processor = NAEmptyOrBlankStringsToNull.class)
+	@CsvBindByName(column = "EST_AGE_SPP3")
+	@CsvBindByPosition(position = 38)
+	private String estimatedAgeSpp3;
+
+	@PreAssignmentProcessor(processor = NAEmptyOrBlankStringsToNull.class)
+	@CsvBindByName(column = "EST_HEIGHT_SPP3")
+	@CsvBindByPosition(position = 39)
+	private String estimatedHeightSpp3;
+
+	@PreAssignmentProcessor(processor = NAEmptyOrBlankStringsToNull.class)
+	@CsvBindByName(column = "EST_AGE_SPP4")
+	@CsvBindByPosition(position = 40)
+	private String estimatedAgeSpp4;
+
+	@PreAssignmentProcessor(processor = NAEmptyOrBlankStringsToNull.class)
+	@CsvBindByName(column = "EST_HEIGHT_SPP4")
+	@CsvBindByPosition(position = 41)
+	private String estimatedHeightSpp4;
+
+	@PreAssignmentProcessor(processor = NAEmptyOrBlankStringsToNull.class)
+	@CsvBindByName(column = "EST_AGE_SPP5")
+	@CsvBindByPosition(position = 42)
+	private String estimatedAgeSpp5;
+
+	@PreAssignmentProcessor(processor = NAEmptyOrBlankStringsToNull.class)
+	@CsvBindByName(column = "EST_HEIGHT_SPP5")
+	@CsvBindByPosition(position = 43)
+	private String estimatedHeightSpp5;
+
+	@PreAssignmentProcessor(processor = NAEmptyOrBlankStringsToNull.class)
+	@CsvBindByName(column = "EST_AGE_SPP6")
+	@CsvBindByPosition(position = 44)
+	private String estimatedAgeSpp6;
+
+	@PreAssignmentProcessor(processor = NAEmptyOrBlankStringsToNull.class)
+	@CsvBindByName(column = "EST_HEIGHT_SPP6")
+	@CsvBindByPosition(position = 45)
+	private String estimatedHeightSpp6;
+
+	// Optional: per-species site index for species 2-6
+	@PreAssignmentProcessor(processor = NAEmptyOrBlankStringsToNull.class)
+	@CsvBindByName(column = "EST_SITE_INDEX_SPP2")
+	@CsvBindByPosition(position = 46)
+	private String estimatedSiteIndexSpp2;
+
+	@PreAssignmentProcessor(processor = NAEmptyOrBlankStringsToNull.class)
+	@CsvBindByName(column = "EST_SITE_INDEX_SPP3")
+	@CsvBindByPosition(position = 47)
+	private String estimatedSiteIndexSpp3;
+
+	@PreAssignmentProcessor(processor = NAEmptyOrBlankStringsToNull.class)
+	@CsvBindByName(column = "EST_SITE_INDEX_SPP4")
+	@CsvBindByPosition(position = 48)
+	private String estimatedSiteIndexSpp4;
+
+	@PreAssignmentProcessor(processor = NAEmptyOrBlankStringsToNull.class)
+	@CsvBindByName(column = "EST_SITE_INDEX_SPP5")
+	@CsvBindByPosition(position = 49)
+	private String estimatedSiteIndexSpp5;
+
+	@PreAssignmentProcessor(processor = NAEmptyOrBlankStringsToNull.class)
+	@CsvBindByName(column = "EST_SITE_INDEX_SPP6")
+	@CsvBindByPosition(position = 50)
+	private String estimatedSiteIndexSpp6;
+
 	public long getFeatureId() {
 		Validate.notNull(featureId, "HcsvLayerRecordBean.getFeatureId: featureId must not be null");
 		return CsvRecordBeanHelper.parseLongAcceptNull(featureId);
@@ -339,7 +406,8 @@ public class HcsvLayerRecordBean {
 	}
 
 	public record SpeciesDetails(
-			int layerSpeciesIndex, String speciesCode, double percent, Short estimatedAge, Double estimatedHeight
+			int layerSpeciesIndex, String speciesCode, double percent, Short estimatedAge, Double estimatedHeight,
+			Double estimatedSiteIndex
 	) {
 	}
 
@@ -354,36 +422,52 @@ public class HcsvLayerRecordBean {
 		var details = new ArrayList<SpeciesDetails>();
 
 		if (getSpeciesPercent1() != null) {
-			var speciesCode = getSpeciesCode1();
 			details.add(
 					new SpeciesDetails(
-							1, speciesCode, getSpeciesPercent1(), getEstimatedAgeSpp1(), getEstimatedHeightSpp1()
+							1, getSpeciesCode1(), getSpeciesPercent1(), getEstimatedAgeSpp1(), getEstimatedHeightSpp1(),
+							null
 					)
 			);
 		}
 		if (getSpeciesPercent2() != null) {
-			var speciesCode = getSpeciesCode2();
 			details.add(
 					new SpeciesDetails(
-							2, speciesCode, getSpeciesPercent2(), getEstimatedAgeSpp2(), getEstimatedHeightSpp2()
+							2, getSpeciesCode2(), getSpeciesPercent2(), getEstimatedAgeSpp2(), getEstimatedHeightSpp2(),
+							getEstimatedSiteIndexSpp2()
 					)
 			);
 		}
 		if (getSpeciesPercent3() != null) {
-			var speciesCode = getSpeciesCode3();
-			details.add(new SpeciesDetails(3, speciesCode, getSpeciesPercent3(), null, null));
+			details.add(
+					new SpeciesDetails(
+							3, getSpeciesCode3(), getSpeciesPercent3(), getEstimatedAgeSpp3(), getEstimatedHeightSpp3(),
+							getEstimatedSiteIndexSpp3()
+					)
+			);
 		}
 		if (getSpeciesPercent4() != null) {
-			var speciesCode = getSpeciesCode4();
-			details.add(new SpeciesDetails(4, speciesCode, getSpeciesPercent4(), null, null));
+			details.add(
+					new SpeciesDetails(
+							4, getSpeciesCode4(), getSpeciesPercent4(), getEstimatedAgeSpp4(), getEstimatedHeightSpp4(),
+							getEstimatedSiteIndexSpp4()
+					)
+			);
 		}
 		if (getSpeciesPercent5() != null) {
-			var speciesCode = getSpeciesCode5();
-			details.add(new SpeciesDetails(5, speciesCode, getSpeciesPercent5(), null, null));
+			details.add(
+					new SpeciesDetails(
+							5, getSpeciesCode5(), getSpeciesPercent5(), getEstimatedAgeSpp5(), getEstimatedHeightSpp5(),
+							getEstimatedSiteIndexSpp5()
+					)
+			);
 		}
 		if (getSpeciesPercent6() != null) {
-			var speciesCode = getSpeciesCode6();
-			details.add(new SpeciesDetails(6, speciesCode, getSpeciesPercent6(), null, null));
+			details.add(
+					new SpeciesDetails(
+							6, getSpeciesCode6(), getSpeciesPercent6(), getEstimatedAgeSpp6(), getEstimatedHeightSpp6(),
+							getEstimatedSiteIndexSpp6()
+					)
+			);
 		}
 
 		return details;
@@ -451,6 +535,58 @@ public class HcsvLayerRecordBean {
 
 	public Double getEstimatedHeightSpp2() {
 		return CsvRecordBeanHelper.parseDoubleAcceptNull(estimatedHeightSpp2);
+	}
+
+	public Short getEstimatedAgeSpp3() {
+		return CsvRecordBeanHelper.parseShortAcceptNull(estimatedAgeSpp3);
+	}
+
+	public Double getEstimatedHeightSpp3() {
+		return CsvRecordBeanHelper.parseDoubleAcceptNull(estimatedHeightSpp3);
+	}
+
+	public Short getEstimatedAgeSpp4() {
+		return CsvRecordBeanHelper.parseShortAcceptNull(estimatedAgeSpp4);
+	}
+
+	public Double getEstimatedHeightSpp4() {
+		return CsvRecordBeanHelper.parseDoubleAcceptNull(estimatedHeightSpp4);
+	}
+
+	public Short getEstimatedAgeSpp5() {
+		return CsvRecordBeanHelper.parseShortAcceptNull(estimatedAgeSpp5);
+	}
+
+	public Double getEstimatedHeightSpp5() {
+		return CsvRecordBeanHelper.parseDoubleAcceptNull(estimatedHeightSpp5);
+	}
+
+	public Short getEstimatedAgeSpp6() {
+		return CsvRecordBeanHelper.parseShortAcceptNull(estimatedAgeSpp6);
+	}
+
+	public Double getEstimatedHeightSpp6() {
+		return CsvRecordBeanHelper.parseDoubleAcceptNull(estimatedHeightSpp6);
+	}
+
+	public Double getEstimatedSiteIndexSpp2() {
+		return CsvRecordBeanHelper.parseDoubleAcceptNull(estimatedSiteIndexSpp2);
+	}
+
+	public Double getEstimatedSiteIndexSpp3() {
+		return CsvRecordBeanHelper.parseDoubleAcceptNull(estimatedSiteIndexSpp3);
+	}
+
+	public Double getEstimatedSiteIndexSpp4() {
+		return CsvRecordBeanHelper.parseDoubleAcceptNull(estimatedSiteIndexSpp4);
+	}
+
+	public Double getEstimatedSiteIndexSpp5() {
+		return CsvRecordBeanHelper.parseDoubleAcceptNull(estimatedSiteIndexSpp5);
+	}
+
+	public Double getEstimatedSiteIndexSpp6() {
+		return CsvRecordBeanHelper.parseDoubleAcceptNull(estimatedSiteIndexSpp6);
 	}
 
 	public Boolean getAdjustmentIndicatorInd() {
@@ -642,6 +778,34 @@ public class HcsvLayerRecordBean {
 			bvh.validateNumber(bean.estimatedHeightSpp1, n -> Double.parseDouble(n), "Estimated Height Spp 1");
 			bvh.validateNumber(bean.estimatedAgeSpp2, n -> Short.parseShort(n), "Estimated Age Spp 2");
 			bvh.validateNumber(bean.estimatedHeightSpp2, n -> Double.parseDouble(n), "Estimated Height Spp 2");
+			bvh.validateNumber(bean.estimatedAgeSpp3, n -> Short.parseShort(n), "Estimated Age Spp 3");
+			bvh.validateNumber(bean.estimatedHeightSpp3, n -> Double.parseDouble(n), "Estimated Height Spp 3");
+			bvh.validateNumber(bean.estimatedAgeSpp4, n -> Short.parseShort(n), "Estimated Age Spp 4");
+			bvh.validateNumber(bean.estimatedHeightSpp4, n -> Double.parseDouble(n), "Estimated Height Spp 4");
+			bvh.validateNumber(bean.estimatedAgeSpp5, n -> Short.parseShort(n), "Estimated Age Spp 5");
+			bvh.validateNumber(bean.estimatedHeightSpp5, n -> Double.parseDouble(n), "Estimated Height Spp 5");
+			bvh.validateNumber(bean.estimatedAgeSpp6, n -> Short.parseShort(n), "Estimated Age Spp 6");
+			bvh.validateNumber(bean.estimatedHeightSpp6, n -> Double.parseDouble(n), "Estimated Height Spp 6");
+			bvh.validateRange(
+					bean.estimatedSiteIndexSpp2, Double::parseDouble, Double::parseDouble, 0d, Double.MAX_VALUE,
+					"Estimated Site Index Spp 2"
+			);
+			bvh.validateRange(
+					bean.estimatedSiteIndexSpp3, Double::parseDouble, Double::parseDouble, 0d, Double.MAX_VALUE,
+					"Estimated Site Index Spp 3"
+			);
+			bvh.validateRange(
+					bean.estimatedSiteIndexSpp4, Double::parseDouble, Double::parseDouble, 0d, Double.MAX_VALUE,
+					"Estimated Site Index Spp 4"
+			);
+			bvh.validateRange(
+					bean.estimatedSiteIndexSpp5, Double::parseDouble, Double::parseDouble, 0d, Double.MAX_VALUE,
+					"Estimated Site Index Spp 5"
+			);
+			bvh.validateRange(
+					bean.estimatedSiteIndexSpp6, Double::parseDouble, Double::parseDouble, 0d, Double.MAX_VALUE,
+					"Estimated Site Index Spp 6"
+			);
 			bvh.validateNumber(
 					bean.loreyHeight75Adjustment, n -> Double.parseDouble(n), "Lorey Height 7.5cm+ Adjustment"
 			);

--- a/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/input/HcsvPolygonStream.java
+++ b/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/input/HcsvPolygonStream.java
@@ -502,6 +502,7 @@ public class HcsvPolygonStream extends AbstractPolygonStream {
 		var speciesPercent = sp64Details.percent();
 		var totalAge = sp64Details.estimatedAge() == null ? null : Double.valueOf(sp64Details.estimatedAge());
 		var dominantHeight = sp64Details.estimatedHeight();
+		var siteIndex = sp64Details.estimatedSiteIndex();
 
 		String sp0Code = SiteTool.getSpeciesVDYP7Code(speciesCode);
 
@@ -585,6 +586,7 @@ public class HcsvPolygonStream extends AbstractPolygonStream {
 				.speciesPercent(speciesPercent) //
 				.totalAge(totalAge) //
 				.dominantHeight(dominantHeight) //
+				.siteIndex(siteIndex) //
 				.standSuppliedOrderIndex(stand.getSpecies().size()) //
 				.build();
 

--- a/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/model/Species.java
+++ b/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/model/Species.java
@@ -284,8 +284,8 @@ public class Species implements Comparable<Species> {
 	/**
 	 * Determine if the Site information for this species is equivalent to that of <code>other</code>, a
 	 * <code>SpeciesDetails</code> instance. Note that SpeciesDetail does not contain a full set of Site information -
-	 * only age, dominant height and site index, and then only for certain species of a layer. Fields that are
-	 * <code>null</code> in either are considered equivalent.
+	 * only age and dominant height, and then only for certain species of a layer. Fields that are <code>other</code> in
+	 * either are considered equivalent.
 	 *
 	 * @param other the SpeciesDetails object to compare against
 	 * @return as described
@@ -294,8 +294,7 @@ public class Species implements Comparable<Species> {
 	public boolean equivalentSiteInfo(SpeciesDetails other) {
 
 		return equivalentSiteInfoValue(this.totalAge, other.estimatedAge())
-				&& equivalentSiteInfoValue(this.dominantHeight, other.estimatedHeight())
-				&& equivalentSiteInfoValue(this.siteIndex, other.estimatedSiteIndex());
+				&& equivalentSiteInfoValue(this.dominantHeight, other.estimatedHeight());
 	}
 
 	/**

--- a/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/model/Species.java
+++ b/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/model/Species.java
@@ -284,8 +284,8 @@ public class Species implements Comparable<Species> {
 	/**
 	 * Determine if the Site information for this species is equivalent to that of <code>other</code>, a
 	 * <code>SpeciesDetails</code> instance. Note that SpeciesDetail does not contain a full set of Site information -
-	 * only age and dominant height, and then only for certain species of a layer. Fields that are <code>other</code> in
-	 * either are considered equivalent.
+	 * only age, dominant height and site index, and then only for certain species of a layer. Fields that are
+	 * <code>null</code> in either are considered equivalent.
 	 *
 	 * @param other the SpeciesDetails object to compare against
 	 * @return as described
@@ -294,7 +294,8 @@ public class Species implements Comparable<Species> {
 	public boolean equivalentSiteInfo(SpeciesDetails other) {
 
 		return equivalentSiteInfoValue(this.totalAge, other.estimatedAge())
-				&& equivalentSiteInfoValue(this.dominantHeight, other.estimatedHeight());
+				&& equivalentSiteInfoValue(this.dominantHeight, other.estimatedHeight())
+				&& equivalentSiteInfoValue(this.siteIndex, other.estimatedSiteIndex());
 	}
 
 	/**

--- a/lib/vdyp-extended-core/src/test/java/ca/bc/gov/nrs/vdyp/ecore/projection/input/HcsvLayerRecordBeanTest.java
+++ b/lib/vdyp-extended-core/src/test/java/ca/bc/gov/nrs/vdyp/ecore/projection/input/HcsvLayerRecordBeanTest.java
@@ -1,0 +1,63 @@
+package ca.bc.gov.nrs.vdyp.ecore.projection.input;
+
+import static ca.bc.gov.nrs.vdyp.test.TestUtils.LAYER_CSV_HEADER_LINE;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.io.ByteArrayInputStream;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class HcsvLayerRecordBeanTest {
+
+	private static final String EXTENDED_HEADER = LAYER_CSV_HEADER_LINE
+			+ ",EST_AGE_SPP3,EST_HEIGHT_SPP3,EST_AGE_SPP4,EST_HEIGHT_SPP4"
+			+ ",EST_AGE_SPP5,EST_HEIGHT_SPP5,EST_AGE_SPP6,EST_HEIGHT_SPP6"
+			+ ",EST_SITE_INDEX_SPP2,EST_SITE_INDEX_SPP3,EST_SITE_INDEX_SPP4,EST_SITE_INDEX_SPP5,EST_SITE_INDEX_SPP6";
+
+	// pos0-3: FEATURE_ID, TREE_COVER_LAYER_ESTIMATED_ID, MAP_ID, POLYGON_NUMBER
+	private static final String PREFIX = "13919428,14321067,093C090,94833422,";
+
+	private HcsvLayerRecordBean parseFirstBean(String header, String dataRow) {
+		String csv = header + "\n" + PREFIX + dataRow;
+		var stream = HcsvLayerRecordBean.createHcsvLayerStream(new ByteArrayInputStream(csv.getBytes()));
+		return stream.parse().get(0);
+	}
+
+	@Test
+	void testSiteIndexNullForAllSpeciesWhenOldFormatCsvUsed() {
+		// Old-format CSV (no per-species site index columns): estimatedSiteIndex is null for all species
+		// pos4-37 (34 fields): layer-level values, 2 species (PLI 60%, FD 40%), age/height for spp1+spp2
+		String row = "1,P,,,,,,5,1.0,150,PLI,60.0,FD,40.0,,,,,,,,,60,9.0,50,8.5,,,,,,,,";
+		List<HcsvLayerRecordBean.SpeciesDetails> details = parseFirstBean(LAYER_CSV_HEADER_LINE, row).getSpeciesDetails();
+
+		assertThat(details.get(0).estimatedSiteIndex(), is(nullValue()));
+		assertThat(details.get(1).estimatedSiteIndex(), is(nullValue()));
+	}
+
+	@Test
+	void testSiteIndexSpp2IsPopulatedFromEstSiteIndexSpp2Column() {
+		// EST_SITE_INDEX_SPP2 = 22.5 for FD (species 2 in this row)
+		// pos4-50 (47 fields): standard fields + 13 new optional fields; pos46=22.5
+		String row = "1,P,,,,,,5,1.0,150,PLI,60.0,FD,40.0,,,,,,,,,60,9.0,50,8.5,,,,,,,,,,,,,,,,,22.5,,,,";
+		List<HcsvLayerRecordBean.SpeciesDetails> details = parseFirstBean(EXTENDED_HEADER, row).getSpeciesDetails();
+
+		assertThat(details.get(0).estimatedSiteIndex(), is(nullValue())); // SPP1 has no per-species SI column
+		assertThat(details.get(1).estimatedSiteIndex(), is(22.5));
+	}
+
+	@Test
+	void testAgeHeightAndSiteIndexSpp3ArePopulatedFromNewColumns() {
+		// 3 species: PLI 50%, FD 30%, CW 20%
+		// EST_AGE_SPP3=55 (pos38), EST_HEIGHT_SPP3=12.5 (pos39), EST_SITE_INDEX_SPP3=18.0 (pos47)
+		String row = "1,P,,,,,,5,1.0,150,PLI,50.0,FD,30.0,CW,20.0,,,,,,,60,9.0,50,8.5,,,,,,,,,55,12.5,,,,,,,,18.0,,,";
+		List<HcsvLayerRecordBean.SpeciesDetails> details = parseFirstBean(EXTENDED_HEADER, row).getSpeciesDetails();
+
+		HcsvLayerRecordBean.SpeciesDetails spp3 = details.get(2); // CW is third species (index 2)
+		assertThat(spp3.estimatedAge(), is((short) 55));
+		assertThat(spp3.estimatedHeight(), is(12.5));
+		assertThat(spp3.estimatedSiteIndex(), is(18.0));
+	}
+}

--- a/lib/vdyp-extended-core/src/test/java/ca/bc/gov/nrs/vdyp/ecore/projection/input/HcsvLayerRecordBeanTest.java
+++ b/lib/vdyp-extended-core/src/test/java/ca/bc/gov/nrs/vdyp/ecore/projection/input/HcsvLayerRecordBeanTest.java
@@ -31,7 +31,8 @@ class HcsvLayerRecordBeanTest {
 		// Old-format CSV (no per-species site index columns): estimatedSiteIndex is null for all species
 		// pos4-37 (34 fields): layer-level values, 2 species (PLI 60%, FD 40%), age/height for spp1+spp2
 		String row = "1,P,,,,,,5,1.0,150,PLI,60.0,FD,40.0,,,,,,,,,60,9.0,50,8.5,,,,,,,,";
-		List<HcsvLayerRecordBean.SpeciesDetails> details = parseFirstBean(LAYER_CSV_HEADER_LINE, row).getSpeciesDetails();
+		List<HcsvLayerRecordBean.SpeciesDetails> details = parseFirstBean(LAYER_CSV_HEADER_LINE, row)
+				.getSpeciesDetails();
 
 		assertThat(details.get(0).estimatedSiteIndex(), is(nullValue()));
 		assertThat(details.get(1).estimatedSiteIndex(), is(nullValue()));

--- a/lib/vdyp-extended-core/src/test/java/ca/bc/gov/nrs/vdyp/ecore/projection/input/HcsvPolygonStreamTest.java
+++ b/lib/vdyp-extended-core/src/test/java/ca/bc/gov/nrs/vdyp/ecore/projection/input/HcsvPolygonStreamTest.java
@@ -33,6 +33,12 @@ class HcsvPolygonStreamTest {
 	String layerFileHeader = LAYER_CSV_HEADER_LINE + "\n";
 	String defaultLayerPrefix = "13919428,14321067,093C090,94833422,";
 
+	// Standard header extended with the 13 new optional columns (positions 38-50)
+	static final String EXTENDED_LAYER_CSV_HEADER_LINE = LAYER_CSV_HEADER_LINE
+			+ ",EST_AGE_SPP3,EST_HEIGHT_SPP3,EST_AGE_SPP4,EST_HEIGHT_SPP4"
+			+ ",EST_AGE_SPP5,EST_HEIGHT_SPP5,EST_AGE_SPP6,EST_HEIGHT_SPP6"
+			+ ",EST_SITE_INDEX_SPP2,EST_SITE_INDEX_SPP3,EST_SITE_INDEX_SPP4,EST_SITE_INDEX_SPP5,EST_SITE_INDEX_SPP6";
+
 	@BeforeEach
 	void setup() throws AbstractProjectionRequestException {
 		p = new Parameters().ageStart(0).ageEnd(100);
@@ -170,6 +176,21 @@ class HcsvPolygonStreamTest {
 		}
 
 		@Test
+		void testNegativeSiteIndexSpp2RaisesValidationError() {
+			// EST_SITE_INDEX_SPP2=-1.0 is below the valid range [0, MAX_VALUE] and must cause an error
+			// pos4-50 (47 fields): standard fields + 13 new; pos46=-1.0
+			String hcsvLayerFileContents = EXTENDED_LAYER_CSV_HEADER_LINE + "\n" + defaultLayerPrefix
+					+ "1,P,,,,,,5,1.0,150,PLI,60.0,FD,40.0,,,,,,,,,60,9.0,50,8.5,,,,,,,,,,,,,,,,,-1.0,,,,\n";
+
+			HcsvPolygonStream unit = new HcsvPolygonStream(
+					context, new ByteArrayInputStream(hcsvPolygonFileContents.getBytes()),
+					new ByteArrayInputStream(hcsvLayerFileContents.getBytes())
+			);
+
+			assertThrows(PolygonValidationException.class, () -> unit.getNextPolygon());
+		}
+
+		@Test
 		void testDuplicateRank1Layers() throws PolygonValidationException {
 			String hcsvLayerFileContents = layerFileHeader + defaultLayerPrefix
 					+ "1,P,,1,,,,5,1.000050,150,PLI,100.00,,,,,,,,,,,60,9.00,,,,,,,,,,\n" + defaultLayerPrefix
@@ -292,6 +313,22 @@ class HcsvPolygonStreamTest {
 
 		Polygon poly = unit.getNextPolygon();
 		assertThat(poly.getBecZone(), is(output));
+	}
+
+	@Test
+	void testExtendedColumnsWithValidSiteIndexSpp2ParsedWithoutErrors() throws PolygonValidationException {
+		// Provide EST_SITE_INDEX_SPP2=22.5 for FD (species 2) via the extended header columns.
+		// pos4-50 (47 fields): standard fields + 13 new optional fields; pos46=22.5
+		String hcsvLayerFileContents = EXTENDED_LAYER_CSV_HEADER_LINE + "\n" + defaultLayerPrefix
+				+ "1,P,,,,,,5,1.0,150,PLI,60.0,FD,40.0,,,,,,,,,60,9.0,50,8.5,,,,,,,,,,,,,,,,,22.5,,,,\n";
+
+		HcsvPolygonStream unit = new HcsvPolygonStream(
+				context, new ByteArrayInputStream(hcsvPolygonFileContents.getBytes()),
+				new ByteArrayInputStream(hcsvLayerFileContents.getBytes())
+		);
+
+		Polygon poly = unit.getNextPolygon();
+		assertThat(poly.getMessages().size(), is(0));
 	}
 
 }

--- a/lib/vdyp-extended-core/src/test/java/ca/bc/gov/nrs/vdyp/ecore/projection/model/SpeciesTest.java
+++ b/lib/vdyp-extended-core/src/test/java/ca/bc/gov/nrs/vdyp/ecore/projection/model/SpeciesTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import ca.bc.gov.nrs.vdyp.common_calculators.enumerations.SiteIndexEquation;
 import ca.bc.gov.nrs.vdyp.ecore.api.v1.exceptions.AbstractProjectionRequestException;
+import ca.bc.gov.nrs.vdyp.ecore.projection.input.HcsvLayerRecordBean;
 import ca.bc.gov.nrs.vdyp.ecore.model.v1.Parameters;
 import ca.bc.gov.nrs.vdyp.ecore.model.v1.ProjectionRequestKind;
 import ca.bc.gov.nrs.vdyp.ecore.projection.ProjectionContext;
@@ -374,6 +375,50 @@ class SpeciesTest {
 			assertThat(unit.getSiteCurve(), is(collaborator.getSiteCurve()));
 			assertThat(unit.getPercentsPerDuplicate().size(), is(2));
 			assertThat(unit.getPercentsPerDuplicate().get(1), is(speciesPercent));
+		}
+	}
+
+	@Nested
+	class EquivalentSiteInfoSpeciesDetails {
+
+		Polygon polygon;
+		Layer layer;
+		Stand stand;
+
+		@BeforeEach
+		void setup() {
+			polygon = new Polygon.Builder().build();
+			layer = new Layer.Builder().polygon(polygon).layerId("Test").build();
+			stand = new Stand.Builder().sp0Code("P").layer(layer).build();
+		}
+
+		private HcsvLayerRecordBean.SpeciesDetails details(Double siteIndex) {
+			// age and height are null so only siteIndex is compared in equivalentSiteInfo
+			return new HcsvLayerRecordBean.SpeciesDetails(1, "PL", 100.0, null, null, siteIndex);
+		}
+
+		@Test
+		void testEquivalentWhenSiteIndexMatches() {
+			var unit = new Species.Builder().stand(stand).speciesCode("PL").speciesPercent(100).siteIndex(20.0).build();
+			assertThat(unit.equivalentSiteInfo(details(20.0)), is(true));
+		}
+
+		@Test
+		void testEquivalentWhenSiteIndexNullInDetails() {
+			var unit = new Species.Builder().stand(stand).speciesCode("PL").speciesPercent(100).siteIndex(20.0).build();
+			assertThat(unit.equivalentSiteInfo(details(null)), is(true));
+		}
+
+		@Test
+		void testEquivalentWhenSiteIndexNullInSpecies() {
+			var unit = new Species.Builder().stand(stand).speciesCode("PL").speciesPercent(100).build();
+			assertThat(unit.equivalentSiteInfo(details(20.0)), is(true));
+		}
+
+		@Test
+		void testNotEquivalentWhenSiteIndexDiffers() {
+			var unit = new Species.Builder().stand(stand).speciesCode("PL").speciesPercent(100).siteIndex(20.0).build();
+			assertThat(unit.equivalentSiteInfo(details(15.0)), is(false));
 		}
 	}
 }

--- a/lib/vdyp-extended-core/src/test/java/ca/bc/gov/nrs/vdyp/ecore/projection/model/SpeciesTest.java
+++ b/lib/vdyp-extended-core/src/test/java/ca/bc/gov/nrs/vdyp/ecore/projection/model/SpeciesTest.java
@@ -18,7 +18,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import ca.bc.gov.nrs.vdyp.common_calculators.enumerations.SiteIndexEquation;
 import ca.bc.gov.nrs.vdyp.ecore.api.v1.exceptions.AbstractProjectionRequestException;
-import ca.bc.gov.nrs.vdyp.ecore.projection.input.HcsvLayerRecordBean;
 import ca.bc.gov.nrs.vdyp.ecore.model.v1.Parameters;
 import ca.bc.gov.nrs.vdyp.ecore.model.v1.ProjectionRequestKind;
 import ca.bc.gov.nrs.vdyp.ecore.projection.ProjectionContext;
@@ -378,47 +377,4 @@ class SpeciesTest {
 		}
 	}
 
-	@Nested
-	class EquivalentSiteInfoSpeciesDetails {
-
-		Polygon polygon;
-		Layer layer;
-		Stand stand;
-
-		@BeforeEach
-		void setup() {
-			polygon = new Polygon.Builder().build();
-			layer = new Layer.Builder().polygon(polygon).layerId("Test").build();
-			stand = new Stand.Builder().sp0Code("P").layer(layer).build();
-		}
-
-		private HcsvLayerRecordBean.SpeciesDetails details(Double siteIndex) {
-			// age and height are null so only siteIndex is compared in equivalentSiteInfo
-			return new HcsvLayerRecordBean.SpeciesDetails(1, "PL", 100.0, null, null, siteIndex);
-		}
-
-		@Test
-		void testEquivalentWhenSiteIndexMatches() {
-			var unit = new Species.Builder().stand(stand).speciesCode("PL").speciesPercent(100).siteIndex(20.0).build();
-			assertThat(unit.equivalentSiteInfo(details(20.0)), is(true));
-		}
-
-		@Test
-		void testEquivalentWhenSiteIndexNullInDetails() {
-			var unit = new Species.Builder().stand(stand).speciesCode("PL").speciesPercent(100).siteIndex(20.0).build();
-			assertThat(unit.equivalentSiteInfo(details(null)), is(true));
-		}
-
-		@Test
-		void testEquivalentWhenSiteIndexNullInSpecies() {
-			var unit = new Species.Builder().stand(stand).speciesCode("PL").speciesPercent(100).build();
-			assertThat(unit.equivalentSiteInfo(details(20.0)), is(true));
-		}
-
-		@Test
-		void testNotEquivalentWhenSiteIndexDiffers() {
-			var unit = new Species.Builder().stand(stand).speciesCode("PL").speciesPercent(100).siteIndex(20.0).build();
-			assertThat(unit.equivalentSiteInfo(details(15.0)), is(false));
-		}
-	}
 }


### PR DESCRIPTION
VDYP-1070: API - Extend HCSV file format to support multiple species values
- Added optional columns EST_AGE_SPP3-6 and EST_HEIGHT_SPP3-6 for species-specific age and height
- Added optional columns EST_SITE_INDEX_SPP2-6 for species-specific site index
- When present and populated, values are parsed into the correct species during projection
- Missing or blank columns have no effect on projection