### PR TITLE
Feature/VDYP-1073: Push final progress on projection completion

### DIFF
--- a/backend/src/main/java/ca/bc/gov/nrs/vdyp/backend/endpoints/v1/ProjectionEndpoint.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/vdyp/backend/endpoints/v1/ProjectionEndpoint.java
@@ -294,13 +294,16 @@ public class ProjectionEndpoint implements Endpoint {
 	@RolesAllowed("SYSTEM")
 	@Path("/{projectionGUID}/complete")
 	@Produces({ MediaType.APPLICATION_JSON })
+	@Consumes({ MediaType.APPLICATION_JSON })
 	@Tag(
 			name = "Set a Projections Status", description = "(System Only) Updates as a projection status to complete after processing."
 	)
 	public Response updateCompleteProjectionStatus(
-			@PathParam("projectionGUID") UUID projectionGUID, @QueryParam("success") boolean success
+			@PathParam("projectionGUID") UUID projectionGUID, @QueryParam("success") boolean success,
+			ProjectionProgressUpdate progressUpdate
 	) throws ProjectionServiceException {
-		var started = projectionService.updateCompleteStatus(currentUser.getUser(), projectionGUID, success);
+		var started = projectionService
+				.updateCompleteStatus(currentUser.getUser(), projectionGUID, success, progressUpdate);
 		return Response.status(Status.OK).entity(started).build();
 	}
 

--- a/backend/src/main/java/ca/bc/gov/nrs/vdyp/backend/services/ProjectionService.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/vdyp/backend/services/ProjectionService.java
@@ -563,11 +563,16 @@ public class ProjectionService {
 	}
 
 	@Transactional
-	public ProjectionModel updateCompleteStatus(VDYPUserModel actingUser, UUID projectionGUID, boolean success)
-			throws ProjectionServiceException {
+	public ProjectionModel updateCompleteStatus(
+			VDYPUserModel actingUser, UUID projectionGUID, boolean success, ProjectionProgressUpdate progressUpdate
+	) throws ProjectionServiceException {
 		ProjectionEntity entity = getProjectionEntity(projectionGUID);
 		checkUserCanPerformAction(entity, actingUser, ProjectionAction.COMPLETE_PROJECTION);
 		checkProjectionStatusPermitsAction(entity, ProjectionAction.COMPLETE_PROJECTION);
+
+		if (progressUpdate != null) {
+			batchMappingService.updateProgress(entity, progressUpdate);
+		}
 
 		ProjectionStatusCodeEntity status = statusLookup
 				.requireEntity(success ? ProjectionStatusCodeModel.READY : ProjectionStatusCodeModel.FAILED);

--- a/backend/src/test/java/ca/bc/gov/nrs/vdyp/backend/services/ProjectionServiceTest.java
+++ b/backend/src/test/java/ca/bc/gov/nrs/vdyp/backend/services/ProjectionServiceTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.net.URL;
 import java.time.OffsetDateTime;
 import java.util.Collections;
 import java.util.HashMap;
@@ -71,6 +72,7 @@ import ca.bc.gov.nrs.vdyp.backend.exceptions.ProjectionStateException;
 import ca.bc.gov.nrs.vdyp.backend.exceptions.ProjectionUnauthorizedException;
 import ca.bc.gov.nrs.vdyp.backend.exceptions.ProjectionValidationException;
 import ca.bc.gov.nrs.vdyp.backend.model.ModelParameters;
+import ca.bc.gov.nrs.vdyp.backend.model.ProjectionProgressUpdate;
 import ca.bc.gov.nrs.vdyp.ecore.model.v1.Parameters;
 import jakarta.persistence.EntityManager;
 import jakarta.ws.rs.core.Response;
@@ -1591,5 +1593,133 @@ class ProjectionServiceTest {
 		assertNotNull(model);
 		assertEquals(entity.getProjectionGUID(), UUID.fromString(model.getProjectionGUID()));
 		assertEquals(mapping, model.getBatchMapping());
+	}
+
+	// ==========================================================
+	// updateCompleteStatus
+	// ==========================================================
+
+	@Test
+	void updateCompleteStatus_withNullProgressUpdate_doesNotCallBatchMappingService()
+			throws ProjectionServiceException {
+		UUID projectionGUID = UUID.randomUUID();
+		ProjectionEntity entity = projectionEntity(
+				projectionGUID, UUID.randomUUID(), ProjectionStatusCodeModel.RUNNING
+		);
+		UserTypeCodeModel systemUserType = new UserTypeCodeModel();
+		systemUserType.setCode(UserTypeCodeModel.SYSTEM);
+		VDYPUserModel systemUser = new VDYPUserModel();
+		systemUser.setUserTypeCode(systemUserType);
+
+		when(repository.findByIdOptional(projectionGUID)).thenReturn(Optional.of(entity));
+		when(projectionStatusCodeLookup.requireEntity(ProjectionStatusCodeModel.READY))
+				.thenReturn(statusCode(ProjectionStatusCodeModel.READY));
+		when(expiryConfig.expiryFrom(any())).thenReturn(OffsetDateTime.now());
+
+		service.updateCompleteStatus(systemUser, projectionGUID, true, null);
+
+		verify(batchMappingService, never()).updateProgress(any(), any());
+	}
+
+	@Test
+	void updateCompleteStatus_withProgressUpdate_callsBatchMappingService() throws ProjectionServiceException {
+		UUID projectionGUID = UUID.randomUUID();
+		ProjectionEntity entity = projectionEntity(
+				projectionGUID, UUID.randomUUID(), ProjectionStatusCodeModel.RUNNING
+		);
+		UserTypeCodeModel systemUserType = new UserTypeCodeModel();
+		systemUserType.setCode(UserTypeCodeModel.SYSTEM);
+		VDYPUserModel systemUser = new VDYPUserModel();
+		systemUser.setUserTypeCode(systemUserType);
+		ProjectionProgressUpdate progressUpdate = new ProjectionProgressUpdate(UUID.randomUUID(), 10, 8, 1, 1);
+
+		when(repository.findByIdOptional(projectionGUID)).thenReturn(Optional.of(entity));
+		when(projectionStatusCodeLookup.requireEntity(ProjectionStatusCodeModel.READY))
+				.thenReturn(statusCode(ProjectionStatusCodeModel.READY));
+		when(expiryConfig.expiryFrom(any())).thenReturn(OffsetDateTime.now());
+
+		service.updateCompleteStatus(systemUser, projectionGUID, true, progressUpdate);
+
+		verify(batchMappingService).updateProgress(entity, progressUpdate);
+	}
+
+	// ==========================================================
+	// ProjectionEndpoint - updateCompleteProjectionStatus
+	// ==========================================================
+
+	@Test
+	void endpoint_updateCompleteProjectionStatus_returnsOk_withProgressUpdate() throws ProjectionServiceException {
+		ProjectionService mockService = mock(ProjectionService.class);
+		CurrentVDYPUser currentVDYPUser = mock(CurrentVDYPUser.class);
+		VDYPUserModel actingUser = user(UUID.randomUUID());
+		when(currentVDYPUser.getUser()).thenReturn(actingUser);
+
+		ProjectionEndpoint endpoint = new ProjectionEndpoint(mockService, currentVDYPUser);
+
+		UUID projectionGUID = UUID.randomUUID();
+		ProjectionProgressUpdate progressUpdate = new ProjectionProgressUpdate(UUID.randomUUID(), 10, 8, 1, 1);
+
+		ProjectionModel model = new ProjectionModel();
+		model.setProjectionGUID(projectionGUID.toString());
+		when(mockService.updateCompleteStatus(actingUser, projectionGUID, true, progressUpdate)).thenReturn(model);
+
+		Response response = endpoint.updateCompleteProjectionStatus(projectionGUID, true, progressUpdate);
+
+		assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+		assertThat(response.getEntity()).isSameAs(model);
+	}
+
+	@Test
+	void endpoint_updateCompleteProjectionStatus_returnsOk_withNullProgressUpdate() throws ProjectionServiceException {
+		ProjectionService mockService = mock(ProjectionService.class);
+		CurrentVDYPUser currentVDYPUser = mock(CurrentVDYPUser.class);
+		VDYPUserModel actingUser = user(UUID.randomUUID());
+		when(currentVDYPUser.getUser()).thenReturn(actingUser);
+
+		ProjectionEndpoint endpoint = new ProjectionEndpoint(mockService, currentVDYPUser);
+
+		UUID projectionGUID = UUID.randomUUID();
+		ProjectionModel model = new ProjectionModel();
+		model.setProjectionGUID(projectionGUID.toString());
+		when(mockService.updateCompleteStatus(actingUser, projectionGUID, false, null)).thenReturn(model);
+
+		Response response = endpoint.updateCompleteProjectionStatus(projectionGUID, false, null);
+
+		assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+		verify(mockService).updateCompleteStatus(actingUser, projectionGUID, false, null);
+	}
+
+	// ==========================================================
+	// ProjectionEndpoint - streamResultsZip
+	// ==========================================================
+
+	@Test
+	void endpoint_streamResultsZip_returnsOk_whenResultFilesExist() throws Exception {
+		ProjectionService mockService = mock(ProjectionService.class);
+		CurrentVDYPUser currentVDYPUser = mock(CurrentVDYPUser.class);
+		VDYPUserModel actingUser = user(UUID.randomUUID());
+		when(currentVDYPUser.getUser()).thenReturn(actingUser);
+
+		ProjectionEndpoint endpoint = new ProjectionEndpoint(mockService, currentVDYPUser);
+
+		UUID projectionGUID = UUID.randomUUID();
+		UUID fileSetGUID = UUID.randomUUID();
+		UUID fileMappingGUID = UUID.randomUUID();
+
+		ProjectionEntity entity = new ProjectionEntity();
+		entity.setProjectionGUID(projectionGUID);
+		entity.setResultFileSet(fileSetEntity(fileSetGUID));
+
+		FileMappingModel fileWithUrl = fileMappingModel(fileMappingGUID, UUID.randomUUID());
+		fileWithUrl.setDownloadURL(new URL("http://example.com/result.zip"));
+
+		when(mockService.getProjectionEntity(projectionGUID)).thenReturn(entity);
+		when(mockService.getAllFileSetFiles(projectionGUID, fileSetGUID, actingUser)).thenReturn(List.of(fileWithUrl));
+		when(mockService.getFileForDownload(projectionGUID, fileSetGUID, fileMappingGUID, actingUser))
+				.thenReturn(fileWithUrl);
+
+		Response response = endpoint.streamResultsZip(projectionGUID, null);
+
+		assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
 	}
 }

--- a/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/client/vdyp/VdypClient.java
+++ b/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/client/vdyp/VdypClient.java
@@ -71,13 +71,15 @@ public class VdypClient {
 				.body(FileMappingDetails.class);
 	}
 
-	public void markComplete(String projectionGUID, boolean success) {
+	public void markComplete(String projectionGUID, boolean success, VDYPProjectionProgressUpdate progressUpdate) {
 		vdypBackendReliableRestClient.post() //
 				.uri(
 						b -> b.path("/api/v8/projection/{projectionGUID}/complete") //
 								.queryParam("success", success) //
 								.build(projectionGUID)
 				) //
+				.contentType(MediaType.APPLICATION_JSON) //
+				.body(progressUpdate) //
 				.retrieve() //
 				.body(Void.class);
 	}

--- a/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/configuration/VDYPJobFailedListener.java
+++ b/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/configuration/VDYPJobFailedListener.java
@@ -5,13 +5,11 @@ import org.slf4j.LoggerFactory;
 import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobExecutionListener;
-import org.springframework.batch.core.StepExecution;
-import org.springframework.batch.item.ExecutionContext;
 import org.springframework.lang.NonNull;
 
 import ca.bc.gov.nrs.vdyp.batch.client.vdyp.VdypClient;
-import ca.bc.gov.nrs.vdyp.batch.model.VDYPProjectionProgressUpdate;
 import ca.bc.gov.nrs.vdyp.batch.util.BatchConstants;
+import ca.bc.gov.nrs.vdyp.batch.util.BatchUtils;
 
 public class VDYPJobFailedListener implements JobExecutionListener {
 	private static final Logger logger = LoggerFactory.getLogger(VDYPJobFailedListener.class);
@@ -34,23 +32,7 @@ public class VDYPJobFailedListener implements JobExecutionListener {
 					"[GUID: {}] [Job Failed Listener] Job execution ID: {} Projection GUID: {} Status:{} Updating Vdyp backend",
 					jobGuid, projectionGUID, jobExecution.getId(), status
 			);
-			vdypClient.markComplete(projectionGUID, false, buildFinalProgress(jobGuid, jobExecution));
+			vdypClient.markComplete(projectionGUID, false, BatchUtils.buildFinalProgress(jobGuid, jobExecution));
 		}
-	}
-
-	private VDYPProjectionProgressUpdate buildFinalProgress(String jobGuid, JobExecution jobExecution) {
-		int totalPolygons = jobExecution.getExecutionContext().getInt(BatchConstants.Job.TOTAL_POLYGONS, 0);
-		int polygonsProcessed = 0;
-		int errorCount = 0;
-		int polygonsSkipped = 0;
-		for (StepExecution step : jobExecution.getStepExecutions()) {
-			if (step.getStepName().startsWith(BatchConstants.Job.WORKER_STEP_NAME)) {
-				ExecutionContext stepCtx = step.getExecutionContext();
-				polygonsProcessed += stepCtx.getInt(BatchConstants.Job.POLYGONS_PROCESSED, 0);
-				errorCount += stepCtx.getInt(BatchConstants.Job.PROJECTION_ERRORS, 0);
-				polygonsSkipped += stepCtx.getInt(BatchConstants.Job.POLYGONS_SKIPPED, 0);
-			}
-		}
-		return new VDYPProjectionProgressUpdate(jobGuid, totalPolygons, polygonsProcessed, errorCount, polygonsSkipped);
 	}
 }

--- a/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/configuration/VDYPJobFailedListener.java
+++ b/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/configuration/VDYPJobFailedListener.java
@@ -5,9 +5,12 @@ import org.slf4j.LoggerFactory;
 import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobExecutionListener;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.item.ExecutionContext;
 import org.springframework.lang.NonNull;
 
 import ca.bc.gov.nrs.vdyp.batch.client.vdyp.VdypClient;
+import ca.bc.gov.nrs.vdyp.batch.model.VDYPProjectionProgressUpdate;
 import ca.bc.gov.nrs.vdyp.batch.util.BatchConstants;
 
 public class VDYPJobFailedListener implements JobExecutionListener {
@@ -31,7 +34,23 @@ public class VDYPJobFailedListener implements JobExecutionListener {
 					"[GUID: {}] [Job Failed Listener] Job execution ID: {} Projection GUID: {} Status:{} Updating Vdyp backend",
 					jobGuid, projectionGUID, jobExecution.getId(), status
 			);
-			vdypClient.markComplete(projectionGUID, false);
+			vdypClient.markComplete(projectionGUID, false, buildFinalProgress(jobGuid, jobExecution));
 		}
+	}
+
+	private VDYPProjectionProgressUpdate buildFinalProgress(String jobGuid, JobExecution jobExecution) {
+		int totalPolygons = jobExecution.getExecutionContext().getInt(BatchConstants.Job.TOTAL_POLYGONS, 0);
+		int polygonsProcessed = 0;
+		int errorCount = 0;
+		int polygonsSkipped = 0;
+		for (StepExecution step : jobExecution.getStepExecutions()) {
+			if (step.getStepName().startsWith(BatchConstants.Job.WORKER_STEP_NAME)) {
+				ExecutionContext stepCtx = step.getExecutionContext();
+				polygonsProcessed += stepCtx.getInt(BatchConstants.Job.POLYGONS_PROCESSED, 0);
+				errorCount += stepCtx.getInt(BatchConstants.Job.PROJECTION_ERRORS, 0);
+				polygonsSkipped += stepCtx.getInt(BatchConstants.Job.POLYGONS_SKIPPED, 0);
+			}
+		}
+		return new VDYPProjectionProgressUpdate(jobGuid, totalPolygons, polygonsProcessed, errorCount, polygonsSkipped);
 	}
 }

