### PR TITLE
Feature/VDYP-1139 [2] : Fix progress bar placement and button spacing

### DIFF
--- a/frontend/src/components/projection/reporting/ReportingActions.vue
+++ b/frontend/src/components/projection/reporting/ReportingActions.vue
@@ -63,7 +63,6 @@ const handleDownload = () => {
   justify-content: flex-end;
   align-items: flex-end;
   text-align: end;
-  margin-right: var(--layout-margin-small);
   background-color: transparent;
 }
 

--- a/frontend/src/components/projection/reporting/ReportingContainer.vue
+++ b/frontend/src/components/projection/reporting/ReportingContainer.vue
@@ -114,7 +114,7 @@ const handlePrint = () => {
   width: 100%;
   padding-left: var(--layout-padding-none) !important;
   padding-right: var(--layout-padding-none) !important;
-  padding-top: var(--layout-padding-medium);
+  padding-top: 0px;
   padding-bottom: var(--layout-padding-medium);
   margin: var(--layout-margin-none);
 }

--- a/frontend/src/components/projection/reporting/ReportingOutput.vue
+++ b/frontend/src/components/projection/reporting/ReportingOutput.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="ml-2 mr-2"
+    class="ml-2"
     :style="outputStyle"
   >
     {{ formattedData }}

--- a/frontend/src/styles/_tabs.scss
+++ b/frontend/src/styles/_tabs.scss
@@ -3,7 +3,6 @@
 /* Tab container styling */
 .v-slide-group.v-tabs {
   margin-top: var(--layout-margin-none);
-  margin-bottom: var(--layout-margin-medium);
 }
 
 /* Default tab styling */

--- a/frontend/src/views/ProjectionDetail.vue
+++ b/frontend/src/views/ProjectionDetail.vue
@@ -117,7 +117,17 @@
         CONSTANTS.METHOD_SELECTION.MANUAL_INPUT
       "
     >
-      <div class="tabs-with-download">
+      <ProjectionRunProgressBar
+        v-if="isManualInputRunProgressBarVisible"
+        :status="appStore.currentProjectionStatus"
+        :polygonCount="batchPolygonCount"
+        :completedPolygonCount="batchCompletedPolygonCount"
+        :errorCount="batchErrorCount"
+        :startDate="runStartDate"
+        :endDate="runEndDate"
+        class="panel-spacing"
+      />
+      <div class="tabs-with-download" :style="isManualInputRunProgressBarVisible ? { marginTop: '16px' } : {}">
         <AppTabs
           v-model:currentTab="modelParamActiveTab"
           :tabs="modelParamTabs"
@@ -131,16 +141,6 @@
           @click="handleDownloadReport"
         />
       </div>
-      <ProjectionRunProgressBar
-        v-if="isManualInputRunProgressBarVisible"
-        :status="appStore.currentProjectionStatus"
-        :polygonCount="batchPolygonCount"
-        :completedPolygonCount="batchCompletedPolygonCount"
-        :errorCount="batchErrorCount"
-        :startDate="runStartDate"
-        :endDate="runEndDate"
-        class="panel-spacing"
-      />
       <template v-if="isModelParameterPanelsVisible">
         <ParameterSelectionProgressBar
           v-if="isDraft"


### PR DESCRIPTION
- Move ProjectionRunProgressBar above the tabs so it appears directly below the page title, matching the requested layout
- Reduce whitespace between the Download Report button and the Print / Download Yield Table buttons