### PR TITLE
Feature/VDYP-1141: Optimize CSV header validation to read first line only and improve error messages

### DIFF
--- a/frontend/src/components/projection/input/attachments/AttachmentsPanel.vue
+++ b/frontend/src/components/projection/input/attachments/AttachmentsPanel.vue
@@ -227,12 +227,14 @@ const getDuplicateColumnsError = async (
 
 const getHeaderColumnsError = async (
   file: File,
-  validateFn: (file: File) => Promise<{ isValid: boolean; isEmpty: boolean; details: any }>,
+  validateFn: (file: File) => Promise<{ isValid: boolean; isEmpty: boolean; isWrongFileType: boolean; details: any }>,
   emptyFileMessage: string,
+  wrongFileTypeMessage: string,
 ): Promise<string | null> => {
   const result = await validateFn(file)
   if (!result.isValid) {
     if (result.isEmpty) return emptyFileMessage
+    if (result.isWrongFileType) return wrongFileTypeMessage
     return buildHeaderErrorMessage(result.details)
   }
   return null
@@ -253,6 +255,7 @@ const validatePolygonFile = async (file: File): Promise<boolean> => {
     file,
     fileUploadValidation.validatePolygonHeader,
     MESSAGE.FILE_UPLOAD_ERR.POLYGON_FILE_EMPTY,
+    MESSAGE.FILE_UPLOAD_ERR.POLYGON_UPLOAD_RECEIVED_LAYER_FILE,
   )
   if (headerError) {
     polygonFileError.value = headerError
@@ -278,6 +281,7 @@ const validateLayerFile = async (file: File): Promise<boolean> => {
     file,
     fileUploadValidation.validateLayerHeader,
     MESSAGE.FILE_UPLOAD_ERR.LAYER_FILE_EMPTY,
+    MESSAGE.FILE_UPLOAD_ERR.LAYER_UPLOAD_RECEIVED_POLYGON_FILE,
   )
   if (headerError) {
     layerFileError.value = headerError

--- a/frontend/src/components/projection/input/attachments/AttachmentsPanel.vue
+++ b/frontend/src/components/projection/input/attachments/AttachmentsPanel.vue
@@ -227,10 +227,12 @@ const getDuplicateColumnsError = async (
 
 const getHeaderColumnsError = async (
   file: File,
-  validateFn: (file: File) => Promise<{ isValid: boolean; details: any }>,
+  validateFn: (file: File) => Promise<{ isValid: boolean; isEmpty: boolean; details: any }>,
+  emptyFileMessage: string,
 ): Promise<string | null> => {
   const result = await validateFn(file)
   if (!result.isValid) {
+    if (result.isEmpty) return emptyFileMessage
     return buildHeaderErrorMessage(result.details)
   }
   return null
@@ -250,6 +252,7 @@ const validatePolygonFile = async (file: File): Promise<boolean> => {
   const headerError = await getHeaderColumnsError(
     file,
     fileUploadValidation.validatePolygonHeader,
+    MESSAGE.FILE_UPLOAD_ERR.POLYGON_FILE_EMPTY,
   )
   if (headerError) {
     polygonFileError.value = headerError
@@ -274,6 +277,7 @@ const validateLayerFile = async (file: File): Promise<boolean> => {
   const headerError = await getHeaderColumnsError(
     file,
     fileUploadValidation.validateLayerHeader,
+    MESSAGE.FILE_UPLOAD_ERR.LAYER_FILE_EMPTY,
   )
   if (headerError) {
     layerFileError.value = headerError

--- a/frontend/src/components/projection/input/attachments/AttachmentsPanel.vue
+++ b/frontend/src/components/projection/input/attachments/AttachmentsPanel.vue
@@ -210,11 +210,13 @@ const buildHeaderErrorMessage = (details: {
 
 const getDuplicateColumnsError = async (
   file: File,
-  validateFn: (file: File) => Promise<{ isValid: boolean; duplicates: string[] }>,
+  validateFn: (file: File) => Promise<{ isValid: boolean; isColumnCountInvalid: boolean; duplicates: string[] }>,
   errorMessage: string,
+  columnCountErrorMessage: string,
 ): Promise<string | null> => {
   const result = await validateFn(file)
   if (!result.isValid) {
+    if (result.isColumnCountInvalid) return columnCountErrorMessage
     let message = errorMessage
     if (result.duplicates.length > 0) {
       message += '\n\nDuplicate columns found:\n' +
@@ -245,6 +247,7 @@ const validatePolygonFile = async (file: File): Promise<boolean> => {
     file,
     fileUploadValidation.validatePolygonDuplicateColumns,
     MESSAGE.FILE_UPLOAD_ERR.POLYGON_FILE_DUPLICATE_COLUMNS,
+    MESSAGE.FILE_UPLOAD_ERR.POLYGON_FILE_INVALID_COLUMN_COUNT,
   )
   if (duplicateError) {
     polygonFileError.value = duplicateError
@@ -271,6 +274,7 @@ const validateLayerFile = async (file: File): Promise<boolean> => {
     file,
     fileUploadValidation.validateLayerDuplicateColumns,
     MESSAGE.FILE_UPLOAD_ERR.LAYER_FILE_DUPLICATE_COLUMNS,
+    MESSAGE.FILE_UPLOAD_ERR.LAYER_FILE_INVALID_COLUMN_COUNT,
   )
   if (duplicateError) {
     layerFileError.value = duplicateError

--- a/frontend/src/components/projection/input/attachments/AttachmentsPanel.vue
+++ b/frontend/src/components/projection/input/attachments/AttachmentsPanel.vue
@@ -229,13 +229,11 @@ const getDuplicateColumnsError = async (
 
 const getHeaderColumnsError = async (
   file: File,
-  validateFn: (file: File) => Promise<{ isValid: boolean; isEmpty: boolean; isWrongFileType: boolean; details: any }>,
-  emptyFileMessage: string,
+  validateFn: (file: File) => Promise<{ isValid: boolean; isWrongFileType: boolean; details: any }>,
   wrongFileTypeMessage: string,
 ): Promise<string | null> => {
   const result = await validateFn(file)
   if (!result.isValid) {
-    if (result.isEmpty) return emptyFileMessage
     if (result.isWrongFileType) return wrongFileTypeMessage
     return buildHeaderErrorMessage(result.details)
   }
@@ -243,6 +241,11 @@ const getHeaderColumnsError = async (
 }
 
 const validatePolygonFile = async (file: File): Promise<boolean> => {
+  if (await fileUploadValidation.isFileEmpty(file)) {
+    polygonFileError.value = MESSAGE.FILE_UPLOAD_ERR.POLYGON_FILE_EMPTY
+    return false
+  }
+
   const duplicateError = await getDuplicateColumnsError(
     file,
     fileUploadValidation.validatePolygonDuplicateColumns,
@@ -257,7 +260,6 @@ const validatePolygonFile = async (file: File): Promise<boolean> => {
   const headerError = await getHeaderColumnsError(
     file,
     fileUploadValidation.validatePolygonHeader,
-    MESSAGE.FILE_UPLOAD_ERR.POLYGON_FILE_EMPTY,
     MESSAGE.FILE_UPLOAD_ERR.POLYGON_UPLOAD_RECEIVED_LAYER_FILE,
   )
   if (headerError) {
@@ -270,6 +272,11 @@ const validatePolygonFile = async (file: File): Promise<boolean> => {
 }
 
 const validateLayerFile = async (file: File): Promise<boolean> => {
+  if (await fileUploadValidation.isFileEmpty(file)) {
+    layerFileError.value = MESSAGE.FILE_UPLOAD_ERR.LAYER_FILE_EMPTY
+    return false
+  }
+
   const duplicateError = await getDuplicateColumnsError(
     file,
     fileUploadValidation.validateLayerDuplicateColumns,
@@ -284,7 +291,6 @@ const validateLayerFile = async (file: File): Promise<boolean> => {
   const headerError = await getHeaderColumnsError(
     file,
     fileUploadValidation.validateLayerHeader,
-    MESSAGE.FILE_UPLOAD_ERR.LAYER_FILE_EMPTY,
     MESSAGE.FILE_UPLOAD_ERR.LAYER_UPLOAD_RECEIVED_POLYGON_FILE,
   )
   if (headerError) {

--- a/frontend/src/components/projection/reporting/ReportingContainer.cy.ts
+++ b/frontend/src/components/projection/reporting/ReportingContainer.cy.ts
@@ -52,7 +52,7 @@ describe('ReportingContainer.vue', () => {
 
     it('renders the ReportingOutput panel', () => {
       mountComponent(REPORTING_TAB.MODEL_REPORT)
-      cy.get('.ml-2.mr-2').should('exist')
+      cy.get('.ml-2').should('exist')
     })
   })
 
@@ -138,8 +138,8 @@ describe('ReportingContainer.vue', () => {
         txtYieldLines: ['Yield Report Header', 'Species: Fir'],
         csvYieldLines: ['csv,header,col'],
       })
-      cy.get('.ml-2.mr-2').should('contain.text', 'Yield Report Header')
-      cy.get('.ml-2.mr-2').should('contain.text', 'Species: Fir')
+      cy.get('.ml-2').should('contain.text', 'Yield Report Header')
+      cy.get('.ml-2').should('contain.text', 'Species: Fir')
     })
 
     it('does NOT show csvYieldLines in output for MODEL_REPORT (display uses txtYieldLines)', () => {
@@ -147,39 +147,39 @@ describe('ReportingContainer.vue', () => {
         txtYieldLines: ['Text report line'],
         csvYieldLines: ['csv,only,data'],
       })
-      cy.get('.ml-2.mr-2').should('contain.text', 'Text report line')
-      cy.get('.ml-2.mr-2').should('not.contain.text', 'csv,only,data')
+      cy.get('.ml-2').should('contain.text', 'Text report line')
+      cy.get('.ml-2').should('not.contain.text', 'csv,only,data')
     })
 
     it('displays errorMessages in output for VIEW_ERR_MSG', () => {
       mountComponent(REPORTING_TAB.VIEW_ERR_MSG, {
         errorMessages: ['ERROR: Missing polygon', 'WARNING: Low density value'],
       })
-      cy.get('.ml-2.mr-2').should('contain.text', 'ERROR: Missing polygon')
-      cy.get('.ml-2.mr-2').should('contain.text', 'WARNING: Low density value')
+      cy.get('.ml-2').should('contain.text', 'ERROR: Missing polygon')
+      cy.get('.ml-2').should('contain.text', 'WARNING: Low density value')
     })
 
     it('displays logMessages in output for VIEW_LOG_FILE', () => {
       mountComponent(REPORTING_TAB.VIEW_LOG_FILE, {
         logMessages: ['Batch job started', 'Batch job completed'],
       })
-      cy.get('.ml-2.mr-2').should('contain.text', 'Batch job started')
-      cy.get('.ml-2.mr-2').should('contain.text', 'Batch job completed')
+      cy.get('.ml-2').should('contain.text', 'Batch job started')
+      cy.get('.ml-2').should('contain.text', 'Batch job completed')
     })
 
     it('shows empty output when store has no data', () => {
       mountComponent(REPORTING_TAB.MODEL_REPORT, { txtYieldLines: [] })
-      cy.get('.ml-2.mr-2').should('have.text', '')
+      cy.get('.ml-2').should('have.text', '')
     })
 
     it('output updates reactively when store data changes after mount', () => {
       mountComponent(REPORTING_TAB.VIEW_ERR_MSG, { errorMessages: [] })
-      cy.get('.ml-2.mr-2').should('have.text', '')
+      cy.get('.ml-2').should('have.text', '')
 
       cy.then(() => {
         useProjectionStore().errorMessages = ['Late-arriving error message']
       })
-      cy.get('.ml-2.mr-2').should('contain.text', 'Late-arriving error message')
+      cy.get('.ml-2').should('contain.text', 'Late-arriving error message')
     })
   })
 

--- a/frontend/src/components/projection/reporting/ReportingOutput.cy.ts
+++ b/frontend/src/components/projection/reporting/ReportingOutput.cy.ts
@@ -15,63 +15,63 @@ describe('ReportingOutput.vue', () => {
   describe('rendering', () => {
     it('renders the output container', () => {
       mountComponent()
-      cy.get('div.ml-2.mr-2').should('exist')
+      cy.get('div.ml-2').should('exist')
     })
 
     it('renders joined data lines separated by newlines', () => {
       mountComponent()
-      cy.get('div.ml-2.mr-2').should('contain.text', 'Line 1')
-      cy.get('div.ml-2.mr-2').should('contain.text', 'Line 2')
-      cy.get('div.ml-2.mr-2').should('contain.text', 'Line 3')
+      cy.get('div.ml-2').should('contain.text', 'Line 1')
+      cy.get('div.ml-2').should('contain.text', 'Line 2')
+      cy.get('div.ml-2').should('contain.text', 'Line 3')
     })
 
     it('renders empty content when data is an empty array', () => {
       mountComponent({ data: [] })
-      cy.get('div.ml-2.mr-2').should('have.text', '')
+      cy.get('div.ml-2').should('have.text', '')
     })
 
     it('renders a single line when data has one element', () => {
       mountComponent({ data: ['Only line'] })
-      cy.get('div.ml-2.mr-2').should('contain.text', 'Only line')
+      cy.get('div.ml-2').should('contain.text', 'Only line')
     })
   })
 
   describe('formattedData', () => {
     it('joins array elements with newline', () => {
       mountComponent({ data: ['A', 'B', 'C'] })
-      cy.get('div.ml-2.mr-2').invoke('text').should('eq', 'A\nB\nC')
+      cy.get('div.ml-2').invoke('text').should('eq', 'A\nB\nC')
     })
   })
 
   describe('styles', () => {
     it('applies base monospace font style', () => {
       mountComponent()
-      cy.get('div.ml-2.mr-2').should('have.css', 'font-family').and('include', 'Courier')
+      cy.get('div.ml-2').should('have.css', 'font-family').and('include', 'Courier')
     })
 
     it('applies pre whitespace style', () => {
       mountComponent()
-      cy.get('div.ml-2.mr-2').should('have.css', 'white-space', 'pre')
+      cy.get('div.ml-2').should('have.css', 'white-space', 'pre')
     })
 
     it('applies fixed height (420px) for non-MODEL_REPORT tabs', () => {
       mountComponent({ tabname: REPORTING_TAB.VIEW_ERR_MSG })
-      cy.get('div.ml-2.mr-2').should('have.css', 'height', '420px')
+      cy.get('div.ml-2').should('have.css', 'height', '420px')
     })
 
     it('applies fixed height (420px) for VIEW_LOG_FILE tab', () => {
       mountComponent({ tabname: REPORTING_TAB.VIEW_LOG_FILE })
-      cy.get('div.ml-2.mr-2').should('have.css', 'height', '420px')
+      cy.get('div.ml-2').should('have.css', 'height', '420px')
     })
 
     it('applies minHeight (420px) instead of height for MODEL_REPORT tab', () => {
       mountComponent({ tabname: REPORTING_TAB.MODEL_REPORT })
-      cy.get('div.ml-2.mr-2').should('have.css', 'min-height', '420px')
+      cy.get('div.ml-2').should('have.css', 'min-height', '420px')
     })
 
     it('applies fixed height when tabname is not provided', () => {
       mountComponent()
-      cy.get('div.ml-2.mr-2').should('have.css', 'height', '420px')
+      cy.get('div.ml-2').should('have.css', 'height', '420px')
     })
   })
 })

--- a/frontend/src/constants/message.ts
+++ b/frontend/src/constants/message.ts
@@ -156,6 +156,10 @@ export const FILE_UPLOAD_ERR = Object.freeze({
     'The Polygon file is empty. Please upload a file with data.',
   LAYER_FILE_EMPTY:
     'The Layer file is empty. Please upload a file with data.',
+  POLYGON_UPLOAD_RECEIVED_LAYER_FILE:
+    'A Layer file was uploaded to the Polygon file area. Please upload a Polygon file.',
+  LAYER_UPLOAD_RECEIVED_POLYGON_FILE:
+    'A Polygon file was uploaded to the Layer file area. Please upload a Layer file.',
   POLYGON_FILE_DUPLICATE_COLUMNS:
     'The Polygon file contains duplicate column names. Each column must have a unique name. Please fix the file and try again.',
   LAYER_FILE_DUPLICATE_COLUMNS:

--- a/frontend/src/constants/message.ts
+++ b/frontend/src/constants/message.ts
@@ -160,6 +160,10 @@ export const FILE_UPLOAD_ERR = Object.freeze({
     'A Layer file was uploaded to the Polygon file area. Please upload a Polygon file.',
   LAYER_UPLOAD_RECEIVED_POLYGON_FILE:
     'A Polygon file was uploaded to the Layer file area. Please upload a Layer file.',
+  POLYGON_FILE_INVALID_COLUMN_COUNT:
+    'The Polygon file has an incorrect number of columns. Expected 43 columns.',
+  LAYER_FILE_INVALID_COLUMN_COUNT:
+    'The Layer file has an incorrect number of columns. Expected between 38 and 51 columns.',
   POLYGON_FILE_DUPLICATE_COLUMNS:
     'The Polygon file contains duplicate column names. Each column must have a unique name. Please fix the file and try again.',
   LAYER_FILE_DUPLICATE_COLUMNS:

--- a/frontend/src/constants/message.ts
+++ b/frontend/src/constants/message.ts
@@ -152,6 +152,10 @@ export const FILE_UPLOAD_ERR = Object.freeze({
   LAYER_FILE_MISSING: 'Layer file is missing. Please upload the required file.',
   POLYGON_FILE_MISSING:
     'Polygon file is missing. Please upload the required file.',
+  POLYGON_FILE_EMPTY:
+    'The Polygon file is empty. Please upload a file with data.',
+  LAYER_FILE_EMPTY:
+    'The Layer file is empty. Please upload a file with data.',
   POLYGON_FILE_DUPLICATE_COLUMNS:
     'The Polygon file contains duplicate column names. Each column must have a unique name. Please fix the file and try again.',
   LAYER_FILE_DUPLICATE_COLUMNS:

--- a/frontend/src/validation/fileUploadValidation.cy.ts
+++ b/frontend/src/validation/fileUploadValidation.cy.ts
@@ -169,7 +169,8 @@ describe('File Upload Validation Unit Tests', () => {
       const file = createFile(mismatchedHeader, 'polygon.csv', 'text/csv')
       const result = await validatePolygonHeader(file)
       expect(result.isValid).to.be.false
-      expect(result.details.mismatches.length).to.be.greaterThan(0)
+      expect(result.details.extra).to.include('WRONG_COLUMN')
+      expect(result.details.missing).to.include(CSVHEADERS.POLYGON_HEADERS[1])
     })
   })
 
@@ -207,13 +208,14 @@ describe('File Upload Validation Unit Tests', () => {
       const file = createFile(mismatchedHeader, 'layer.csv', 'text/csv')
       const result = await validateLayerHeader(file)
       expect(result.isValid).to.be.false
-      expect(result.details.mismatches.length).to.be.greaterThan(0)
+      expect(result.details.extra).to.include('WRONG_COLUMN')
+      expect(result.details.missing).to.include(CSVHEADERS.LAYER_HEADERS[1])
     })
   })
 
   context('validatePolygonDuplicateColumns', () => {
     it('should return true for a polygon file with no duplicate columns', async () => {
-      const validHeader = 'COL1,COL2,COL3,COL4'
+      const validHeader = `${CSVHEADERS.POLYGON_HEADERS[0]},COL1,COL2,COL3`
       const file = createFile(validHeader, 'polygon.csv', 'text/csv')
       const result = await validatePolygonDuplicateColumns(file)
       expect(result.isValid).to.be.true
@@ -250,7 +252,7 @@ describe('File Upload Validation Unit Tests', () => {
 
   context('validateLayerDuplicateColumns', () => {
     it('should return true for a layer file with no duplicate columns', async () => {
-      const validHeader = 'LAYER1,LAYER2,LAYER3,LAYER4'
+      const validHeader = `${CSVHEADERS.LAYER_HEADERS[0]},LAYER1,LAYER2,LAYER3`
       const file = createFile(validHeader, 'layer.csv', 'text/csv')
       const result = await validateLayerDuplicateColumns(file)
       expect(result.isValid).to.be.true
@@ -303,7 +305,7 @@ describe('File Upload Validation Unit Tests', () => {
     })
 
     it('should handle mixed quoted and unquoted columns', async () => {
-      const mixedHeader = '"COL1",COL2,"COL3",COL4'
+      const mixedHeader = `"${CSVHEADERS.POLYGON_HEADERS[0]}",COL2,"COL3",COL4`
       const file = createFile(mixedHeader, 'polygon.csv', 'text/csv')
       const result = await validatePolygonDuplicateColumns(file)
       expect(result.isValid).to.be.true
@@ -329,7 +331,7 @@ describe('File Upload Validation Unit Tests', () => {
     })
 
     it('should handle mixed quoted and unquoted columns', async () => {
-      const mixedHeader = '"COL1",COL2,"COL3",COL4'
+      const mixedHeader = `"${CSVHEADERS.LAYER_HEADERS[0]}",COL2,"COL3",COL4`
       const file = createFile(mixedHeader, 'layer.csv', 'text/csv')
       const result = await validateLayerDuplicateColumns(file)
       expect(result.isValid).to.be.true

--- a/frontend/src/validation/fileUploadValidation.cy.ts
+++ b/frontend/src/validation/fileUploadValidation.cy.ts
@@ -147,11 +147,11 @@ describe('File Upload Validation Unit Tests', () => {
     })
 
     it('should return false for a polygon header with missing columns', async () => {
-      const incompleteHeader = CSVHEADERS.POLYGON_HEADERS.slice(1).join(',')
+      const incompleteHeader = CSVHEADERS.POLYGON_HEADERS.filter((_, i) => i !== 1).join(',')
       const file = createFile(incompleteHeader, 'polygon.csv', 'text/csv')
       const result = await validatePolygonHeader(file)
       expect(result.isValid).to.be.false
-      expect(result.details.missing).to.include(CSVHEADERS.POLYGON_HEADERS[0])
+      expect(result.details.missing).to.include(CSVHEADERS.POLYGON_HEADERS[1])
     })
 
     it('should return false for a polygon header with extra columns', async () => {
@@ -164,7 +164,7 @@ describe('File Upload Validation Unit Tests', () => {
 
     it('should return false for a polygon header with mismatched columns', async () => {
       const mismatchedHeader = CSVHEADERS.POLYGON_HEADERS.map((h, i) =>
-        i === 0 ? 'WRONG_COLUMN' : h,
+        i === 1 ? 'WRONG_COLUMN' : h,
       ).join(',')
       const file = createFile(mismatchedHeader, 'polygon.csv', 'text/csv')
       const result = await validatePolygonHeader(file)
@@ -185,11 +185,11 @@ describe('File Upload Validation Unit Tests', () => {
     })
 
     it('should return false for a layer header with missing columns', async () => {
-      const incompleteHeader = CSVHEADERS.LAYER_HEADERS.slice(1).join(',')
+      const incompleteHeader = CSVHEADERS.LAYER_HEADERS.filter((_, i) => i !== 1).join(',')
       const file = createFile(incompleteHeader, 'layer.csv', 'text/csv')
       const result = await validateLayerHeader(file)
       expect(result.isValid).to.be.false
-      expect(result.details.missing).to.include(CSVHEADERS.LAYER_HEADERS[0])
+      expect(result.details.missing).to.include(CSVHEADERS.LAYER_HEADERS[1])
     })
 
     it('should return false for a layer header with extra columns', async () => {
@@ -202,7 +202,7 @@ describe('File Upload Validation Unit Tests', () => {
 
     it('should return false for a layer header with mismatched columns', async () => {
       const mismatchedHeader = CSVHEADERS.LAYER_HEADERS.map((h, i) =>
-        i === 0 ? 'WRONG_COLUMN' : h,
+        i === 1 ? 'WRONG_COLUMN' : h,
       ).join(',')
       const file = createFile(mismatchedHeader, 'layer.csv', 'text/csv')
       const result = await validateLayerHeader(file)
@@ -221,7 +221,7 @@ describe('File Upload Validation Unit Tests', () => {
     })
 
     it('should return false for a polygon file with multiple duplicate columns', async () => {
-      const duplicateHeader = 'COL1,COL2,COL1,COL3,COL2,COL4'
+      const duplicateHeader = `${CSVHEADERS.POLYGON_HEADERS[0]},COL1,COL2,COL3,COL1,COL2`
       const file = createFile(duplicateHeader, 'polygon.csv', 'text/csv')
       const result = await validatePolygonDuplicateColumns(file)
       expect(result.isValid).to.be.false
@@ -231,7 +231,7 @@ describe('File Upload Validation Unit Tests', () => {
     })
 
     it('should handle empty columns and whitespace correctly', async () => {
-      const duplicateHeader = 'COL1, COL2 ,COL1,COL3'
+      const duplicateHeader = `${CSVHEADERS.POLYGON_HEADERS[0]}, COL1 ,COL2,COL1`
       const file = createFile(duplicateHeader, 'polygon.csv', 'text/csv')
       const result = await validatePolygonDuplicateColumns(file)
       expect(result.isValid).to.be.false
@@ -239,7 +239,7 @@ describe('File Upload Validation Unit Tests', () => {
     })
 
     it('should detect case-insensitive duplicate columns', async () => {
-      const duplicateHeader = 'POLYGON_NUMBER,polygon_number,OTHER_COL'
+      const duplicateHeader = `${CSVHEADERS.POLYGON_HEADERS[0]},POLYGON_NUMBER,polygon_number,OTHER_COL`
       const file = createFile(duplicateHeader, 'polygon.csv', 'text/csv')
       const result = await validatePolygonDuplicateColumns(file)
       expect(result.isValid).to.be.false
@@ -258,7 +258,7 @@ describe('File Upload Validation Unit Tests', () => {
     })
 
     it('should return false for a layer file with multiple duplicate columns', async () => {
-      const duplicateHeader = 'LAYER1,LAYER2,LAYER1,LAYER3,LAYER2,LAYER4'
+      const duplicateHeader = `${CSVHEADERS.LAYER_HEADERS[0]},LAYER1,LAYER2,LAYER3,LAYER1,LAYER2`
       const file = createFile(duplicateHeader, 'layer.csv', 'text/csv')
       const result = await validateLayerDuplicateColumns(file)
       expect(result.isValid).to.be.false
@@ -268,7 +268,7 @@ describe('File Upload Validation Unit Tests', () => {
     })
 
     it('should handle empty columns and whitespace correctly', async () => {
-      const duplicateHeader = 'LAYER1, LAYER2 ,LAYER1,LAYER3'
+      const duplicateHeader = `${CSVHEADERS.LAYER_HEADERS[0]}, LAYER1 ,LAYER2,LAYER1`
       const file = createFile(duplicateHeader, 'layer.csv', 'text/csv')
       const result = await validateLayerDuplicateColumns(file)
       expect(result.isValid).to.be.false
@@ -276,7 +276,7 @@ describe('File Upload Validation Unit Tests', () => {
     })
 
     it('should detect case-insensitive duplicate columns', async () => {
-      const duplicateHeader = 'LAYER_ID,layer_id,OTHER_LAYER'
+      const duplicateHeader = `${CSVHEADERS.LAYER_HEADERS[0]},LAYER_ID,layer_id,OTHER_LAYER`
       const file = createFile(duplicateHeader, 'layer.csv', 'text/csv')
       const result = await validateLayerDuplicateColumns(file)
       expect(result.isValid).to.be.false

--- a/frontend/src/validation/fileUploadValidation.ts
+++ b/frontend/src/validation/fileUploadValidation.ts
@@ -1,4 +1,5 @@
 import { FileUploadValidator } from './fileUploadValidator'
+import { CSVHEADERS } from '@/constants'
 
 const fileUploadValidator = new FileUploadValidator()
 
@@ -103,9 +104,15 @@ export const validateLayerHeader = async (file: File) => {
 }
 
 export const validatePolygonDuplicateColumns = async (file: File) => {
-  return fileUploadValidator.validateDuplicateColumns(file)
+  return fileUploadValidator.validateDuplicateColumns(
+    file,
+    CSVHEADERS.POLYGON_HEADERS[0],
+  )
 }
 
 export const validateLayerDuplicateColumns = async (file: File) => {
-  return fileUploadValidator.validateDuplicateColumns(file)
+  return fileUploadValidator.validateDuplicateColumns(
+    file,
+    CSVHEADERS.LAYER_HEADERS[0],
+  )
 }

--- a/frontend/src/validation/fileUploadValidation.ts
+++ b/frontend/src/validation/fileUploadValidation.ts
@@ -95,6 +95,10 @@ export const validateFiles = async (
   return { isValid: true }
 }
 
+export const isFileEmpty = async (file: File) => {
+  return fileUploadValidator.isFileEmpty(file)
+}
+
 export const validatePolygonHeader = async (file: File) => {
   return fileUploadValidator.validatePolygonHeader(file)
 }

--- a/frontend/src/validation/fileUploadValidation.ts
+++ b/frontend/src/validation/fileUploadValidation.ts
@@ -107,6 +107,7 @@ export const validatePolygonDuplicateColumns = async (file: File) => {
   return fileUploadValidator.validateDuplicateColumns(
     file,
     CSVHEADERS.POLYGON_HEADERS[0],
+    CSVHEADERS.POLYGON_HEADERS,
   )
 }
 
@@ -114,5 +115,7 @@ export const validateLayerDuplicateColumns = async (file: File) => {
   return fileUploadValidator.validateDuplicateColumns(
     file,
     CSVHEADERS.LAYER_HEADERS[0],
+    CSVHEADERS.LAYER_HEADERS,
+    CSVHEADERS.OPTIONAL_LAYER_HEADERS,
   )
 }

--- a/frontend/src/validation/fileUploadValidator.ts
+++ b/frontend/src/validation/fileUploadValidator.ts
@@ -75,22 +75,24 @@ export class FileUploadValidator extends ValidationBase {
     file: File,
     expectedHeaders: string[],
     optionalHeaders: Set<string> = new Set(),
+    otherTypeHeaders?: string[],
   ): Promise<{
     isValid: boolean
     isEmpty: boolean
+    isWrongFileType: boolean
     details: { missing: string[]; extra: string[]; mismatches: string[] }
   }> {
     const actualHeaders = await this.getFileHeaders(file)
 
     // Empty file - fail with isEmpty flag so callers can show a specific message.
     if (actualHeaders.length === 0) {
-      return { isValid: false, isEmpty: true, details: { missing: [], extra: [], mismatches: [] } }
+      return { isValid: false, isEmpty: true, isWrongFileType: false, details: { missing: [], extra: [], mismatches: [] } }
     }
 
     // If the first field doesn't match the expected first header, treat the file
     // as headerless and skip validation.
     if (actualHeaders[0] !== expectedHeaders[0]) {
-      return { isValid: true, isEmpty: false, details: { missing: [], extra: [], mismatches: [] } }
+      return { isValid: true, isEmpty: false, isWrongFileType: false, details: { missing: [], extra: [], mismatches: [] } }
     }
 
     const missing: string[] = []
@@ -120,34 +122,49 @@ export class FileUploadValidator extends ValidationBase {
 
     const isValid =
       missing.length === 0 && extra.length === 0 && mismatches.length === 0
-    return { isValid, isEmpty: false, details: { missing, extra, mismatches } }
+
+    // Detect if the file looks like the other file type by comparing the second header.
+    const isWrongFileType =
+      !isValid &&
+      otherTypeHeaders !== undefined &&
+      actualHeaders.length > 1 &&
+      actualHeaders[1] === otherTypeHeaders[1]
+
+    return { isValid, isEmpty: false, isWrongFileType, details: { missing, extra, mismatches } }
   }
 
   async validatePolygonHeader(file: File): Promise<{
     isValid: boolean
     isEmpty: boolean
+    isWrongFileType: boolean
     details: { missing: string[]; extra: string[]; mismatches: string[] }
     expected: string[]
   }> {
-    const { isValid, isEmpty, details } = await this.getHeaderValidationDetails(
-      file,
-      CSVHEADERS.POLYGON_HEADERS,
-    )
-    return { isValid, isEmpty, details, expected: CSVHEADERS.POLYGON_HEADERS }
+    const { isValid, isEmpty, isWrongFileType, details } =
+      await this.getHeaderValidationDetails(
+        file,
+        CSVHEADERS.POLYGON_HEADERS,
+        new Set(),
+        CSVHEADERS.LAYER_HEADERS,
+      )
+    return { isValid, isEmpty, isWrongFileType, details, expected: CSVHEADERS.POLYGON_HEADERS }
   }
 
   async validateLayerHeader(file: File): Promise<{
     isValid: boolean
     isEmpty: boolean
+    isWrongFileType: boolean
     details: { missing: string[]; extra: string[]; mismatches: string[] }
     expected: string[]
   }> {
-    const { isValid, isEmpty, details } = await this.getHeaderValidationDetails(
-      file,
-      CSVHEADERS.LAYER_HEADERS,
-      CSVHEADERS.OPTIONAL_LAYER_HEADERS,
-    )
-    return { isValid, isEmpty, details, expected: CSVHEADERS.LAYER_HEADERS }
+    const { isValid, isEmpty, isWrongFileType, details } =
+      await this.getHeaderValidationDetails(
+        file,
+        CSVHEADERS.LAYER_HEADERS,
+        CSVHEADERS.OPTIONAL_LAYER_HEADERS,
+        CSVHEADERS.POLYGON_HEADERS,
+      )
+    return { isValid, isEmpty, isWrongFileType, details, expected: CSVHEADERS.LAYER_HEADERS }
   }
 
   private async getFileHeaders(file: File): Promise<string[]> {

--- a/frontend/src/validation/fileUploadValidator.ts
+++ b/frontend/src/validation/fileUploadValidator.ts
@@ -109,9 +109,11 @@ export class FileUploadValidator extends ValidationBase {
       if (!expectedSet.has(h)) extra.push(h)
     })
 
-    // Only check mismatches if lengths are equal (to avoid unnecessary details)
-    if (actualHeaders.length === expectedHeaders.length) {
-      for (let i = 0; i < expectedHeaders.length; i++) {
+    // Check mismatches only when there are no missing or extra columns.
+    // Use min length to handle files without optional headers.
+    if (missing.length === 0 && extra.length === 0) {
+      const checkLength = Math.min(actualHeaders.length, expectedHeaders.length)
+      for (let i = 0; i < checkLength; i++) {
         if (actualHeaders[i] !== expectedHeaders[i]) {
           mismatches.push(
             `Position ${i + 1}: Expected '${expectedHeaders[i]}', found '${actualHeaders[i]}'`,

--- a/frontend/src/validation/fileUploadValidator.ts
+++ b/frontend/src/validation/fileUploadValidator.ts
@@ -169,6 +169,11 @@ export class FileUploadValidator extends ValidationBase {
     return { isValid, isEmpty, isWrongFileType, details, expected: CSVHEADERS.LAYER_HEADERS }
   }
 
+  async isFileEmpty(file: File): Promise<boolean> {
+    const firstLine = await this.readFirstLine(file)
+    return firstLine.length === 0
+  }
+
   private async getFileHeaders(file: File): Promise<string[]> {
     const headerLine = await this.readFirstLine(file)
     return this.parseCSVHeader(headerLine)

--- a/frontend/src/validation/fileUploadValidator.ts
+++ b/frontend/src/validation/fileUploadValidator.ts
@@ -232,15 +232,23 @@ export class FileUploadValidator extends ValidationBase {
   async validateDuplicateColumns(
     file: File,
     expectedFirstHeader: string,
+    expectedHeaders: string[],
+    optionalHeaders: Set<string> = new Set(),
   ): Promise<{
     isValid: boolean
+    isColumnCountInvalid: boolean
     duplicates: string[]
   }> {
     const headers = await this.getFileHeaders(file)
 
     if (headers[0] !== expectedFirstHeader) {
-      return { isValid: true, duplicates: [] }
+      // Headerless file: validate column count is within expected range.
+      const minColumns = expectedHeaders.length - optionalHeaders.size
+      const maxColumns = expectedHeaders.length
+      const validCount = headers.length >= minColumns && headers.length <= maxColumns
+      return { isValid: validCount, isColumnCountInvalid: !validCount, duplicates: [] }
     }
+
     const seen = new Set<string>()
     const duplicates: string[] = []
     const duplicateTracker = new Set<string>()
@@ -259,6 +267,7 @@ export class FileUploadValidator extends ValidationBase {
 
     return {
       isValid: duplicates.length === 0,
+      isColumnCountInvalid: false,
       duplicates,
     }
   }

--- a/frontend/src/validation/fileUploadValidator.ts
+++ b/frontend/src/validation/fileUploadValidator.ts
@@ -137,9 +137,32 @@ export class FileUploadValidator extends ValidationBase {
   }
 
   private async getFileHeaders(file: File): Promise<string[]> {
-    const fileContent = await file.text()
-    const headerLine = fileContent.split('\n')[0]
+    const headerLine = await this.readFirstLine(file)
     return this.parseCSVHeader(headerLine)
+  }
+
+  // Streams the file until the first newline, then cancels - avoids loading
+  // large files into memory entirely.
+  private async readFirstLine(file: File): Promise<string> {
+    const reader = file.stream().getReader()
+    const decoder = new TextDecoder()
+    let line = ''
+
+    try {
+      outer: while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+        const chunk = decoder.decode(value, { stream: true })
+        for (const char of chunk) {
+          if (char === '\n') break outer
+          line += char
+        }
+      }
+    } finally {
+      await reader.cancel()
+    }
+
+    return line
   }
 
   private parseCSVHeader(headerLine: string): string[] {

--- a/frontend/src/validation/fileUploadValidator.ts
+++ b/frontend/src/validation/fileUploadValidator.ts
@@ -81,6 +81,12 @@ export class FileUploadValidator extends ValidationBase {
   }> {
     const actualHeaders = await this.getFileHeaders(file)
 
+    // If the first field doesn't match the expected first header, treat the file
+    // as headerless and skip validation.
+    if (actualHeaders[0] !== expectedHeaders[0]) {
+      return { isValid: true, details: { missing: [], extra: [], mismatches: [] } }
+    }
+
     const missing: string[] = []
     const extra: string[] = []
     const mismatches: string[] = []
@@ -198,11 +204,18 @@ export class FileUploadValidator extends ValidationBase {
     return headers
   }
 
-  async validateDuplicateColumns(file: File): Promise<{
+  async validateDuplicateColumns(
+    file: File,
+    expectedFirstHeader: string,
+  ): Promise<{
     isValid: boolean
     duplicates: string[]
   }> {
     const headers = await this.getFileHeaders(file)
+
+    if (headers[0] !== expectedFirstHeader) {
+      return { isValid: true, duplicates: [] }
+    }
     const seen = new Set<string>()
     const duplicates: string[] = []
     const duplicateTracker = new Set<string>()

--- a/frontend/src/validation/fileUploadValidator.ts
+++ b/frontend/src/validation/fileUploadValidator.ts
@@ -77,14 +77,20 @@ export class FileUploadValidator extends ValidationBase {
     optionalHeaders: Set<string> = new Set(),
   ): Promise<{
     isValid: boolean
+    isEmpty: boolean
     details: { missing: string[]; extra: string[]; mismatches: string[] }
   }> {
     const actualHeaders = await this.getFileHeaders(file)
 
+    // Empty file - fail with isEmpty flag so callers can show a specific message.
+    if (actualHeaders.length === 0) {
+      return { isValid: false, isEmpty: true, details: { missing: [], extra: [], mismatches: [] } }
+    }
+
     // If the first field doesn't match the expected first header, treat the file
     // as headerless and skip validation.
     if (actualHeaders[0] !== expectedHeaders[0]) {
-      return { isValid: true, details: { missing: [], extra: [], mismatches: [] } }
+      return { isValid: true, isEmpty: false, details: { missing: [], extra: [], mismatches: [] } }
     }
 
     const missing: string[] = []
@@ -114,32 +120,34 @@ export class FileUploadValidator extends ValidationBase {
 
     const isValid =
       missing.length === 0 && extra.length === 0 && mismatches.length === 0
-    return { isValid, details: { missing, extra, mismatches } }
+    return { isValid, isEmpty: false, details: { missing, extra, mismatches } }
   }
 
   async validatePolygonHeader(file: File): Promise<{
     isValid: boolean
+    isEmpty: boolean
     details: { missing: string[]; extra: string[]; mismatches: string[] }
     expected: string[]
   }> {
-    const { isValid, details } = await this.getHeaderValidationDetails(
+    const { isValid, isEmpty, details } = await this.getHeaderValidationDetails(
       file,
       CSVHEADERS.POLYGON_HEADERS,
     )
-    return { isValid, details, expected: CSVHEADERS.POLYGON_HEADERS }
+    return { isValid, isEmpty, details, expected: CSVHEADERS.POLYGON_HEADERS }
   }
 
   async validateLayerHeader(file: File): Promise<{
     isValid: boolean
+    isEmpty: boolean
     details: { missing: string[]; extra: string[]; mismatches: string[] }
     expected: string[]
   }> {
-    const { isValid, details } = await this.getHeaderValidationDetails(
+    const { isValid, isEmpty, details } = await this.getHeaderValidationDetails(
       file,
       CSVHEADERS.LAYER_HEADERS,
       CSVHEADERS.OPTIONAL_LAYER_HEADERS,
     )
-    return { isValid, details, expected: CSVHEADERS.LAYER_HEADERS }
+    return { isValid, isEmpty, details, expected: CSVHEADERS.LAYER_HEADERS }
   }
 
   private async getFileHeaders(file: File): Promise<string[]> {
@@ -168,7 +176,7 @@ export class FileUploadValidator extends ValidationBase {
       await reader.cancel()
     }
 
-    return line
+    return line.replace(/\r$/, '')
   }
 
   private parseCSVHeader(headerLine: string): string[] {


### PR DESCRIPTION
- Replace full file read with streaming first-line-only approach to fix false header validation errors on large CSV files
- Skip header validation for headerless CSV files (detected by checking if first field matches expected header)
- Reject empty files with a clear "file is empty" error message instead of a misleading "missing columns" error
- Detect and report when the wrong file type is uploaded (e.g. Layer file uploaded to Polygon area, or vice versa)