--- a/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/service/ResultPersistenceTasklet.java
+++ b/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/service/ResultPersistenceTasklet.java
@@ -9,8 +9,10 @@ import java.util.UUID;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.StepExecution;
 import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.ExecutionContext;
 import org.springframework.stereotype.Component;
 
 import ca.bc.gov.nrs.vdyp.batch.client.vdyp.FileMappingDetails;
@@ -18,6 +20,8 @@ import ca.bc.gov.nrs.vdyp.batch.client.vdyp.VdypClient;
 import ca.bc.gov.nrs.vdyp.batch.client.vdyp.VdypProjectionDetails;
 import ca.bc.gov.nrs.vdyp.batch.exception.BatchException;
 import ca.bc.gov.nrs.vdyp.batch.exception.BatchResultPersistenceException;
+import ca.bc.gov.nrs.vdyp.batch.model.VDYPProjectionProgressUpdate;
+import ca.bc.gov.nrs.vdyp.batch.util.BatchConstants;
 import ca.bc.gov.nrs.vdyp.batch.util.BatchUtils;
 
 @Component
@@ -68,13 +72,29 @@ public class ResultPersistenceTasklet extends VdypFileTasklet {
 				);
 			}
 
-			vdypClient.markComplete(projectionGUID, true);
+			vdypClient.markComplete(projectionGUID, true, buildFinalProgress(stepExecution.getJobExecution()));
 
 			logger.debug("Completed persistence of result zip file to COMS.");
 		} catch (Exception e) {
 			throw BatchResultPersistenceException
 					.handleResultPersistenceFailure(e, "Failed to persist result zip to COMS.", jobGuid, jobId, logger);
 		}
