### PR TITLE
Feature/VDYP-1119: Fix Cancel button resetting downstream panel confirmed states in File Upload and Manual Input modes

### DIFF
--- a/frontend/src/services/projection/fileUploadService.ts
+++ b/frontend/src/services/projection/fileUploadService.ts
@@ -279,11 +279,12 @@ export const revertPanelToSaved = async (panelName: FileUploadPanelName): Promis
   const params = parseProjectionParams(projectionModel.projectionParameters)
   fileUploadStore.restoreFromProjectionParams(params, false)
   fileUploadStore.reportDescription = projectionModel.reportDescription ?? null
-  fileUploadStore.updateRunModelEnabled()
 
-  // Keep the cancelled panel open and editable so the user can continue editing
-  fileUploadStore.panelOpenStates[panelName] = CONSTANTS.PANEL.OPEN
-  fileUploadStore.panelState[panelName] = { confirmed: false, editable: true }
+  // editPanel resets the cancelled panel and all subsequent panels to unconfirmed/closed.
+  // This prevents stale confirmed states (restored from the backend) from blocking
+  // confirmPanel calls when the user re-navigates via Next, and prevents the attachments
+  // panel from being opened incorrectly by applyEditModePanelStates.
+  fileUploadStore.editPanel(panelName)
 }
 
 /**

--- a/frontend/src/services/projection/modelParameterService.ts
+++ b/frontend/src/services/projection/modelParameterService.ts
@@ -907,28 +907,13 @@ export const revertPanelToSaved = async (panelName: PanelName): Promise<void> =>
   }
   modelParameterStore.restoreFromModelParameters(modelParams)
 
-  // Restore projection params with isViewMode=true to preserve all other panels as confirmed.
-  // (isViewMode=false would reset all panels to CREATE mode, losing confirmed states.)
-  modelParameterStore.restoreFromProjectionParams(params, true)
+  // isViewMode=false: uses restoreEditModePanelState to infer confirmed states from data,
+  // which correctly marks prior panels as confirmed without setting runModelEnabled=true.
+  modelParameterStore.restoreFromProjectionParams(params, false)
   modelParameterStore.reportDescription = projectionModel.reportDescription ?? null
 
-  // Close all panels except the cancelled panel.
-  // restoreFromProjectionParams with isViewMode=true opens all panels, so we should close the
-  // ones the user was not editing to avoid them auto-opening on Cancel.
-  const allPanelNames: PanelName[] = [
-    CONSTANTS.MANUAL_INPUT_PANEL.REPORT_DETAILS,
-    CONSTANTS.MANUAL_INPUT_PANEL.SPECIES_INFO,
-    CONSTANTS.MANUAL_INPUT_PANEL.SITE_INFO,
-    CONSTANTS.MANUAL_INPUT_PANEL.STAND_INFO,
-    CONSTANTS.MANUAL_INPUT_PANEL.REPORT_SETTINGS,
-  ]
-  for (const panel of allPanelNames) {
-    if (panel !== panelName) {
-      modelParameterStore.panelOpenStates[panel] = CONSTANTS.PANEL.CLOSE
-    }
-  }
-
-  // Keep the cancelled panel open and editable so the user can continue editing
-  modelParameterStore.panelOpenStates[panelName] = CONSTANTS.PANEL.OPEN
-  modelParameterStore.panelState[panelName] = { confirmed: false, editable: true }
+  // editPanel resets the cancelled panel and all subsequent panels to unconfirmed/closed.
+  // This prevents stale confirmed states from blocking confirmPanel calls when the user
+  // re-navigates via Next, and ensures runModelEnabled is correctly false during editing.
+  modelParameterStore.editPanel(panelName)
 }


### PR DESCRIPTION
- Clicking Cancel on an earlier section was incorrectly restoring downstream panels as confirmed, causing the attachments panel to open unexpectedly, the progress bar to advance, the Run Projection button to activate prematurely, and subsequent Next clicks to have no effect.
- Fixed by replacing manual panel state overrides in revertPanelToSaved with a call to editPanel, which correctly resets the cancelled panel and all downstream panels to unconfirmed.