### PR TITLE
Feature/VDYP-1135: Normalize null/empty reportDescription comparison to prevent false unsaved-changes warning

### DIFF
--- a/frontend/src/services/projection/modelParameterService.ts
+++ b/frontend/src/services/projection/modelParameterService.ts
@@ -807,7 +807,7 @@ const hasReportInfoChanges = (
   if (!numEq(store.finishingAge, savedParams.ageEnd)) return true
   if (!numEq(store.ageIncrement, savedParams.ageIncrement)) return true
   if (!strEq(store.reportTitle, savedParams.reportTitle)) return true
-  if (!strEq(store.reportDescription, savedDescription)) return true
+  if (!strEq(store.reportDescription || null, savedDescription || null)) return true
   const opts = savedParams.selectedExecutionOptions
   if (store.isComputedMAIEnabled !== opts.includes(ExecutionOptionsEnum.ReportIncludeVolumeMAI)) return true
   if (store.isCulminationValuesEnabled !== opts.includes(ExecutionOptionsEnum.ReportIncludeCulminationValues)) return true


### PR DESCRIPTION
Fixes a false 'Unsaved Changes' warning on Report Settings in the new projection flow. The store initializes reportDescription as null, but the backend stores it as empty string, causing a mismatch. Normalized both sides with || null before comparison.