+	}
+
+	private VDYPProjectionProgressUpdate buildFinalProgress(JobExecution jobExecution) {
+		int totalPolygons = jobExecution.getExecutionContext().getInt(BatchConstants.Job.TOTAL_POLYGONS, 0);
+		int polygonsProcessed = 0;
+		int errorCount = 0;
+		int polygonsSkipped = 0;
+		for (StepExecution step : jobExecution.getStepExecutions()) {
+			if (step.getStepName().startsWith(BatchConstants.Job.WORKER_STEP_NAME)) {
+				ExecutionContext stepCtx = step.getExecutionContext();
+				polygonsProcessed += stepCtx.getInt(BatchConstants.Job.POLYGONS_PROCESSED, 0);
+				errorCount += stepCtx.getInt(BatchConstants.Job.PROJECTION_ERRORS, 0);
+				polygonsSkipped += stepCtx.getInt(BatchConstants.Job.POLYGONS_SKIPPED, 0);
+			}
+		}
+		return new VDYPProjectionProgressUpdate(jobGuid, totalPolygons, polygonsProcessed, errorCount, polygonsSkipped);
 	}
 
 }

--- a/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/service/ResultPersistenceTasklet.java
+++ b/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/service/ResultPersistenceTasklet.java
@@ -9,10 +9,8 @@ import java.util.UUID;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.StepExecution;
 import org.springframework.batch.core.configuration.annotation.StepScope;
