### PR TITLE
VDYP-1138: Configure backend -> COMS communication to permit large files

### DIFF
--- a/backend/src/main/java/ca/bc/gov/nrs/vdyp/backend/services/FileMappingPersistenceService.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/vdyp/backend/services/FileMappingPersistenceService.java
@@ -1,0 +1,37 @@
+package ca.bc.gov.nrs.vdyp.backend.services;
+
+import java.util.UUID;
+
+import ca.bc.gov.nrs.vdyp.backend.data.assemblers.FileMappingResourceAssembler;
+import ca.bc.gov.nrs.vdyp.backend.data.entities.FileMappingEntity;
+import ca.bc.gov.nrs.vdyp.backend.data.entities.ProjectionFileSetEntity;
+import ca.bc.gov.nrs.vdyp.backend.data.models.FileMappingModel;
+import ca.bc.gov.nrs.vdyp.backend.data.repositories.FileMappingRepository;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+
+@ApplicationScoped
+public class FileMappingPersistenceService {
+	private final EntityManager em;
+	private final FileMappingRepository repository;
+	private final FileMappingResourceAssembler assembler;
+
+	public FileMappingPersistenceService(
+			EntityManager em, FileMappingRepository repository, FileMappingResourceAssembler assembler
+	) {
+		this.em = em;
+		this.repository = repository;
+		this.assembler = assembler;
+	}
+
+	@Transactional
+	public FileMappingModel persistFileMapping(UUID objectGUID, UUID fileSetGUID, String fileName) {
+		FileMappingEntity entity = new FileMappingEntity();
+		entity.setComsObjectGUID(objectGUID);
+		entity.setProjectionFileSet(em.find(ProjectionFileSetEntity.class, fileSetGUID));
+		entity.setFilename(fileName);
+		repository.persist(entity);
+		return assembler.toModel(entity);
+	}
+}

--- a/backend/src/main/java/ca/bc/gov/nrs/vdyp/backend/services/FileMappingService.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/vdyp/backend/services/FileMappingService.java
@@ -27,7 +27,6 @@ import ca.bc.gov.nrs.vdyp.backend.exceptions.ProjectionServiceException;
 import ca.bc.gov.nrs.vdyp.backend.model.COMSObject;
 import ca.bc.gov.nrs.vdyp.backend.model.COMSObjectVersion;
 import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.transaction.Transactional;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
@@ -39,15 +38,17 @@ public class FileMappingService {
 
 	private final HttpClient httpClient;
 	private final COMSClient comsClient;
+	private final FileMappingPersistenceService persistenceService;
 
 	public FileMappingService(
 			FileMappingRepository repository, FileMappingResourceAssembler assembler, @RestClient COMSClient comsClient,
-			HttpClient httpClient
+			HttpClient httpClient, FileMappingPersistenceService persistenceService
 	) {
 		this.repository = repository;
 		this.assembler = assembler;
 		this.comsClient = comsClient;
 		this.httpClient = httpClient;
+		this.persistenceService = persistenceService;
 	}
 
 	public FileMappingModel
@@ -70,10 +71,9 @@ public class FileMappingService {
 				UUID objectGUID = UUID.fromString(createObjectResponse.id());
 
 				// persist a record here for the file
-				FileMappingEntity entity = persistFileMapping(objectGUID, projectionFileSetEntity, file.fileName());
-
-				// return the data from COMS up the chain
-				return assembler.toModel(entity);
+				return persistenceService.persistFileMapping(
+						objectGUID, projectionFileSetEntity.getProjectionFileSetGUID(), file.fileName()
+				);
 			}
 		} catch (Exception e) {
 			throw new ProjectionServiceException("Error uploading file to COMS", e);
@@ -182,10 +182,9 @@ public class FileMappingService {
 						jakarta.ws.rs.core.MediaType.APPLICATION_OCTET_STREAM, // String constant
 						in
 				);
-				FileMappingEntity newEntity = persistFileMapping(
-						UUID.fromString(comsObj.id()), fileSetEntity, file.getFilename()
+				return persistenceService.persistFileMapping(
+						UUID.fromString(comsObj.id()), fileSetEntity.getProjectionFileSetGUID(), file.getFilename()
 				);
-				return assembler.toModel(newEntity);
 			}
 		} catch (ProjectionServiceException e) {
 			throw e;
@@ -209,21 +208,10 @@ public class FileMappingService {
 					placeholderStream
 			);
 			UUID objectGUID = UUID.fromString(createObjectResponse.id());
-			FileMappingEntity entity = persistFileMapping(objectGUID, projectionFileSetEntity, filename);
-			return assembler.toModel(entity);
+			return persistenceService
+					.persistFileMapping(objectGUID, projectionFileSetEntity.getProjectionFileSetGUID(), filename);
 		} catch (Exception e) {
 			throw new ProjectionServiceException("Error creating placeholder file in COMS", e);
 		}
