### PR TITLE
Feature/VDYP-1006: Hide parameter selection progress bar in Manual Input during non-Draft states

### DIFF
--- a/frontend/src/views/ProjectionDetail.vue
+++ b/frontend/src/views/ProjectionDetail.vue
@@ -133,6 +133,7 @@
       </div>
       <template v-if="isModelParameterPanelsVisible">
         <ParameterSelectionProgressBar
+          v-if="isDraft"
           :sections="manualInputProgressSections"
           :percentage="manualInputPercentage"
           :completedCount="manualInputCompletedCount"


### PR DESCRIPTION
- In Manual Input mode, the ParameterSelectionProgressBar is now hidden when the projection is not draft state.