-import org.springframework.batch.item.ExecutionContext;
 import org.springframework.stereotype.Component;
 
 import ca.bc.gov.nrs.vdyp.batch.client.vdyp.FileMappingDetails;
@@ -20,8 +18,6 @@ import ca.bc.gov.nrs.vdyp.batch.client.vdyp.VdypClient;
 import ca.bc.gov.nrs.vdyp.batch.client.vdyp.VdypProjectionDetails;
 import ca.bc.gov.nrs.vdyp.batch.exception.BatchException;
 import ca.bc.gov.nrs.vdyp.batch.exception.BatchResultPersistenceException;
-import ca.bc.gov.nrs.vdyp.batch.model.VDYPProjectionProgressUpdate;
-import ca.bc.gov.nrs.vdyp.batch.util.BatchConstants;
 import ca.bc.gov.nrs.vdyp.batch.util.BatchUtils;
 
 @Component
@@ -72,29 +68,15 @@ public class ResultPersistenceTasklet extends VdypFileTasklet {
 				);
 			}
 
-			vdypClient.markComplete(projectionGUID, true, buildFinalProgress(stepExecution.getJobExecution()));
+			vdypClient.markComplete(
+					projectionGUID, true, BatchUtils.buildFinalProgress(jobGuid, stepExecution.getJobExecution())
+			);
 
 			logger.debug("Completed persistence of result zip file to COMS.");
 		} catch (Exception e) {
 			throw BatchResultPersistenceException
 					.handleResultPersistenceFailure(e, "Failed to persist result zip to COMS.", jobGuid, jobId, logger);
 		}