-	}
-
-	@Transactional
-	protected FileMappingEntity
-			persistFileMapping(UUID objectGUID, ProjectionFileSetEntity fileSetEntity, String fileName) {
-		FileMappingEntity entity = new FileMappingEntity();
-		entity.setComsObjectGUID(objectGUID);
-		entity.setProjectionFileSet(fileSetEntity);
-		entity.setFilename(fileName);
-		repository.persist(entity);
-		return entity;
 	}
 }

--- a/backend/src/main/java/ca/bc/gov/nrs/vdyp/backend/services/ProjectionFileSetService.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/vdyp/backend/services/ProjectionFileSetService.java
@@ -120,7 +120,6 @@ public class ProjectionFileSetService {
 		}
 	}
 
-	@Transactional
 	public FileMappingModel addNewFileToFileSet(UUID fileSetGUID, VDYPUserModel user, FileUpload file)
 			throws ProjectionServiceException {
 		// Check that the file set exists

--- a/backend/src/main/java/ca/bc/gov/nrs/vdyp/backend/services/ProjectionService.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/vdyp/backend/services/ProjectionService.java
@@ -644,7 +644,6 @@ public class ProjectionService {
 		return fileSetService.getAllFiles(fileSetGUID, user, false);
 	}
 
-	@Transactional
 	public ProjectionModel addProjectionFile(UUID projectionGUID, UUID fileSetGUID, FileUpload file, VDYPUserModel user)
 			throws ProjectionServiceException {
 		var entity = getProjectionEntity(projectionGUID);

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -10,7 +10,7 @@ mp.openapi.scan.disable=false
 mp.openapi.extensions.smallrye.operationIdStrategy=METHOD
 quarkus.native.additional-build-args=--initialize-at-run-time=ca.bc.gov.nrs.vdyp.backend.projection.model.enumerations.Vdyp7LayerTypeCode\\,io.netty.resolver.dns.DnsServerAddressStreamProviders,-H:Log=registerResource:30,-H:+ReportExceptionStackTraces,-H:+ReportUnsupportedElementsAtRuntime,-H:+UnlockExperimentalVMOptions
 quarkus.http.limits.max-form-attribute-size=16K
-quarkus.http.limits.max-body-size=512M
+quarkus.http.limits.max-body-size=1024M
 quarkus.test.integration-test-profile=test
 # Quarkus Persistence Properties
 quarkus.datasource.db-kind=postgresql
@@ -58,6 +58,8 @@ quarkus.http.auth.permission.permitted.paths=/auth/*,/api/v8/projection/scsv,/ap
 quarkus.http.auth.permission.permitted.policy=permit
 #For INternal Rest Clients
 quarkus.rest-client.coms.url=${COMS_BASE_URL}
+quarkus.rest-client.coms.connect-timeout=${COMS_REST_CLIENT_CONNECT_TIMEOUT:30000}
+quarkus.rest-client.coms.read-timeout=${COMS_REST_CLIENT_READ_TIMEOUT:240000}
 quarkus.rest-client.vdyp-batch.url=${BATCH_BASE_URL:http://vdyp-batch:8081/vdyp-batch}
 # Log the REST Client request + response (headers + body up to the limit)
 quarkus.rest-client.logging.scope=request-response

--- a/backend/src/test/java/ca/bc/gov/nrs/vdyp/backend/services/FileMappingPersistenceServiceTest.java
+++ b/backend/src/test/java/ca/bc/gov/nrs/vdyp/backend/services/FileMappingPersistenceServiceTest.java
@@ -1,0 +1,73 @@
+package ca.bc.gov.nrs.vdyp.backend.services;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import ca.bc.gov.nrs.vdyp.backend.data.assemblers.FileMappingResourceAssembler;
+import ca.bc.gov.nrs.vdyp.backend.data.entities.FileMappingEntity;
+import ca.bc.gov.nrs.vdyp.backend.data.entities.ProjectionFileSetEntity;
+import ca.bc.gov.nrs.vdyp.backend.data.models.FileMappingModel;
+import ca.bc.gov.nrs.vdyp.backend.data.repositories.FileMappingRepository;
+import jakarta.persistence.EntityManager;
+
+@ExtendWith(MockitoExtension.class)
+class FileMappingPersistenceServiceTest {
+	@Mock
+	EntityManager em;
+	@Mock
+	FileMappingRepository repository;
+
+	FileMappingPersistenceService service;
+
+	@BeforeEach
+	void setUp() {
+		service = new FileMappingPersistenceService(em, repository, new FileMappingResourceAssembler());
+	}
+
+	@Test
+	void persistFileMapping_persistsEntityAndReturnsModel() {
+		UUID fileSetGUID = UUID.randomUUID();
+		UUID comsObjectGUID = UUID.randomUUID();
+		UUID fileMappingGUID = UUID.randomUUID();
+		String filename = "large-input.csv";
+
+		ProjectionFileSetEntity fileSetEntity = new ProjectionFileSetEntity();
+		fileSetEntity.setProjectionFileSetGUID(fileSetGUID);
+
+		when(em.find(ProjectionFileSetEntity.class, fileSetGUID)).thenReturn(fileSetEntity);
+		doAnswer(invocation -> {
+			FileMappingEntity entity = invocation.getArgument(0, FileMappingEntity.class);
+			entity.setFileMappingGUID(fileMappingGUID);
+			return null;
+		}).when(repository).persist(any(FileMappingEntity.class));
+
+		FileMappingModel result = service.persistFileMapping(comsObjectGUID, fileSetGUID, filename);
+
+		assertNotNull(result);
+		assertEquals(fileMappingGUID.toString(), result.getFileMappingGUID());
+		assertEquals(comsObjectGUID.toString(), result.getComsObjectGUID());
+		assertEquals(filename, result.getFilename());
+		assertEquals(fileSetGUID.toString(), result.getProjectionFileSet().getProjectionFileSetGUID());
+
+		ArgumentCaptor<FileMappingEntity> captor = ArgumentCaptor.forClass(FileMappingEntity.class);
+		verify(repository).persist(captor.capture());
+
+		FileMappingEntity persisted = captor.getValue();
+		assertEquals(comsObjectGUID, persisted.getComsObjectGUID());
+		assertEquals(filename, persisted.getFilename());
+		assertEquals(fileSetEntity, persisted.getProjectionFileSet());
+	}
+}

--- a/backend/src/test/java/ca/bc/gov/nrs/vdyp/backend/services/TestFileMappingService.java
+++ b/backend/src/test/java/ca/bc/gov/nrs/vdyp/backend/services/TestFileMappingService.java
@@ -4,7 +4,6 @@ import static ca.bc.gov.nrs.vdyp.backend.test.TestUtils.fileSetEntity;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -12,7 +11,6 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.startsWith;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -41,7 +39,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -70,13 +67,15 @@ class TestFileMappingService {
 	FileUpload fileUpload;
 	@Mock
 	HttpClient httpClient;
+	@Mock
+	FileMappingPersistenceService persistenceService;
 
 	FileMappingService service;
 
 	@BeforeEach
 	void setUp() {
 		assembler = new FileMappingResourceAssembler();
-		service = new FileMappingService(repository, assembler, comsClient, httpClient);
+		service = new FileMappingService(repository, assembler, comsClient, httpClient, persistenceService);
 	}
 
 	@Test
@@ -107,6 +106,10 @@ class TestFileMappingService {
 						any()
 				)
 		).thenReturn(createdObject);
+		FileMappingModel persistedModel = new FileMappingModel();
+		persistedModel.setComsObjectGUID(objectGuid.toString());
+		persistedModel.setFilename("input.txt");
+		when(persistenceService.persistFileMapping(objectGuid, fileSetGUID, "input.txt")).thenReturn(persistedModel);
 
 		FileMappingModel result = service.createNewFile("bucket-guid-123", fileSetEntity, fileUpload);
 
@@ -114,7 +117,7 @@ class TestFileMappingService {
 		assertEquals(objectGuid.toString(), result.getComsObjectGUID());
 		assertEquals("input.txt", result.getFilename());
 
-		verify(repository).persist(any(FileMappingEntity.class));
+		verify(persistenceService).persistFileMapping(objectGuid, fileSetGUID, "input.txt");
 	}
 
 	@Test
@@ -128,6 +131,7 @@ class TestFileMappingService {
 		);
 
 		verify(repository, never()).persist(any(FileMappingEntity.class));
+		verify(persistenceService, never()).persistFileMapping(any(), any(), any());
 	}
 
 	@Test
@@ -318,23 +322,22 @@ class TestFileMappingService {
 				)
 		).thenReturn(comsObj);
 
-		// Let persistFileMapping run real logic, but mock repository and assembler
-		var expectedEntity = new FileMappingEntity();
-		expectedEntity.setComsObjectGUID(UUID.fromString(comsObj.id()));
-		expectedEntity.setProjectionFileSet(fileSetEntity);
-		expectedEntity.setFilename("file.bin");
-
-		ArgumentCaptor<FileMappingEntity> entityCaptor = ArgumentCaptor.forClass(FileMappingEntity.class);
-		doNothing().when(repository).persist(entityCaptor.capture());
+		var persistedModel = new FileMappingModel();
+		persistedModel.setComsObjectGUID(comsObj.id());
+		persistedModel.setFilename("file.bin");
+		when(
+				persistenceService.persistFileMapping(
+						UUID.fromString(comsObj.id()), fileSetEntity.getProjectionFileSetGUID(), "file.bin"
+				)
+		).thenReturn(persistedModel);
 
 		// Act
 		service.duplicateFile(file, fileSetEntity, bucketGuid);
 
 		// Assert
-		var persisted = entityCaptor.getValue();
-		assertEquals(UUID.fromString(comsObj.id()), persisted.getComsObjectGUID());
-		assertSame(fileSetEntity, persisted.getProjectionFileSet());
-		assertEquals("file.bin", persisted.getFilename());
+		verify(persistenceService).persistFileMapping(
+				UUID.fromString(comsObj.id()), fileSetEntity.getProjectionFileSetGUID(), "file.bin"
+		);
 
 		verify(comsClient).createObject(
 				eq(bucketGuid), anyString(), eq(3L), eq(jakarta.ws.rs.core.MediaType.APPLICATION_OCTET_STREAM),
@@ -375,13 +378,17 @@ class TestFileMappingService {
 						eq("bucket-id"), anyString(), anyLong(), eq(MediaType.APPLICATION_OCTET_STREAM), any()
 				)
 		).thenReturn(createdObject);
+		FileMappingModel persistedModel = new FileMappingModel();
+		persistedModel.setComsObjectGUID(objectGuid.toString());
+		persistedModel.setFilename("result.zip");
+		when(persistenceService.persistFileMapping(objectGuid, fileSetGUID, "result.zip")).thenReturn(persistedModel);
 
 		FileMappingModel result = service.createPlaceholderFile("bucket-id", fileSetEntity, "result.zip");
 
 		assertNotNull(result);
 		assertEquals(objectGuid.toString(), result.getComsObjectGUID());
 		assertEquals("result.zip", result.getFilename());
-		verify(repository).persist(any(FileMappingEntity.class));
+		verify(persistenceService).persistFileMapping(objectGuid, fileSetGUID, "result.zip");
 	}
 
 	@Test


### PR DESCRIPTION
- Expand Quarkus max body size to allow 1GB files (850MB is a full province HCSV file)
- Extend Quarkus rest client in backend timeout to 4 minutes to permit transfer from backend through coms
- Move COMS communication out of the DB transaction to prevent db transaction killing coms transfer

All changes were made to test locally if 850MB backend proxy to COMS is feasible. It appears to be with configuration changes.