### PR TITLE
Feature/VDYP-990: Add edit capability to Species Information panel

### DIFF
--- a/frontend/src/components/projection/input/minimum-dbh/MinimumDBHPanel.vue
+++ b/frontend/src/components/projection/input/minimum-dbh/MinimumDBHPanel.vue
@@ -86,7 +86,7 @@ import { useAppStore } from '@/stores/projection/appStore'
 import { useFileUploadStore } from '@/stores/projection/fileUploadStore'
 import { AppButton } from '@/components'
 import { ActionPanel } from '@/components/projection'
-import { CONSTANTS, OPTIONS } from '@/constants'
+import { CONSTANTS, MESSAGE, OPTIONS } from '@/constants'
 import { saveProjectionOnPanelConfirm, revertPanelToSaved } from '@/services/projection/fileUploadService'
 import { useNotificationStore } from '@/stores/common/notificationStore'
 import { PROJECTION_ERR } from '@/constants/message'
@@ -132,10 +132,10 @@ const isHeaderEditActive = computed(() => {
 const editTooltipText = computed(() => {
   const status = appStore.currentProjectionStatus
   if (status === CONSTANTS.PROJECTION_STATUS.RUNNING || status === CONSTANTS.PROJECTION_STATUS.READY) {
-    return `This section may not be edited with a status of ${status}`
+    return MESSAGE.EDIT_SECTION_TOOLTIP.RESTRICTED_BY_STATUS(status)
   }
   if (isConfirmed.value && !fileUploadStore.panelState[panelName].editable) {
-    return 'Click Edit to make changes to this section'
+    return MESSAGE.EDIT_SECTION_TOOLTIP.CLICK_TO_EDIT
   }
   return ''
 })
@@ -197,7 +197,7 @@ const onConfirm = async () => {
   try {
     await saveProjectionOnPanelConfirm(fileUploadStore, panelName)
   } catch (error) {
-    console.error('Error saving projection:', error)
+    console.error(PROJECTION_ERR.SAVE_ERROR_LOG, error)
     notificationStore.showErrorMessage(PROJECTION_ERR.SAVE_FAILED, PROJECTION_ERR.SAVE_FAILED_TITLE)
     return
   } finally {
@@ -214,7 +214,7 @@ const onCancel = async () => {
   try {
     await revertPanelToSaved(panelName)
   } catch (error) {
-    console.error('Error reverting panel to saved state:', error)
+    console.error(PROJECTION_ERR.REVERT_ERROR_LOG, error)
     notificationStore.showErrorMessage(PROJECTION_ERR.LOAD_FAILED, PROJECTION_ERR.LOAD_FAILED_TITLE)
   } finally {
     appStore.isSavingProjection = false

--- a/frontend/src/components/projection/input/report-info/ReportConfigPanel.vue
+++ b/frontend/src/components/projection/input/report-info/ReportConfigPanel.vue
@@ -338,7 +338,7 @@ import { AppButton, AppSpinField } from '@/components'
 import { useAlertDialogStore } from '@/stores/common/alertDialogStore'
 import { ActionPanel } from '@/components/projection'
 import { CONSTANTS, DEFAULTS, MESSAGE, OPTIONS } from '@/constants'
-import { PROJECTION_ERR } from '@/constants/message'
+import { PROJECTION_ERR, VALIDATION_WARN } from '@/constants/message'
 import type { FileUploadPanelName } from '@/types/types'
 import { reportInfoValidation } from '@/validation'
 import { saveProjectionOnPanelConfirm as saveFileUploadProjection, revertPanelToSaved, hasMinimumDBHUnsavedChanges } from '@/services/projection/fileUploadService'
@@ -374,10 +374,10 @@ const isHeaderEditActive = computed(() => {
 const editTooltipText = computed(() => {
   const status = appStore.currentProjectionStatus
   if (status === CONSTANTS.PROJECTION_STATUS.RUNNING || status === CONSTANTS.PROJECTION_STATUS.READY) {
-    return `This section may not be edited with a status of ${status}`
+    return MESSAGE.EDIT_SECTION_TOOLTIP.RESTRICTED_BY_STATUS(status)
   }
   if (isConfirmed.value && !fileUploadStore.panelState[panelName].editable) {
-    return 'Click Edit to make changes to this section'
+    return MESSAGE.EDIT_SECTION_TOOLTIP.CLICK_TO_EDIT
   }
   return ''
 })
@@ -651,14 +651,14 @@ const onConfirm = async () => {
   if (form.value) {
     form.value.validate()
   } else {
-    console.warn('Form reference is null. Validation skipped.')
+    console.warn(VALIDATION_WARN.FORM_REF_NULL)
   }
 
   appStore.isSavingProjection = true
   try {
     await saveFileUploadProjection(fileUploadStore, panelName)
   } catch (error) {
-    console.error('Error saving projection:', error)
+    console.error(PROJECTION_ERR.SAVE_ERROR_LOG, error)
     notificationStore.showErrorMessage(PROJECTION_ERR.SAVE_FAILED, PROJECTION_ERR.SAVE_FAILED_TITLE)
     return
   } finally {
@@ -675,7 +675,7 @@ const onCancel = async () => {
   try {
     await revertPanelToSaved(panelName as FileUploadPanelName)
   } catch (error) {
-    console.error('Error reverting panel to saved state:', error)
+    console.error(PROJECTION_ERR.REVERT_ERROR_LOG, error)
     notificationStore.showErrorMessage(PROJECTION_ERR.LOAD_FAILED, PROJECTION_ERR.LOAD_FAILED_TITLE)
   } finally {
     appStore.isSavingProjection = false

--- a/frontend/src/components/projection/input/report-info/ReportDetailsPanel.vue
+++ b/frontend/src/components/projection/input/report-info/ReportDetailsPanel.vue
@@ -152,10 +152,10 @@ const isHeaderEditActive = computed(() => {
 const editTooltipText = computed(() => {
   const status = appStore.currentProjectionStatus
   if (status === CONSTANTS.PROJECTION_STATUS.RUNNING || status === CONSTANTS.PROJECTION_STATUS.READY) {
-    return `This section may not be edited with a status of ${status}`
+    return MESSAGE.EDIT_SECTION_TOOLTIP.RESTRICTED_BY_STATUS(status)
   }
   if (isConfirmed.value && !modelParameterStore.panelState[panelName].editable) {
-    return 'Click Edit to make changes to this section'
+    return MESSAGE.EDIT_SECTION_TOOLTIP.CLICK_TO_EDIT
   }
   return ''
 })
@@ -187,7 +187,7 @@ const onHeaderEdit = async () => {
         try {
           await revertPanelToSaved(editablePanel as PanelName)
         } catch (error) {
-          console.error('Error reverting panel to saved state:', error)
+          console.error(PROJECTION_ERR.REVERT_ERROR_LOG, error)
           notificationStore.showErrorMessage(PROJECTION_ERR.LOAD_FAILED, PROJECTION_ERR.LOAD_FAILED_TITLE)
           return
         } finally {
@@ -244,7 +244,7 @@ const onConfirm = async () => {
   try {
     await saveProjectionOnPanelConfirm(modelParameterStore, panelName)
   } catch (error) {
-    console.error('Error saving projection:', error)
+    console.error(PROJECTION_ERR.SAVE_ERROR_LOG, error)
     notificationStore.showErrorMessage(PROJECTION_ERR.SAVE_FAILED, PROJECTION_ERR.SAVE_FAILED_TITLE)
     return
   } finally {
@@ -261,7 +261,7 @@ const onCancel = async () => {
   try {
     await revertPanelToSaved(panelName)
   } catch (error) {
-    console.error('Error reverting panel to saved state:', error)
+    console.error(PROJECTION_ERR.REVERT_ERROR_LOG, error)
     notificationStore.showErrorMessage(PROJECTION_ERR.LOAD_FAILED, PROJECTION_ERR.LOAD_FAILED_TITLE)
   } finally {
     appStore.isSavingProjection = false

--- a/frontend/src/components/projection/input/report-info/ReportSettingsPanel.vue
+++ b/frontend/src/components/projection/input/report-info/ReportSettingsPanel.vue
@@ -250,7 +250,7 @@ import { useModelParameterStore } from '@/stores/projection/modelParameterStore'
 import { AppButton, AppSpinField } from '@/components'
 import { useNotificationStore } from '@/stores/common/notificationStore'
 import { saveProjectionOnPanelConfirm as saveModelParamProjection, revertPanelToSaved, hasPanelUnsavedChanges } from '@/services/projection/modelParameterService'
-import { PROJECTION_ERR } from '@/constants/message'
+import { PROJECTION_ERR, VALIDATION_WARN } from '@/constants/message'
 import type { PanelName } from '@/types/types'
 import { useAlertDialogStore } from '@/stores/common/alertDialogStore'
 
@@ -284,10 +284,10 @@ const isHeaderEditActive = computed(() => {
 const editTooltipText = computed(() => {
   const status = appStore.currentProjectionStatus
   if (status === CONSTANTS.PROJECTION_STATUS.RUNNING || status === CONSTANTS.PROJECTION_STATUS.READY) {
-    return `This section may not be edited with a status of ${status}`
+    return MESSAGE.EDIT_SECTION_TOOLTIP.RESTRICTED_BY_STATUS(status)
   }
   if (isConfirmed.value && !modelParameterStore.panelState[panelName].editable) {
-    return 'Click Edit to make changes to this section'
+    return MESSAGE.EDIT_SECTION_TOOLTIP.CLICK_TO_EDIT
   }
   return ''
 })
@@ -319,7 +319,7 @@ const onHeaderEdit = async () => {
         try {
           await revertPanelToSaved(editablePanel as PanelName)
         } catch (error) {
-          console.error('Error reverting panel to saved state:', error)
+          console.error(PROJECTION_ERR.REVERT_ERROR_LOG, error)
           notificationStore.showErrorMessage(PROJECTION_ERR.LOAD_FAILED, PROJECTION_ERR.LOAD_FAILED_TITLE)
           return
         } finally {
@@ -701,14 +701,14 @@ const onConfirm = async (): Promise<boolean> => {
   if (form.value) {
     form.value.validate()
   } else {
-    console.warn('Form reference is null. Validation skipped.')
+    console.warn(VALIDATION_WARN.FORM_REF_NULL)
   }
 
   appStore.isSavingProjection = true
   try {
     await saveModelParamProjection(modelParameterStore, panelName)
   } catch (error) {
-    console.error('Error saving projection:', error)
+    console.error(PROJECTION_ERR.SAVE_ERROR_LOG, error)
     notificationStore.showErrorMessage(PROJECTION_ERR.SAVE_FAILED, PROJECTION_ERR.SAVE_FAILED_TITLE)
     return false
   } finally {

--- a/frontend/src/components/projection/input/site-info/SiteInfoPanel.vue
+++ b/frontend/src/components/projection/input/site-info/SiteInfoPanel.vue
@@ -270,7 +270,7 @@ import {
 import SiteIndicesTable from './SiteIndicesTable.vue'
 import type { SpeciesGroup, SiteIndexSpeciesRow } from '@/interfaces/interfaces'
 import { CONSTANTS, OPTIONS, DEFAULTS, MESSAGE } from '@/constants'
-import { PROJECTION_ERR } from '@/constants/message'
+import { PROJECTION_ERR, VALIDATION_WARN } from '@/constants/message'
 import { siteInfoValidation } from '@/validation'
 import { isZeroValue, isEmptyOrZero } from '@/utils/util'
 import { saveProjectionOnPanelConfirm, revertPanelToSaved, hasPanelUnsavedChanges } from '@/services/projection/modelParameterService'
@@ -589,7 +589,7 @@ const onConfirm = async () => {
   }
 
   if (form.value) form.value.validate()
-  else console.warn('Form reference is null. Validation skipped.')
+  else console.warn(VALIDATION_WARN.FORM_REF_NULL)
 
   formattingValues()
 
@@ -598,7 +598,7 @@ const onConfirm = async () => {
   try {
     await saveProjectionOnPanelConfirm(modelParameterStore, panelName)
   } catch (error) {
-    console.error('Error saving projection:', error)
+    console.error(PROJECTION_ERR.SAVE_ERROR_LOG, error)
     notificationStore.showErrorMessage(PROJECTION_ERR.SAVE_FAILED, PROJECTION_ERR.SAVE_FAILED_TITLE)
     return
   } finally {
@@ -618,10 +618,10 @@ const isHeaderEditActive = computed(() => {
 const editTooltipText = computed(() => {
   const status = appStore.currentProjectionStatus
   if (status === CONSTANTS.PROJECTION_STATUS.RUNNING || status === CONSTANTS.PROJECTION_STATUS.READY) {
-    return `This section may not be edited with a status of ${status}`
+    return MESSAGE.EDIT_SECTION_TOOLTIP.RESTRICTED_BY_STATUS(status)
   }
   if (isConfirmed.value && !modelParameterStore.panelState[panelName].editable) {
-    return 'Click Edit to make changes to this section'
+    return MESSAGE.EDIT_SECTION_TOOLTIP.CLICK_TO_EDIT
   }
   return ''
 })
@@ -653,7 +653,7 @@ const onHeaderEdit = async () => {
         try {
           await revertPanelToSaved(editablePanel as PanelName)
         } catch (error) {
-          console.error('Error reverting panel to saved state:', error)
+          console.error(PROJECTION_ERR.REVERT_ERROR_LOG, error)
           notificationStore.showErrorMessage(PROJECTION_ERR.LOAD_FAILED, PROJECTION_ERR.LOAD_FAILED_TITLE)
           return
         } finally {
@@ -670,7 +670,7 @@ const onCancel = async () => {
   try {
     await revertPanelToSaved(panelName)
   } catch (error) {
-    console.error('Error reverting panel to saved state:', error)
+    console.error(PROJECTION_ERR.REVERT_ERROR_LOG, error)
     notificationStore.showErrorMessage(PROJECTION_ERR.LOAD_FAILED, PROJECTION_ERR.LOAD_FAILED_TITLE)
   } finally {
     appStore.isSavingProjection = false

--- a/frontend/src/components/projection/input/species-info/SpeciesInfoPanel.vue
+++ b/frontend/src/components/projection/input/species-info/SpeciesInfoPanel.vue
@@ -26,6 +26,22 @@
             <v-col>
               <span class="text-h6">Species Information</span>
             </v-col>
+            <v-col cols="auto" v-if="!isReadOnly" class="edit-button-col">
+              <v-tooltip :text="editTooltipText" :disabled="!editTooltipText" location="top">
+                <template #activator="{ props: tooltipProps }">
+                  <span v-bind="tooltipProps">
+                    <AppButton
+                      label="Edit"
+                      variant="tertiary"
+                      mdi-name="mdi-pencil-outline"
+                      iconPosition="top"
+                      :isDisabled="!isHeaderEditActive"
+                      @click="onHeaderEdit"
+                    />
+                  </span>
+                </template>
+              </v-tooltip>
+            </v-col>
           </v-row>
         </v-expansion-panel-title>
         <v-expansion-panel-text class="expansion-panel-text">
@@ -98,11 +114,14 @@
             </div>
             <ActionPanel
               v-if="!isReadOnly"
+              class="action-panel"
               :isConfirmEnabled="isConfirmEnabled"
               :isConfirmed="isConfirmed"
-              @clear="onClear"
+              :hideClearButton="true"
+              :hideEditButton="true"
+              :showCancelButton="true"
               @confirm="onConfirm"
-              @edit="onEdit"
+              @cancel="onCancel"
             />
           </v-form>
         </v-expansion-panel-text>
@@ -115,8 +134,10 @@ import { ref, watch, computed } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useModelParameterStore } from '@/stores/projection/modelParameterStore'
 import { useAppStore } from '@/stores/projection/appStore'
+import { useAlertDialogStore } from '@/stores/common/alertDialogStore'
 import {
   AppMessageDialog,
+  AppButton,
 } from '@/components'
 import {
   ActionPanel,
@@ -129,17 +150,19 @@ import {
   MESSAGE,
   OPTIONS,
 } from '@/constants'
-import { PROJECTION_ERR } from '@/constants/message'
+import { PROJECTION_ERR, VALIDATION_WARN } from '@/constants/message'
 import type { SpeciesList, MessageDialog } from '@/interfaces/interfaces'
 import { speciesInfoValidation } from '@/validation'
 import { cloneDeep } from 'lodash'
-import { saveProjectionOnPanelConfirm } from '@/services/projection/modelParameterService'
+import { saveProjectionOnPanelConfirm, revertPanelToSaved, hasPanelUnsavedChanges } from '@/services/projection/modelParameterService'
 import { useNotificationStore } from '@/stores/common/notificationStore'
+import type { PanelName } from '@/types/types'
 
 const form = ref<HTMLFormElement>()
 
 const modelParameterStore = useModelParameterStore()
 const appStore = useAppStore()
+const alertDialogStore = useAlertDialogStore()
 const notificationStore = useNotificationStore()
 
 // Check if we're in read-only (view) mode
@@ -273,7 +296,7 @@ const onConfirm = async () => {
   if (form.value) {
     form.value.validate()
   } else {
-    console.warn('Form reference is null. Validation skipped.')
+    console.warn(VALIDATION_WARN.FORM_REF_NULL)
   }
 
   // Save projection (create or update) before confirming the panel
@@ -281,7 +304,7 @@ const onConfirm = async () => {
   try {
     await saveProjectionOnPanelConfirm(modelParameterStore, panelName)
   } catch (error) {
-    console.error('Error saving projection:', error)
+    console.error(PROJECTION_ERR.SAVE_ERROR_LOG, error)
     notificationStore.showErrorMessage(PROJECTION_ERR.SAVE_FAILED, PROJECTION_ERR.SAVE_FAILED_TITLE)
     return
   } finally {
@@ -294,25 +317,81 @@ const onConfirm = async () => {
   }
 }
 
-const onEdit = () => {
-  // this panel has already been confirmed.
+const isHeaderEditActive = computed(() => {
+  const status = appStore.currentProjectionStatus
+  if (status === CONSTANTS.PROJECTION_STATUS.RUNNING || status === CONSTANTS.PROJECTION_STATUS.READY) return false
+  return isConfirmed.value && !modelParameterStore.panelState[panelName].editable
+})
+
+const editTooltipText = computed(() => {
+  const status = appStore.currentProjectionStatus
+  if (status === CONSTANTS.PROJECTION_STATUS.RUNNING || status === CONSTANTS.PROJECTION_STATUS.READY) {
+    return MESSAGE.EDIT_SECTION_TOOLTIP.RESTRICTED_BY_STATUS(status)
+  }
+  if (isConfirmed.value && !modelParameterStore.panelState[panelName].editable) {
+    return MESSAGE.EDIT_SECTION_TOOLTIP.CLICK_TO_EDIT
+  }
+  return ''
+})
+
+const getEditablePanel = (): string | null => {
+  const panelsToCheck = [
+    CONSTANTS.MANUAL_INPUT_PANEL.SITE_INFO,
+    CONSTANTS.MANUAL_INPUT_PANEL.STAND_INFO,
+    CONSTANTS.MANUAL_INPUT_PANEL.REPORT_SETTINGS,
+  ]
+  return panelsToCheck.find((p) => modelParameterStore.panelState[p].editable) ?? null
+}
+
+const onHeaderEdit = async () => {
   if (isConfirmed.value) {
+    const editablePanel = getEditablePanel()
+    if (editablePanel) {
+      const hasChanges = await hasPanelUnsavedChanges(editablePanel, modelParameterStore)
+      if (hasChanges) {
+        const proceed = await alertDialogStore.openDialog(
+          MESSAGE.UNSAVED_CHANGES_DIALOG.TITLE,
+          MESSAGE.UNSAVED_CHANGES_DIALOG.MESSAGE,
+          { variant: 'warning' },
+        )
+        if (!proceed) return
+
+        appStore.isSavingProjection = true
+        try {
+          await revertPanelToSaved(editablePanel as PanelName)
+        } catch (error) {
+          console.error(PROJECTION_ERR.REVERT_ERROR_LOG, error)
+          notificationStore.showErrorMessage(PROJECTION_ERR.LOAD_FAILED, PROJECTION_ERR.LOAD_FAILED_TITLE)
+          return
+        } finally {
+          appStore.isSavingProjection = false
+        }
+      }
+    }
     modelParameterStore.editPanel(panelName)
   }
 }
 
-const onClear = () => {
-  for (const item of speciesList.value) {
-    item.species = null
-    item.percent = null
+const onCancel = async () => {
+  appStore.isSavingProjection = true
+  try {
+    await revertPanelToSaved(panelName)
+  } catch (error) {
+    console.error(PROJECTION_ERR.REVERT_ERROR_LOG, error)
+    notificationStore.showErrorMessage(PROJECTION_ERR.LOAD_FAILED, PROJECTION_ERR.LOAD_FAILED_TITLE)
+  } finally {
+    appStore.isSavingProjection = false
   }
-  derivedBy.value = null
 }
 
 const handleDialogClose = () => {}
 </script>
 
 <style scoped>
+.action-panel {
+  margin-top: 16px;
+}
+
 .vertical-line {
   display: flex;
   align-items: center;
@@ -335,4 +414,21 @@ const handleDialogClose = () => {}
   padding-bottom: 0px;
 }
 
+.edit-button-col {
+  display: flex;
+  align-items: center;
+}
+
+.edit-button-col :deep(.bcds-button.icon-top) {
+  padding: 2px 4px;
+  gap: 2px;
+}
+
+.edit-button-col :deep(.bcds-button.icon-top .v-icon) {
+  font-size: 18px;
+}
+
+.edit-button-col :deep(.bcds-button.icon-top .button-label) {
+  font-size: 11px;
+}
 </style>

--- a/frontend/src/components/projection/input/stand-info/StandInfoPanel.vue
+++ b/frontend/src/components/projection/input/stand-info/StandInfoPanel.vue
@@ -156,7 +156,7 @@ import {
   ActionPanel,
 } from '@/components/projection'
 import { CONSTANTS, DEFAULTS, MESSAGE, OPTIONS } from '@/constants'
-import { PROJECTION_ERR } from '@/constants/message'
+import { PROJECTION_ERR, VALIDATION_WARN } from '@/constants/message'
 import type { SpeciesGroup } from '@/interfaces/interfaces'
 import { standInfoValidation } from '@/validation'
 import { isEmptyOrZero, isZeroValue } from '@/utils/util'
@@ -466,7 +466,7 @@ const onConfirm = async () => {
   if (form.value) {
     form.value.validate()
   } else {
-    console.warn('Form reference is null. Validation skipped.')
+    console.warn(VALIDATION_WARN.FORM_REF_NULL)
   }
 
   if (isEmptyOrZero(percentStockableArea.value)) {
@@ -480,7 +480,7 @@ const onConfirm = async () => {
   try {
     await saveProjectionOnPanelConfirm(modelParameterStore, panelName)
   } catch (error) {
-    console.error('Error saving projection:', error)
+    console.error(PROJECTION_ERR.SAVE_ERROR_LOG, error)
     notificationStore.showErrorMessage(PROJECTION_ERR.SAVE_FAILED, PROJECTION_ERR.SAVE_FAILED_TITLE)
     return
   } finally {
@@ -502,10 +502,10 @@ const isHeaderEditActive = computed(() => {
 const editTooltipText = computed(() => {
   const status = appStore.currentProjectionStatus
   if (status === CONSTANTS.PROJECTION_STATUS.RUNNING || status === CONSTANTS.PROJECTION_STATUS.READY) {
-    return `This section may not be edited with a status of ${status}`
+    return MESSAGE.EDIT_SECTION_TOOLTIP.RESTRICTED_BY_STATUS(status)
   }
   if (isConfirmed.value && !modelParameterStore.panelState[panelName].editable) {
-    return 'Click Edit to make changes to this section'
+    return MESSAGE.EDIT_SECTION_TOOLTIP.CLICK_TO_EDIT
   }
   return ''
 })
@@ -537,7 +537,7 @@ const onHeaderEdit = async () => {
         try {
           await revertPanelToSaved(editablePanel as PanelName)
         } catch (error) {
-          console.error('Error reverting panel to saved state:', error)
+          console.error(PROJECTION_ERR.REVERT_ERROR_LOG, error)
           notificationStore.showErrorMessage(PROJECTION_ERR.LOAD_FAILED, PROJECTION_ERR.LOAD_FAILED_TITLE)
           return
         } finally {
@@ -554,7 +554,7 @@ const onCancel = async () => {
   try {
     await revertPanelToSaved(panelName)
   } catch (error) {
-    console.error('Error reverting panel to saved state:', error)
+    console.error(PROJECTION_ERR.REVERT_ERROR_LOG, error)
     notificationStore.showErrorMessage(PROJECTION_ERR.LOAD_FAILED, PROJECTION_ERR.LOAD_FAILED_TITLE)
   } finally {
     appStore.isSavingProjection = false

--- a/frontend/src/constants/message.ts
+++ b/frontend/src/constants/message.ts
@@ -224,6 +224,8 @@ export const PROJECTION_ERR = Object.freeze({
   MISSING_GUID: 'No projection is currently selected. Please create or select a projection first.',
   SAVE_FAILED: 'Failed to save the projection. Please try again.',
   SAVE_FAILED_TITLE: 'Projection Save Failed',
+  SAVE_ERROR_LOG: 'Error saving projection:',
+  REVERT_ERROR_LOG: 'Error reverting panel to saved state:',
   FILE_UPLOAD_FAILED: 'Failed to upload the file. Please try again.',
   FILE_UPLOAD_FAILED_TITLE: 'File Upload Failed',
   FILE_DELETE_FAILED: 'Failed to remove the file. Please try again.',
@@ -258,4 +260,13 @@ export const FILE_REMOVAL_DIALOG = Object.freeze({
 export const UNSAVED_CHANGES_DIALOG = Object.freeze({
   TITLE: 'Unsaved Changes',
   MESSAGE: 'You have unsaved changes that will be lost if you navigate away. Do you wish to continue?',
+})
+
+export const VALIDATION_WARN = Object.freeze({
+  FORM_REF_NULL: 'Form reference is null. Validation skipped.',
+})
+
+export const EDIT_SECTION_TOOLTIP = Object.freeze({
+  RESTRICTED_BY_STATUS: (status: string) => `This section may not be edited with a status of ${status}`,
+  CLICK_TO_EDIT: 'Click Edit to make changes to this section',
 })


### PR DESCRIPTION
- Add header Edit button to Species Information panel, matching the pattern of all other input panels (Stand, Site, Report Details, etc.)
- Show unsaved-changes warning dialog when editing Species Info while a subsequent panel has unsaved changes
- Extract hardcoded message strings into constants in message.ts