-	}
-
-	private VDYPProjectionProgressUpdate buildFinalProgress(JobExecution jobExecution) {
-		int totalPolygons = jobExecution.getExecutionContext().getInt(BatchConstants.Job.TOTAL_POLYGONS, 0);
-		int polygonsProcessed = 0;
-		int errorCount = 0;
-		int polygonsSkipped = 0;
-		for (StepExecution step : jobExecution.getStepExecutions()) {
-			if (step.getStepName().startsWith(BatchConstants.Job.WORKER_STEP_NAME)) {
-				ExecutionContext stepCtx = step.getExecutionContext();
-				polygonsProcessed += stepCtx.getInt(BatchConstants.Job.POLYGONS_PROCESSED, 0);
-				errorCount += stepCtx.getInt(BatchConstants.Job.PROJECTION_ERRORS, 0);
-				polygonsSkipped += stepCtx.getInt(BatchConstants.Job.POLYGONS_SKIPPED, 0);
-			}
-		}
-		return new VDYPProjectionProgressUpdate(jobGuid, totalPolygons, polygonsProcessed, errorCount, polygonsSkipped);
 	}
 
 }

--- a/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/util/BatchUtils.java
+++ b/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/util/BatchUtils.java
@@ -8,6 +8,12 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.UUID;
 
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.item.ExecutionContext;
+
+import ca.bc.gov.nrs.vdyp.batch.model.VDYPProjectionProgressUpdate;
+
 public final class BatchUtils {
 
 	private BatchUtils() {
@@ -199,6 +205,22 @@ public final class BatchUtils {
 		String sanitized = (base + "_All Files").replaceAll("[^a-zA-Z0-9._\\-]", "_").replaceAll("_+", "_")
 				.replaceAll("(^_)|(_$)", "");
 		return sanitized + ".zip";
+	}
+
+	public static VDYPProjectionProgressUpdate buildFinalProgress(String jobGuid, JobExecution jobExecution) {
+		int totalPolygons = jobExecution.getExecutionContext().getInt(BatchConstants.Job.TOTAL_POLYGONS, 0);
+		int polygonsProcessed = 0;
+		int errorCount = 0;
+		int polygonsSkipped = 0;
+		for (StepExecution step : jobExecution.getStepExecutions()) {
+			if (step.getStepName().startsWith(BatchConstants.Job.WORKER_STEP_NAME)) {
+				ExecutionContext stepCtx = step.getExecutionContext();
+				polygonsProcessed += stepCtx.getInt(BatchConstants.Job.POLYGONS_PROCESSED, 0);
+				errorCount += stepCtx.getInt(BatchConstants.Job.PROJECTION_ERRORS, 0);
+				polygonsSkipped += stepCtx.getInt(BatchConstants.Job.POLYGONS_SKIPPED, 0);
+			}
+		}
+		return new VDYPProjectionProgressUpdate(jobGuid, totalPolygons, polygonsProcessed, errorCount, polygonsSkipped);
 	}
 
 	public static void confirmDirectoryExists(Path dirPath) throws IOException {

--- a/batch/src/test/java/ca/bc/gov/nrs/vdyp/batch/client/vdyp/VdypClientTest.java
+++ b/batch/src/test/java/ca/bc/gov/nrs/vdyp/batch/client/vdyp/VdypClientTest.java
@@ -33,6 +33,8 @@ import org.springframework.web.client.RestClient;
 import org.springframework.web.util.DefaultUriBuilderFactory;
 import org.springframework.web.util.UriBuilder;
 
+import ca.bc.gov.nrs.vdyp.batch.model.VDYPProjectionProgressUpdate;
+
 @ExtendWith(MockitoExtension.class)
 class VdypClientTest {
 
@@ -202,6 +204,30 @@ class VdypClientTest {
 
 		Object part = formCaptor.getValue().getFirst("file");
 		assertInstanceOf(FileSystemResource.class, part);
+	}
+
+	@Test
+	void markComplete_buildsExpectedUri_andSendsProgressUpdate() {
+		String projectionGuid = "proj-123";
+		VDYPProjectionProgressUpdate progressUpdate = new VDYPProjectionProgressUpdate("job-guid", 10, 8, 1, 1);
+
+		var req = mock(RestClient.RequestBodyUriSpec.class);
+		var resp = mock(RestClient.ResponseSpec.class);
+		when(restClient.post()).thenReturn(req);
+		when(req.uri(ArgumentMatchers.<Function<UriBuilder, URI>>any())).thenReturn(req);
+		when(req.contentType(MediaType.APPLICATION_JSON)).thenReturn(req);
+		doReturn(req).when(req).body(any(VDYPProjectionProgressUpdate.class));
+		when(req.retrieve()).thenReturn(resp);
+		when(resp.body(Void.class)).thenReturn(null);
+
+		client.markComplete(projectionGuid, true, progressUpdate);
+
+		@SuppressWarnings("unchecked")
+		ArgumentCaptor<Function<UriBuilder, URI>> uriCaptor = ArgumentCaptor.forClass(Function.class);
+		verify(req).uri(uriCaptor.capture());
+
+		URI built = uriCaptor.getValue().apply(new DefaultUriBuilderFactory(BASE_URL).builder());
+		assertEquals(BASE_URL + "/api/v8/projection/" + projectionGuid + "/complete?success=true", built.toString());
 	}
 
 }

--- a/batch/src/test/java/ca/bc/gov/nrs/vdyp/batch/configuration/VDYPJobFailedListenerTest.java
+++ b/batch/src/test/java/ca/bc/gov/nrs/vdyp/batch/configuration/VDYPJobFailedListenerTest.java
@@ -7,6 +7,8 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.Collections;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,6 +22,7 @@ import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.item.ExecutionContext;
 
 import ca.bc.gov.nrs.vdyp.batch.client.vdyp.VdypClient;
 import ca.bc.gov.nrs.vdyp.batch.util.BatchConstants;
@@ -50,12 +53,14 @@ class VDYPJobFailedListenerTest {
 		when(jobExecution.getId()).thenReturn(1L);
 		when(jobExecution.getJobParameters()).thenReturn(jobParameters);
 		when(jobExecution.getStatus()).thenReturn(BatchStatus.FAILED);
+		when(jobExecution.getExecutionContext()).thenReturn(new ExecutionContext());
+		when(jobExecution.getStepExecutions()).thenReturn(Collections.emptyList());
 
 		listener.afterJob(jobExecution);
 
 		verify(jobExecution, atLeastOnce()).getId();
 		verify(jobExecution, atLeastOnce()).getJobParameters();
-		verify(vdypClient, atLeastOnce()).markComplete(any(), eq(false));
+		verify(vdypClient, atLeastOnce()).markComplete(any(), eq(false), any());
 	}
 
 	@ParameterizedTest
@@ -71,6 +76,6 @@ class VDYPJobFailedListenerTest {
 
 		listener.afterJob(jobExecution);
 
-		verify(vdypClient, never()).markComplete(any(), eq(false));
+		verify(vdypClient, never()).markComplete(any(), eq(false), any());
 	}
 }

--- a/batch/src/test/java/ca/bc/gov/nrs/vdyp/batch/service/ResultPersistenceTaskletTest.java
+++ b/batch/src/test/java/ca/bc/gov/nrs/vdyp/batch/service/ResultPersistenceTaskletTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.when;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
@@ -27,6 +28,7 @@ import org.springframework.batch.core.StepContribution;
 import org.springframework.batch.core.StepExecution;
 import org.springframework.batch.core.scope.context.ChunkContext;
 import org.springframework.batch.core.scope.context.StepContext;
+import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.repeat.RepeatStatus;
 
 import ca.bc.gov.nrs.vdyp.batch.client.vdyp.FileMappingDetails;
@@ -132,6 +134,8 @@ class ResultPersistenceTaskletTest {
 				.addString(BatchConstants.GuidInput.PROJECTION_GUID, projectionGuid.toString()) //
 				.toJobParameters();
 		when(jobExecution.getJobParameters()).thenReturn(jobParameters);
+		when(jobExecution.getExecutionContext()).thenReturn(new ExecutionContext());
+		when(jobExecution.getStepExecutions()).thenReturn(Collections.emptyList());
 		when(vdypClient.getProjectionDetails(any())).thenReturn(details);
 		when(details.resultFileSet())
 				.thenReturn(new VdypProjectionDetails.VdypProjectionFileSet(resultFileSetGuid.toString()));
@@ -167,6 +171,8 @@ class ResultPersistenceTaskletTest {
 				.addString(BatchConstants.Job.TIMESTAMP, BatchUtils.createJobTimestamp()) //
 				.toJobParameters();
 		when(jobExecution.getJobParameters()).thenReturn(jobParameters);
+		when(jobExecution.getExecutionContext()).thenReturn(new ExecutionContext());
+		when(jobExecution.getStepExecutions()).thenReturn(Collections.emptyList());
 		when(vdypClient.getProjectionDetails(any())).thenReturn(details);
 		when(details.resultFileSet())
 				.thenReturn(new VdypProjectionDetails.VdypProjectionFileSet(resultFileSetGuid.toString()));

--- a/batch/src/test/java/ca/bc/gov/nrs/vdyp/batch/util/BatchUtilsTest.java
+++ b/batch/src/test/java/ca/bc/gov/nrs/vdyp/batch/util/BatchUtilsTest.java
@@ -1,11 +1,20 @@
 package ca.bc.gov.nrs.vdyp.batch.util;
 
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Collections;
+import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.item.ExecutionContext;
+
+import ca.bc.gov.nrs.vdyp.batch.model.VDYPProjectionProgressUpdate;
 
 class BatchUtilsTest {
 	@Test
@@ -93,5 +102,60 @@ class BatchUtilsTest {
 		String reformatted = formatter.format(parsed);
 
 		assertEquals(timestamp, reformatted);
+	}
+
+	@Test
+	void buildFinalProgress_emptySteps_returnsZeroCounts() {
+		JobExecution jobExecution = mock(JobExecution.class);
+		when(jobExecution.getExecutionContext()).thenReturn(new ExecutionContext());
+		when(jobExecution.getStepExecutions()).thenReturn(Collections.emptyList());
+
+		VDYPProjectionProgressUpdate result = BatchUtils.buildFinalProgress("job-guid", jobExecution);
+
+		assertEquals("job-guid", result.batchJobGUID());
+		assertEquals(0, result.totalPolygons());
+		assertEquals(0, result.polygonsProcessed());
+		assertEquals(0, result.projectionErrors());
+		assertEquals(0, result.polygonsSkipped());
+	}
+
+	@Test
+	void buildFinalProgress_workerSteps_accumulatesCounts() {
+		JobExecution jobExecution = mock(JobExecution.class);
+		ExecutionContext jobContext = new ExecutionContext();
+		jobContext.putInt(BatchConstants.Job.TOTAL_POLYGONS, 10);
+		when(jobExecution.getExecutionContext()).thenReturn(jobContext);
+
+		StepExecution workerStep = mock(StepExecution.class);
+		when(workerStep.getStepName()).thenReturn(BatchConstants.Job.WORKER_STEP_NAME + ":partition0");
+		ExecutionContext stepContext = new ExecutionContext();
+		stepContext.putInt(BatchConstants.Job.POLYGONS_PROCESSED, 8);
+		stepContext.putInt(BatchConstants.Job.PROJECTION_ERRORS, 1);
+		stepContext.putInt(BatchConstants.Job.POLYGONS_SKIPPED, 1);
+		when(workerStep.getExecutionContext()).thenReturn(stepContext);
+		when(jobExecution.getStepExecutions()).thenReturn(List.of(workerStep));
+
+		VDYPProjectionProgressUpdate result = BatchUtils.buildFinalProgress("job-guid", jobExecution);
+
+		assertEquals(10, result.totalPolygons());
+		assertEquals(8, result.polygonsProcessed());
+		assertEquals(1, result.projectionErrors());
+		assertEquals(1, result.polygonsSkipped());
+	}
+
+	@Test
+	void buildFinalProgress_nonWorkerStepIgnored() {
+		JobExecution jobExecution = mock(JobExecution.class);
+		when(jobExecution.getExecutionContext()).thenReturn(new ExecutionContext());
+
+		StepExecution nonWorkerStep = mock(StepExecution.class);
+		when(nonWorkerStep.getStepName()).thenReturn("someOtherStep");
+		when(jobExecution.getStepExecutions()).thenReturn(List.of(nonWorkerStep));
+
+		VDYPProjectionProgressUpdate result = BatchUtils.buildFinalProgress("job-guid", jobExecution);
+
+		assertEquals(0, result.polygonsProcessed());
+		assertEquals(0, result.projectionErrors());
+		assertEquals(0, result.polygonsSkipped());
 	}
 }


### PR DESCRIPTION
- Modified 'markComplete' endpoint to accept an optional 'ProjectionProgressUpdate' request body
- Updated batch service to include final progress data (polygons processed, error count) in the 'markComplete' call instead of as a separate push
- Ensures status cards are populated even for projections that complete in under 60 seconds