### PR TITLE
Feature/VDYP-1073(2): Show Time Elapsed in minutes and seconds (MM:SS) instead of minutes only

### DIFF
--- a/frontend/src/components/projection/input/ProjectionRunProgressBar.vue
+++ b/frontend/src/components/projection/input/ProjectionRunProgressBar.vue
@@ -125,16 +125,18 @@ const formattedTimeElapsed = computed(() => {
 
   const upperBoundMs = props.endDate ? new Date(props.endDate).getTime() : currentTime.value
   const elapsedMs = Math.max(0, upperBoundMs - startMs)
-  const totalMinutes = Math.floor(elapsedMs / 60_000)
+  const totalSeconds = Math.floor(elapsedMs / 1_000)
+  const totalMinutes = Math.floor(totalSeconds / 60)
   const totalHours = Math.floor(totalMinutes / 60)
   const days = Math.floor(totalHours / 24)
   const hours = totalHours % 24
   const minutes = totalMinutes % 60
+  const seconds = totalSeconds % 60
 
   const parts: string[] = []
   if (days > 0) parts.push(`${days}d`)
   if (totalHours > 0 || days > 0) parts.push(`${hours}h`)
-  parts.push(`${minutes}m`)
+  parts.push(`${minutes}m ${seconds}s`)
   return parts.join(' ')
 })
 


### PR DESCRIPTION
- Fixes the case where small projection runs completing in under a minute displayed '0m' instead of the actual elapsed time, displaying elapsed time in minutes and seconds (e.g. '0m 45s', '1m 30s', '1h 02m 30s') instead of minutes only