### PR TITLE
Feature/VDYP-1004: Disable Cancel button when there are no unsaved changes

### DIFF
--- a/frontend/src/components/projection/input/ActionPanel.cy.ts
+++ b/frontend/src/components/projection/input/ActionPanel.cy.ts
@@ -26,19 +26,9 @@ const mountPanel = (props: MountProps) =>
 
 describe('<ActionPanel />', () => {
   describe('Clear button', () => {
-    it('renders Clear button by default', () => {
-      mountPanel({ isConfirmEnabled: true, isConfirmed: false })
-      cy.contains('button.bcds-button', 'Clear').should('exist')
-    })
-
     it('is hidden when hideClearButton is true', () => {
       mountPanel({ isConfirmEnabled: true, isConfirmed: false, hideClearButton: true })
       cy.contains('button.bcds-button', 'Clear').should('not.exist')
-    })
-
-    it('is disabled when isConfirmEnabled is false', () => {
-      mountPanel({ isConfirmEnabled: false, isConfirmed: false })
-      cy.contains('button.bcds-button', 'Clear').should('be.disabled')
     })
 
     it('emits "clear" when clicked', () => {
@@ -55,16 +45,6 @@ describe('<ActionPanel />', () => {
       cy.contains('button.bcds-button', 'Cancel').should('not.exist')
     })
 
-    it('renders when showCancelButton is true', () => {
-      mountPanel({ isConfirmEnabled: true, isConfirmed: false, showCancelButton: true })
-      cy.contains('button.bcds-button', 'Cancel').should('exist')
-    })
-
-    it('is disabled when isConfirmEnabled is false', () => {
-      mountPanel({ isConfirmEnabled: false, isConfirmed: false, showCancelButton: true })
-      cy.contains('button.bcds-button', 'Cancel').should('be.disabled')
-    })
-
     it('emits "cancel" when clicked', () => {
       const onCancel = cy.spy().as('cancelSpy')
       mountPanel({ isConfirmEnabled: true, isConfirmed: false, showCancelButton: true, onCancel })
@@ -73,52 +53,32 @@ describe('<ActionPanel />', () => {
     })
   })
 
-  describe('Next button', () => {
-    it('is visible when isConfirmed is false', () => {
+  describe('Next / Edit button toggle', () => {
+    it('shows Next and hides Edit when isConfirmed is false', () => {
       mountPanel({ isConfirmEnabled: true, isConfirmed: false })
       cy.contains('button.bcds-button', 'Next').should('be.visible')
+      cy.contains('button.bcds-button', 'Edit').should('not.be.visible')
     })
 
-    it('is hidden when isConfirmed is true and hideEditButton is false', () => {
+    it('hides Next and shows Edit when isConfirmed is true', () => {
       mountPanel({ isConfirmEnabled: true, isConfirmed: true })
       cy.contains('button.bcds-button', 'Next').should('not.be.visible')
+      cy.contains('button.bcds-button', 'Edit').should('be.visible')
     })
 
-    it('is visible when isConfirmed is true but hideEditButton is true', () => {
-      mountPanel({ isConfirmEnabled: true, isConfirmed: true, hideEditButton: true })
-      cy.contains('button.bcds-button', 'Next').should('be.visible')
-    })
-
-    it('is disabled when isConfirmEnabled is false', () => {
+    it('disables Next when isConfirmEnabled is false', () => {
       mountPanel({ isConfirmEnabled: false, isConfirmed: false })
       cy.contains('button.bcds-button', 'Next').should('be.disabled')
     })
 
-    it('emits "confirm" when clicked', () => {
+    it('emits "confirm" when Next is clicked', () => {
       const onConfirm = cy.spy().as('confirmSpy')
       mountPanel({ isConfirmEnabled: true, isConfirmed: false, onConfirm })
       cy.contains('button.bcds-button', 'Next').click()
       cy.get('@confirmSpy').should('have.been.calledOnce')
     })
-  })
 
-  describe('Edit button', () => {
-    it('is hidden when isConfirmed is false', () => {
-      mountPanel({ isConfirmEnabled: true, isConfirmed: false })
-      cy.contains('button.bcds-button', 'Edit').should('not.be.visible')
-    })
-
-    it('is visible when isConfirmed is true', () => {
-      mountPanel({ isConfirmEnabled: true, isConfirmed: true })
-      cy.contains('button.bcds-button', 'Edit').should('be.visible')
-    })
-
-    it('is hidden when isConfirmed is true but hideEditButton is true', () => {
-      mountPanel({ isConfirmEnabled: true, isConfirmed: true, hideEditButton: true })
-      cy.contains('button.bcds-button', 'Edit').should('not.be.visible')
-    })
-
-    it('emits "edit" when clicked', () => {
+    it('emits "edit" when Edit is clicked', () => {
       const onEdit = cy.spy().as('editSpy')
       mountPanel({ isConfirmEnabled: true, isConfirmed: true, onEdit })
       cy.contains('button.bcds-button', 'Edit').click()

--- a/frontend/src/components/projection/input/ActionPanel.vue
+++ b/frontend/src/components/projection/input/ActionPanel.vue
@@ -13,7 +13,7 @@
       label="Cancel"
       variant="tertiary"
       class="ml-2"
-      :isDisabled="!isConfirmEnabled"
+      :isDisabled="props.isCancelEnabled !== undefined ? !props.isCancelEnabled : !isConfirmEnabled"
       @click="onCancel"
     />
     <AppButton
@@ -38,7 +38,7 @@
 import { AppButton } from '@/components'
 import { PANEL_ACTION } from '@/constants/constants'
 
-defineProps({
+const props = defineProps({
   isConfirmEnabled: {
     type: Boolean,
     required: true,
@@ -58,6 +58,10 @@ defineProps({
   showCancelButton: {
     type: Boolean,
     default: false,
+  },
+  isCancelEnabled: {
+    type: Boolean,
+    default: undefined,
   },
 })
 

--- a/frontend/src/components/projection/input/ParameterSelectionProgressBar.stories.ts
+++ b/frontend/src/components/projection/input/ParameterSelectionProgressBar.stories.ts
@@ -12,7 +12,7 @@ const meta: Meta<typeof ParameterSelectionProgressBar> = {
     },
     percentage: {
       control: { type: 'range', min: 0, max: 100, step: 1 },
-      description: 'Current completion percentage (0–100).',
+      description: 'Current completion percentage (0~100).',
     },
     completedCount: {
       control: { type: 'number', min: 0 },

--- a/frontend/src/components/projection/input/attachments/AttachmentsPanel.cy.ts
+++ b/frontend/src/components/projection/input/attachments/AttachmentsPanel.cy.ts
@@ -33,284 +33,102 @@ const mountPanel = (
   return { fileUploadStore, appStore, alertDialogStore }
 }
 
+const mountViewMode = (extraSetup?: (fu: ReturnType<typeof useFileUploadStore>) => void) =>
+  mountPanel((fu, app) => {
+    app.setViewMode(PROJECTION_VIEW_MODE.VIEW)
+    fu.panelOpenStates.attachments = CONSTANTS.PANEL.OPEN
+    if (extraSetup) extraSetup(fu)
+  })
+
 describe('<AttachmentsPanel />', () => {
-  describe('Panel structure', () => {
-    it('renders the "File Upload" panel title', () => {
-      mountPanel()
-      cy.contains('.text-h6', 'File Upload').should('exist')
+  it('renders the "File Upload" panel title', () => {
+    mountPanel()
+    cy.contains('.text-h6', 'File Upload').should('exist')
+  })
+
+  it('panel content is not in the DOM when the panel is initially closed', () => {
+    mountPanel()
+    cy.get('.bcds-file-upload').should('not.exist')
+  })
+
+  it('renders both polygon and layer file upload components when open', () => {
+    mountPanel((fu) => {
+      fu.panelOpenStates.attachments = CONSTANTS.PANEL.OPEN
+    })
+    cy.contains('.bcds-file-input-label', 'Select Polygon File').should('be.visible')
+    cy.contains('.bcds-file-input-label', 'Select Layer File').should('be.visible')
+    cy.get('.bcds-file-upload').should('have.length', 2)
+  })
+
+  it('shows filename and delete button when file info is set', () => {
+    mountPanel((fu) => {
+      fu.panelOpenStates.attachments = CONSTANTS.PANEL.OPEN
+      fu.setPolygonFileInfo({ filename: 'polygon.csv', fileMappingGUID: 'poly-guid', fileSetGUID: 'set-1' })
+      fu.setLayerFileInfo({ filename: 'layer.csv', fileMappingGUID: 'layer-guid', fileSetGUID: 'set-2' })
+    })
+    cy.get('.file-upload-col-left .uploaded-file-name').should('contain.text', 'polygon.csv')
+    cy.get('.file-upload-col-right .uploaded-file-name').should('contain.text', 'layer.csv')
+    cy.get('.uploaded-file-delete-btn').should('have.length', 2)
+  })
+
+  it('view mode: shows labels without "Select" and applies disabled styling', () => {
+    mountViewMode()
+    cy.contains('.bcds-file-input-label', 'Polygon File').should('be.visible')
+    cy.contains('.bcds-file-input-label', 'Select Polygon File').should('not.exist')
+    cy.contains('.bcds-file-input-label', 'Layer File').should('be.visible')
+    cy.get('.bcds-file-input-label--disabled').should('have.length', 2)
+  })
+
+  it('view mode: shows file-display-containers instead of file upload controls', () => {
+    mountViewMode()
+    cy.get('.file-display-container').should('have.length', 2)
+    cy.get('.bcds-file-upload').should('not.exist')
+  })
+
+  it('view mode: shows "No file uploaded" for both slots when no files are set', () => {
+    mountViewMode()
+    cy.get('.file-upload-col-left .file-display-empty').should('contain.text', 'No file uploaded')
+    cy.get('.file-upload-col-right .file-display-empty').should('contain.text', 'No file uploaded')
+  })
+
+  it('view mode: shows filename with icon and no delete buttons when file info is set', () => {
+    mountViewMode((fu) => {
+      fu.setPolygonFileInfo({ filename: 'polygon.csv', fileMappingGUID: 'poly-guid', fileSetGUID: 'set-1' })
+      fu.setLayerFileInfo({ filename: 'layer.csv', fileMappingGUID: 'layer-guid', fileSetGUID: 'set-2' })
+    })
+    cy.get('.file-upload-col-left .file-display-name').should('contain.text', 'polygon.csv')
+    cy.get('.file-upload-col-left .file-display-icon').should('exist')
+    cy.get('.file-upload-col-right .file-display-name').should('contain.text', 'layer.csv')
+    cy.get('.uploaded-file-delete-btn').should('not.exist')
+  })
+
+  it('opens the confirmation dialog when a delete button is clicked', () => {
+    const { alertDialogStore } = mountPanel((fu) => {
+      fu.panelOpenStates.attachments = CONSTANTS.PANEL.OPEN
+      fu.setPolygonFileInfo({ filename: 'polygon.csv', fileMappingGUID: 'poly-guid', fileSetGUID: 'set-1' })
     })
 
-    it('panel content is not in the DOM when the panel is initially closed', () => {
-      // attachments panel defaults to CLOSE in the store
-      mountPanel()
-      cy.get('.bcds-file-upload').should('not.exist')
+    cy.get('.file-upload-col-left .uploaded-file-delete-btn').click()
+
+    cy.then(() => {
+      expect(alertDialogStore.dialog).to.be.true
+      alertDialogStore.cancel()
     })
   })
 
-  describe('Expansion panel chevron icon', () => {
-    it('shows mdi-chevron-down when the panel is closed', () => {
-      mountPanel((fu) => {
-        fu.panelOpenStates.attachments = CONSTANTS.PANEL.CLOSE
-      })
-      // Vuetify renders <v-icon> as <i> with the icon name as a CSS class
-      cy.get('.expansion-panel-icon').should('have.class', 'mdi-chevron-down')
+  it('preserves file info when the delete dialog is cancelled', () => {
+    const { fileUploadStore, alertDialogStore } = mountPanel((fu) => {
+      fu.panelOpenStates.attachments = CONSTANTS.PANEL.OPEN
+      fu.setPolygonFileInfo({ filename: 'polygon.csv', fileMappingGUID: 'poly-guid', fileSetGUID: 'set-1' })
     })
 
-    it('shows mdi-chevron-up when the panel is open', () => {
-      mountPanel((fu) => {
-        fu.panelOpenStates.attachments = CONSTANTS.PANEL.OPEN
-      })
-      cy.get('.expansion-panel-icon').should('have.class', 'mdi-chevron-up')
-    })
-  })
+    cy.get('.file-upload-col-left .uploaded-file-delete-btn').click()
 
-  describe('Edit mode – file upload (panel open)', () => {
-    it('shows "Select Polygon File" label', () => {
-      mountPanel((fu) => {
-        fu.panelOpenStates.attachments = CONSTANTS.PANEL.OPEN
-      })
-      cy.contains('.bcds-file-input-label', 'Select Polygon File').should('be.visible')
-    })
+    cy.then(() => alertDialogStore.cancel())
 
-    it('shows "Select Layer File" label', () => {
-      mountPanel((fu) => {
-        fu.panelOpenStates.attachments = CONSTANTS.PANEL.OPEN
-      })
-      cy.contains('.bcds-file-input-label', 'Select Layer File').should('be.visible')
-    })
-
-    it('renders both file upload components (polygon and layer)', () => {
-      mountPanel((fu) => {
-        fu.panelOpenStates.attachments = CONSTANTS.PANEL.OPEN
-      })
-      cy.get('.bcds-file-upload').should('have.length', 2)
-    })
-
-    it('does not show uploaded-file-info when no files have been uploaded', () => {
-      mountPanel((fu) => {
-        fu.panelOpenStates.attachments = CONSTANTS.PANEL.OPEN
-      })
-      cy.get('.uploaded-file-info').should('not.exist')
-    })
-  })
-
-  describe('Edit mode - uploaded file info', () => {
-    it('shows polygon filename and delete button when polygonFileInfo is set', () => {
-      mountPanel((fu) => {
-        fu.panelOpenStates.attachments = CONSTANTS.PANEL.OPEN
-        fu.setPolygonFileInfo({
-          filename: 'polygon_data.csv',
-          fileMappingGUID: 'poly-guid',
-          fileSetGUID: 'set-1',
-        })
-      })
-
-      cy.get('.file-upload-col-left .uploaded-file-name').should('contain.text', 'polygon_data.csv')
-      cy.get('.file-upload-col-left .uploaded-file-delete-btn').should('exist')
-    })
-
-    it('shows layer filename and delete button when layerFileInfo is set', () => {
-      mountPanel((fu) => {
-        fu.panelOpenStates.attachments = CONSTANTS.PANEL.OPEN
-        fu.setLayerFileInfo({
-          filename: 'layer_data.csv',
-          fileMappingGUID: 'layer-guid',
-          fileSetGUID: 'set-2',
-        })
-      })
-
-      cy.get('.file-upload-col-right .uploaded-file-name').should('contain.text', 'layer_data.csv')
-      cy.get('.file-upload-col-right .uploaded-file-delete-btn').should('exist')
-    })
-
-    it('delete button is enabled in edit mode', () => {
-      mountPanel((fu) => {
-        fu.panelOpenStates.attachments = CONSTANTS.PANEL.OPEN
-        fu.setPolygonFileInfo({
-          filename: 'polygon.csv',
-          fileMappingGUID: 'poly-guid',
-          fileSetGUID: 'set-1',
-        })
-      })
-
-      cy.get('.uploaded-file-delete-btn').first().should('not.be.disabled')
-    })
-
-    it('updates polygon filename reactively when polygonFileInfo changes after mount', () => {
-      const { fileUploadStore } = mountPanel((fu) => {
-        fu.panelOpenStates.attachments = CONSTANTS.PANEL.OPEN
-      })
-
-      cy.then(() => {
-        fileUploadStore.setPolygonFileInfo({
-          filename: 'updated_polygon.csv',
-          fileMappingGUID: 'poly-guid',
-          fileSetGUID: 'set-1',
-        })
-      })
-
-      cy.get('.uploaded-file-name').first().should('contain.text', 'updated_polygon.csv')
-    })
-  })
-
-  describe('View mode (isReadOnly = true)', () => {
-    const mountViewMode = (
-      extraSetup?: (fu: ReturnType<typeof useFileUploadStore>) => void,
-    ) =>
-      mountPanel((fu, app) => {
-        app.setViewMode(PROJECTION_VIEW_MODE.VIEW)
-        fu.panelOpenStates.attachments = CONSTANTS.PANEL.OPEN
-        if (extraSetup) extraSetup(fu)
-      })
-
-    it('shows "Polygon File" label (without "Select") in view mode', () => {
-      mountViewMode()
-      cy.contains('.bcds-file-input-label', 'Polygon File').should('be.visible')
-      cy.contains('.bcds-file-input-label', 'Select Polygon File').should('not.exist')
-    })
-
-    it('shows "Layer File" label (without "Select") in view mode', () => {
-      mountViewMode()
-      cy.contains('.bcds-file-input-label', 'Layer File').should('be.visible')
-      cy.contains('.bcds-file-input-label', 'Select Layer File').should('not.exist')
-    })
-
-    it('applies disabled CSS class to both labels in view mode', () => {
-      mountViewMode()
-      cy.get('.bcds-file-input-label--disabled').should('have.length', 2)
-    })
-
-    it('shows file-display-container elements instead of v-file-upload in view mode', () => {
-      mountViewMode()
-      cy.get('.file-display-container').should('have.length', 2)
-      cy.get('.bcds-file-upload').should('not.exist')
-    })
-
-    it('shows "No file uploaded" for polygon when no file info is available', () => {
-      mountViewMode()
-      cy.get('.file-upload-col-left .file-display-empty').should('contain.text', 'No file uploaded')
-    })
-
-    it('shows "No file uploaded" for layer when no file info is available', () => {
-      mountViewMode()
-      cy.get('.file-upload-col-right .file-display-empty').should('contain.text', 'No file uploaded')
-    })
-
-    it('shows polygon filename with paperclip icon when polygonFileInfo is set', () => {
-      mountViewMode((fu) => {
-        fu.setPolygonFileInfo({
-          filename: 'polygon.csv',
-          fileMappingGUID: 'poly-guid',
-          fileSetGUID: 'set-1',
-        })
-      })
-
-      cy.get('.file-upload-col-left .file-display-name').should('contain.text', 'polygon.csv')
-      cy.get('.file-upload-col-left .file-display-icon').should('exist')
-    })
-
-    it('shows layer filename with paperclip icon when layerFileInfo is set', () => {
-      mountViewMode((fu) => {
-        fu.setLayerFileInfo({
-          filename: 'layer.csv',
-          fileMappingGUID: 'layer-guid',
-          fileSetGUID: 'set-2',
-        })
-      })
-
-      cy.get('.file-upload-col-right .file-display-name').should('contain.text', 'layer.csv')
-      cy.get('.file-upload-col-right .file-display-icon').should('exist')
-    })
-
-    it('does not show delete buttons in view mode', () => {
-      mountViewMode((fu) => {
-        fu.setPolygonFileInfo({
-          filename: 'polygon.csv',
-          fileMappingGUID: 'poly-guid',
-          fileSetGUID: 'set-1',
-        })
-      })
-
-      cy.get('.uploaded-file-delete-btn').should('not.exist')
-    })
-  })
-
-  describe('Delete button interaction', () => {
-    it('opens the confirmation dialog when the polygon delete button is clicked', () => {
-      const { alertDialogStore } = mountPanel((fu) => {
-        fu.panelOpenStates.attachments = CONSTANTS.PANEL.OPEN
-        fu.setPolygonFileInfo({
-          filename: 'polygon.csv',
-          fileMappingGUID: 'poly-guid',
-          fileSetGUID: 'set-1',
-        })
-      })
-
-      cy.get('.file-upload-col-left .uploaded-file-delete-btn').click()
-
-      cy.then(() => {
-        expect(alertDialogStore.dialog).to.be.true
-        // Cancel to avoid a dangling promise
-        alertDialogStore.cancel()
-      })
-    })
-
-    it('preserves polygon file info when the delete dialog is cancelled', () => {
-      const { fileUploadStore, alertDialogStore } = mountPanel((fu) => {
-        fu.panelOpenStates.attachments = CONSTANTS.PANEL.OPEN
-        fu.setPolygonFileInfo({
-          filename: 'polygon.csv',
-          fileMappingGUID: 'poly-guid',
-          fileSetGUID: 'set-1',
-        })
-      })
-
-      cy.get('.file-upload-col-left .uploaded-file-delete-btn').click()
-
-      cy.then(() => alertDialogStore.cancel())
-
-      cy.then(() => {
-        expect(fileUploadStore.polygonFileInfo).to.not.be.null
-        expect(fileUploadStore.polygonFileInfo?.filename).to.equal('polygon.csv')
-      })
-    })
-
-    it('opens the confirmation dialog when the layer delete button is clicked', () => {
-      const { alertDialogStore } = mountPanel((fu) => {
-        fu.panelOpenStates.attachments = CONSTANTS.PANEL.OPEN
-        fu.setLayerFileInfo({
-          filename: 'layer.csv',
-          fileMappingGUID: 'layer-guid',
-          fileSetGUID: 'set-2',
-        })
-      })
-
-      cy.get('.file-upload-col-right .uploaded-file-delete-btn').click()
-
-      cy.then(() => {
-        expect(alertDialogStore.dialog).to.be.true
-        alertDialogStore.cancel()
-      })
-    })
-
-    it('preserves layer file info when the delete dialog is cancelled', () => {
-      const { fileUploadStore, alertDialogStore } = mountPanel((fu) => {
-        fu.panelOpenStates.attachments = CONSTANTS.PANEL.OPEN
-        fu.setLayerFileInfo({
-          filename: 'layer.csv',
-          fileMappingGUID: 'layer-guid',
-          fileSetGUID: 'set-2',
-        })
-      })
-
-      cy.get('.file-upload-col-right .uploaded-file-delete-btn').click()
-
-      cy.then(() => alertDialogStore.cancel())
-
-      cy.then(() => {
-        expect(fileUploadStore.layerFileInfo).to.not.be.null
-        expect(fileUploadStore.layerFileInfo?.filename).to.equal('layer.csv')
-      })
+    cy.then(() => {
+      expect(fileUploadStore.polygonFileInfo).to.not.be.null
+      expect(fileUploadStore.polygonFileInfo?.filename).to.equal('polygon.csv')
     })
   })
 })

--- a/frontend/src/components/projection/input/minimum-dbh/MinimumDBHPanel.cy.ts
+++ b/frontend/src/components/projection/input/minimum-dbh/MinimumDBHPanel.cy.ts
@@ -6,7 +6,7 @@ import MinimumDBHPanel from './MinimumDBHPanel.vue'
 import { useFileUploadStore } from '@/stores/projection/fileUploadStore'
 import { useAppStore } from '@/stores/projection/appStore'
 import { CONSTANTS, BIZCONSTANTS } from '@/constants'
-import { PROJECTION_VIEW_MODE, PROJECTION_STATUS } from '@/constants/constants'
+import { PROJECTION_VIEW_MODE } from '@/constants/constants'
 
 const vuetify = createVuetify()
 
@@ -45,15 +45,6 @@ describe('<MinimumDBHPanel />', () => {
     })
   })
 
-  describe('Expansion panel chevron icon', () => {
-    it('shows mdi-chevron-down when the panel is closed', () => {
-      mountPanel((fu) => {
-        fu.panelOpenStates.minimumDBH = CONSTANTS.PANEL.CLOSE
-      })
-      cy.get('.expansion-panel-icon').should('have.class', 'mdi-chevron-down')
-    })
-  })
-
   describe('Header Edit button', () => {
     it('is not rendered in view mode', () => {
       mountPanel((fu, app) => {
@@ -75,16 +66,6 @@ describe('<MinimumDBHPanel />', () => {
       })
       cy.get('.edit-button-col button').should('not.be.disabled')
     })
-
-    it('is disabled when projection status is RUNNING', () => {
-      mountPanel((fu, app) => {
-        fu.confirmPanel('reportConfig')
-        fu.confirmPanel('minimumDBH')
-        fu.panelOpenStates.minimumDBH = CONSTANTS.PANEL.OPEN
-        app.setCurrentProjectionStatus(PROJECTION_STATUS.RUNNING)
-      })
-      cy.get('.edit-button-col button').should('be.disabled')
-    })
   })
 
   describe('Species groups', () => {
@@ -94,14 +75,6 @@ describe('<MinimumDBHPanel />', () => {
         fu.panelOpenStates.minimumDBH = CONSTANTS.PANEL.OPEN
       })
       cy.get('.min-dbh-row').should('have.length', BIZCONSTANTS.SPECIES_GROUPS.length)
-    })
-
-    it('renders a slider for each species group', () => {
-      mountPanel((fu) => {
-        fu.initializeSpeciesGroups()
-        fu.panelOpenStates.minimumDBH = CONSTANTS.PANEL.OPEN
-      })
-      cy.get('.v-slider').should('have.length', BIZCONSTANTS.SPECIES_GROUPS.length)
     })
 
     it('sliders are disabled when panel is not editable', () => {
@@ -133,41 +106,14 @@ describe('<MinimumDBHPanel />', () => {
   })
 
   describe('ActionPanel', () => {
-    it('is not rendered in view mode', () => {
-      mountPanel((fu, app) => {
-        fu.initializeSpeciesGroups()
-        app.setViewMode(PROJECTION_VIEW_MODE.VIEW)
-        fu.panelOpenStates.minimumDBH = CONSTANTS.PANEL.OPEN
-      })
-      cy.contains('button', 'Next').should('not.exist')
-      cy.contains('button', 'Cancel').should('not.exist')
-    })
-
-    it('renders "Next" and "Cancel" buttons in edit mode', () => {
-      mountPanel((fu) => {
-        fu.initializeSpeciesGroups()
-        fu.panelOpenStates.minimumDBH = CONSTANTS.PANEL.OPEN
-      })
-      cy.contains('button', 'Next').should('exist')
-      cy.contains('button', 'Cancel').should('exist')
-    })
-
-    it('"Next" and "Cancel" are disabled when the panel is not editable', () => {
-      mountPanel((fu) => {
-        fu.initializeSpeciesGroups()
-        fu.panelOpenStates.minimumDBH = CONSTANTS.PANEL.OPEN
-      })
-      cy.contains('button', 'Next').should('be.disabled')
-      cy.contains('button', 'Cancel').should('be.disabled')
-    })
-
-    it('"Next" and "Cancel" are enabled when the panel is editable', () => {
+    it('"Next" is enabled and "Cancel" is disabled (no changes yet) when the panel is editable', () => {
       mountPanel((fu) => {
         fu.initializeSpeciesGroups()
         fu.confirmPanel('reportConfig')
+        fu.panelOpenStates.minimumDBH = CONSTANTS.PANEL.OPEN
       })
       cy.contains('button', 'Next').should('not.be.disabled')
-      cy.contains('button', 'Cancel').should('not.be.disabled')
+      cy.contains('button', 'Cancel').should('be.disabled')
     })
   })
 })

--- a/frontend/src/components/projection/input/minimum-dbh/MinimumDBHPanel.vue
+++ b/frontend/src/components/projection/input/minimum-dbh/MinimumDBHPanel.vue
@@ -70,6 +70,7 @@
             :hideClearButton="true"
             :hideEditButton="true"
             :showCancelButton="true"
+            :isCancelEnabled="isDirty"
             @confirm="onConfirm"
             @cancel="onCancel"
           />
@@ -80,7 +81,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch } from 'vue'
+import { ref, computed, watch, nextTick } from 'vue'
 import { useDisplay } from 'vuetify'
 import { useAppStore } from '@/stores/projection/appStore'
 import { useFileUploadStore } from '@/stores/projection/fileUploadStore'
@@ -146,6 +147,12 @@ const onHeaderEdit = () => {
   }
 }
 
+const isDirty = ref(false)
+
+watch(() => fileUploadStore.panelState[panelName].editable, (editable, wasEditable) => {
+  if (editable && !wasEditable) isDirty.value = false
+})
+
 // Species groups and slider logic
 const utilizationClassOptions = OPTIONS.utilizationClassOptions
 const fileUploadSpeciesGroups = computed(() => fileUploadStore.fileUploadSpeciesGroup)
@@ -188,6 +195,7 @@ const updateFileUploadMinDBH = (index: number, value: number) => {
     const enumValue = utilizationClassOptions[value]?.value
     if (enumValue !== undefined) {
       fileUploadSpeciesGroups.value[index].minimumDBHLimit = enumValue
+      isDirty.value = true
     }
   }
 }
@@ -204,6 +212,7 @@ const onConfirm = async () => {
     appStore.isSavingProjection = false
   }
 
+  isDirty.value = false
   if (!isConfirmed.value) {
     fileUploadStore.confirmPanel(panelName)
   }
@@ -213,6 +222,8 @@ const onCancel = async () => {
   appStore.isSavingProjection = true
   try {
     await revertPanelToSaved(panelName)
+    await nextTick()
+    isDirty.value = false
   } catch (error) {
     console.error(PROJECTION_ERR.REVERT_ERROR_LOG, error)
     notificationStore.showErrorMessage(PROJECTION_ERR.LOAD_FAILED, PROJECTION_ERR.LOAD_FAILED_TITLE)

--- a/frontend/src/components/projection/input/report-info/ReportConfigPanel.cy.ts
+++ b/frontend/src/components/projection/input/report-info/ReportConfigPanel.cy.ts
@@ -6,7 +6,7 @@ import ReportConfigPanel from './ReportConfigPanel.vue'
 import { useFileUploadStore } from '@/stores/projection/fileUploadStore'
 import { useAppStore } from '@/stores/projection/appStore'
 import { CONSTANTS } from '@/constants'
-import { PROJECTION_VIEW_MODE, PROJECTION_STATUS } from '@/constants/constants'
+import { PROJECTION_VIEW_MODE } from '@/constants/constants'
 
 const vuetify = createVuetify()
 
@@ -33,16 +33,6 @@ const mountPanel = (
 
 describe('<ReportConfigPanel />', () => {
   describe('Panel structure', () => {
-    it('renders the "Report Details" panel title', () => {
-      mountPanel()
-      cy.contains('.text-h6', 'Report Details').should('exist')
-    })
-
-    it('panel content is in the DOM when the panel is open (default)', () => {
-      mountPanel()
-      cy.get('#reportTitle').should('exist')
-    })
-
     it('panel content is not in the DOM when the panel is closed', () => {
       mountPanel((fu) => {
         fu.panelOpenStates.reportConfig = CONSTANTS.PANEL.CLOSE
@@ -52,12 +42,6 @@ describe('<ReportConfigPanel />', () => {
   })
 
   describe('Form fields', () => {
-    it('renders "Volume" and "CFS Biomass" radio options for projection type', () => {
-      mountPanel()
-      cy.contains('.v-label', 'Volume').should('exist')
-      cy.contains('.v-label', 'CFS Biomass').should('exist')
-    })
-
     it('renders all checkboxes in "Include following values in Report"', () => {
       mountPanel()
       cy.get('[data-testid="is-by-species-enabled"]').should('exist')
@@ -67,27 +51,12 @@ describe('<ReportConfigPanel />', () => {
       cy.get('[data-testid="is-current-year-enabled"]').should('exist')
       cy.get('[data-testid="is-reference-year-enabled"]').should('exist')
     })
-
-    it('renders Starting Age, Finishing Age, and Increment fields when Age is selected (default)', () => {
-      mountPanel()
-      cy.get('[data-testid="starting-age"]').should('exist')
-      cy.get('[data-testid="finishing-age"]').should('exist')
-      cy.get('[data-testid="age-increment"]').should('exist')
-    })
   })
 
   describe('Input enabled/disabled state', () => {
     it('inputs are disabled in read-only mode', () => {
       mountPanel((_, app) => {
         app.setViewMode(PROJECTION_VIEW_MODE.VIEW)
-      })
-      cy.get('#reportTitle').should('be.disabled')
-      cy.get('#reportDescription').should('be.disabled')
-    })
-
-    it('inputs are disabled when panel is not editable', () => {
-      mountPanel((fu) => {
-        fu.panelState.reportConfig.editable = false
       })
       cy.get('#reportTitle').should('be.disabled')
       cy.get('#reportDescription').should('be.disabled')
@@ -131,15 +100,6 @@ describe('<ReportConfigPanel />', () => {
       mountPanel((fu) => {
         fu.panelState.reportConfig.confirmed = false
         fu.panelState.reportConfig.editable = true
-      })
-      cy.contains('button', 'Edit').should('be.disabled')
-    })
-
-    it('is disabled when projection is running or ready', () => {
-      mountPanel((fu, app) => {
-        fu.panelState.reportConfig.confirmed = true
-        fu.panelState.reportConfig.editable = false
-        app.setCurrentProjectionStatus(PROJECTION_STATUS.RUNNING)
       })
       cy.contains('button', 'Edit').should('be.disabled')
     })

--- a/frontend/src/components/projection/input/report-info/ReportConfigPanel.stories.ts
+++ b/frontend/src/components/projection/input/report-info/ReportConfigPanel.stories.ts
@@ -33,14 +33,7 @@ export const Default: Story = {
       fileUploadStore.ageIncrement = '5'
     },
     template: '<ReportConfigPanel />',
-  }),
-  parameters: {
-    docs: {
-      description: {
-        story: 'Edit mode - panel open with title, description, and age range fields filled in. All inputs are enabled.',
-      },
-    },
-  },
+  })
 }
 
 export const YearRangeMode: Story = {
@@ -62,14 +55,7 @@ export const YearRangeMode: Story = {
       fileUploadStore.yearIncrement = '5'
     },
     template: '<ReportConfigPanel />',
-  }),
-  parameters: {
-    docs: {
-      description: {
-        story: 'Numeric Range set to "Year" mode - Starting Year, Finishing Year, and Increment fields are shown instead of Age fields.',
-      },
-    },
-  },
+  })
 }
 
 export const CFSBiomassProjection: Story = {
@@ -92,14 +78,7 @@ export const CFSBiomassProjection: Story = {
       fileUploadStore.isBySpeciesEnabled = false
     },
     template: '<ReportConfigPanel />',
-  }),
-  parameters: {
-    docs: {
-      description: {
-        story: 'CFS Biomass projection type selected - the "By Species" checkbox is automatically disabled.',
-      },
-    },
-  },
+  })
 }
 
 export const Confirmed: Story = {
@@ -122,14 +101,7 @@ export const Confirmed: Story = {
       fileUploadStore.ageIncrement = '5'
     },
     template: '<ReportConfigPanel />',
-  }),
-  parameters: {
-    docs: {
-      description: {
-        story: 'Confirmed state - all fields are disabled and the Edit button in the header is enabled.',
-      },
-    },
-  },
+  })
 }
 
 export const ReadOnly: Story = {
@@ -152,14 +124,7 @@ export const ReadOnly: Story = {
       fileUploadStore.ageIncrement = '5'
     },
     template: '<ReportConfigPanel />',
-  }),
-  parameters: {
-    docs: {
-      description: {
-        story: 'Read-only (View) mode - all fields are disabled and the ActionPanel and Edit button are hidden.',
-      },
-    },
-  },
+  })
 }
 
 export const PanelCollapsed: Story = {
@@ -175,12 +140,5 @@ export const PanelCollapsed: Story = {
       fileUploadStore.panelState.reportConfig.editable = true
     },
     template: '<ReportConfigPanel />',
-  }),
-  parameters: {
-    docs: {
-      description: {
-        story: 'Panel in collapsed state - only the "Report Details" header with the chevron icon is visible.',
-      },
-    },
-  },
+  })
 }

--- a/frontend/src/components/projection/input/report-info/ReportConfigPanel.vue
+++ b/frontend/src/components/projection/input/report-info/ReportConfigPanel.vue
@@ -321,6 +321,7 @@
               :hideClearButton="true"
               :hideEditButton="true"
               :showCancelButton="true"
+              :isCancelEnabled="isDirty"
               @confirm="onConfirm"
               @cancel="onCancel"
             />
@@ -331,7 +332,7 @@
   </v-card>
 </template>
 <script setup lang="ts">
-import { ref, watch, computed, type Ref } from 'vue'
+import { ref, watch, computed, nextTick, type Ref } from 'vue'
 import { useAppStore } from '@/stores/projection/appStore'
 import { useFileUploadStore } from '@/stores/projection/fileUploadStore'
 import { AppButton, AppSpinField } from '@/components'
@@ -536,6 +537,14 @@ const validateFields = (): boolean => {
   return isValid && rangeValid
 }
 
+const isDirty = ref(false)
+let suppressDirtyTracking = false
+const markDirty = () => { if (!suppressDirtyTracking) isDirty.value = true }
+
+watch(() => fileUploadStore.panelState[panelName].editable, (editable, wasEditable) => {
+  if (editable && !wasEditable) isDirty.value = false
+})
+
 // Watch store -> local (for external changes)
 watch(() => fileUploadStore.reportTitle, (v) => { localReportTitle.value = v })
 watch(() => fileUploadStore.reportDescription, (v) => { localReportDescription.value = v })
@@ -557,29 +566,29 @@ watch(() => fileUploadStore.isPolygonIDEnabled, (v) => { localIsPolygonIDEnabled
 watch(() => fileUploadStore.isCurrentYearEnabled, (v) => { localIsCurrentYearEnabled.value = v })
 watch(() => fileUploadStore.isReferenceYearEnabled, (v) => { localIsReferenceYearEnabled.value = v })
 
-// Watch local -> store (for UI changes)
-watch(localReportTitle, (v) => { fileUploadStore.reportTitle = v })
-watch(localReportDescription, (v) => { fileUploadStore.reportDescription = v })
+watch(localReportTitle, (v) => { fileUploadStore.reportTitle = v; markDirty() })
+watch(localReportDescription, (v) => { fileUploadStore.reportDescription = v; markDirty() })
 watch(localProjectionType, (v) => {
   if (v === CONSTANTS.PROJECTION_TYPE.CFS_BIOMASS) {
     localIsBySpeciesEnabled.value = false
   }
   fileUploadStore.projectionType = v
+  markDirty()
 })
-watch(localSelectedAgeYearRange, (v) => { fileUploadStore.selectedAgeYearRange = v })
-watch(localStartingAge, (v) => { fileUploadStore.startingAge = v })
-watch(localFinishingAge, (v) => { fileUploadStore.finishingAge = v })
-watch(localAgeIncrement, (v) => { fileUploadStore.ageIncrement = v })
-watch(localStartYear, (v) => { fileUploadStore.startYear = v })
-watch(localEndYear, (v) => { fileUploadStore.endYear = v })
-watch(localYearIncrement, (v) => { fileUploadStore.yearIncrement = v })
-watch(localSpecificYear, (v) => { fileUploadStore.specificYear = v })
-watch(localIsBySpeciesEnabled, (v) => { fileUploadStore.isBySpeciesEnabled = v })
-watch(localIncSecondaryHeight, (v) => { fileUploadStore.incSecondaryHeight = v })
-watch(localIsProjectionModeEnabled, (v) => { fileUploadStore.isProjectionModeEnabled = v })
-watch(localIsPolygonIDEnabled, (v) => { fileUploadStore.isPolygonIDEnabled = v })
-watch(localIsCurrentYearEnabled, (v) => { fileUploadStore.isCurrentYearEnabled = v })
-watch(localIsReferenceYearEnabled, (v) => { fileUploadStore.isReferenceYearEnabled = v })
+watch(localSelectedAgeYearRange, (v) => { fileUploadStore.selectedAgeYearRange = v; markDirty() })
+watch(localStartingAge, (v) => { fileUploadStore.startingAge = v; markDirty() })
+watch(localFinishingAge, (v) => { fileUploadStore.finishingAge = v; markDirty() })
+watch(localAgeIncrement, (v) => { fileUploadStore.ageIncrement = v; markDirty() })
+watch(localStartYear, (v) => { fileUploadStore.startYear = v; markDirty() })
+watch(localEndYear, (v) => { fileUploadStore.endYear = v; markDirty() })
+watch(localYearIncrement, (v) => { fileUploadStore.yearIncrement = v; markDirty() })
+watch(localSpecificYear, (v) => { fileUploadStore.specificYear = v; markDirty() })
+watch(localIsBySpeciesEnabled, (v) => { fileUploadStore.isBySpeciesEnabled = v; markDirty() })
+watch(localIncSecondaryHeight, (v) => { fileUploadStore.incSecondaryHeight = v; markDirty() })
+watch(localIsProjectionModeEnabled, (v) => { fileUploadStore.isProjectionModeEnabled = v; markDirty() })
+watch(localIsPolygonIDEnabled, (v) => { fileUploadStore.isPolygonIDEnabled = v; markDirty() })
+watch(localIsCurrentYearEnabled, (v) => { fileUploadStore.isCurrentYearEnabled = v; markDirty() })
+watch(localIsReferenceYearEnabled, (v) => { fileUploadStore.isReferenceYearEnabled = v; markDirty() })
 
 // Input handlers (clear error on change)
 const handleStartingAgeInput = (value: string | null) => {
@@ -665,20 +674,25 @@ const onConfirm = async () => {
     appStore.isSavingProjection = false
   }
 
+  isDirty.value = false
   if (!isConfirmed.value) {
     fileUploadStore.confirmPanel(panelName)
   }
 }
 
 const onCancel = async () => {
+  suppressDirtyTracking = true
   appStore.isSavingProjection = true
   try {
     await revertPanelToSaved(panelName as FileUploadPanelName)
+    await nextTick()
+    isDirty.value = false
   } catch (error) {
     console.error(PROJECTION_ERR.REVERT_ERROR_LOG, error)
     notificationStore.showErrorMessage(PROJECTION_ERR.LOAD_FAILED, PROJECTION_ERR.LOAD_FAILED_TITLE)
   } finally {
     appStore.isSavingProjection = false
+    suppressDirtyTracking = false
   }
 }
 </script>

--- a/frontend/src/components/projection/input/report-info/ReportDetailsPanel.cy.ts
+++ b/frontend/src/components/projection/input/report-info/ReportDetailsPanel.cy.ts
@@ -32,230 +32,94 @@ const mountPanel = (
 }
 
 describe('<ReportDetailsPanel />', () => {
-  describe('Panel structure', () => {
-    it('renders the "Report Details" panel title', () => {
-      mountPanel()
-      cy.contains('.text-h6', 'Report Details').should('exist')
-    })
+  it('shows panel content when open (default)', () => {
+    mountPanel()
+    cy.get('#manualReportTitle').should('exist')
+  })
 
-    it('panel content is in the DOM when the panel is open (default)', () => {
-      mountPanel()
-      cy.get('#manualReportTitle').should('exist')
+  it('hides panel content when closed', () => {
+    mountPanel((modelStore) => {
+      modelStore.panelOpenStates.reportDetails = CONSTANTS.PANEL.CLOSE
     })
+    cy.get('#manualReportTitle').should('not.exist')
+  })
 
-    it('panel content is not in the DOM when the panel is closed', () => {
-      mountPanel((modelStore) => {
-        modelStore.panelOpenStates.reportDetails = CONSTANTS.PANEL.CLOSE
-      })
-      cy.get('#manualReportTitle').should('not.exist')
+  it('disables inputs in view mode and when panel is not editable', () => {
+    mountPanel((_, app) => {
+      app.setViewMode(PROJECTION_VIEW_MODE.VIEW)
+    })
+    cy.get('#manualReportTitle').should('be.disabled')
+    cy.get('#manualReportDescription').should('be.disabled')
+
+    mountPanel((modelStore) => {
+      modelStore.panelState.reportDetails.editable = false
+    })
+    cy.get('#manualReportTitle').should('be.disabled')
+    cy.get('#manualReportDescription').should('be.disabled')
+  })
+
+  it('shows validation error when title is empty on blur', () => {
+    mountPanel()
+    cy.get('#manualReportTitle').focus()
+    cy.get('#manualReportTitle').blur()
+    cy.contains('Report Title is required.').should('exist')
+  })
+
+  it('reflects the store reportTitle value in the text field', () => {
+    mountPanel((modelStore) => {
+      modelStore.reportTitle = 'Stored Title'
+    })
+    cy.get('#manualReportTitle').should('have.value', 'Stored Title')
+  })
+
+  it('clicking "Next" with empty title shows error and does not confirm', () => {
+    const { modelStore } = mountPanel((modelStore) => {
+      modelStore.reportTitle = null
+    })
+    cy.contains('button', 'Next').click()
+    cy.contains('Report Title is required.').should('exist')
+    cy.then(() => {
+      expect(modelStore.panelState.reportDetails.confirmed).to.be.false
     })
   })
 
-  describe('Expansion panel chevron icon', () => {
-    it('shows mdi-chevron-up when the panel is open (default)', () => {
-      mountPanel()
-      cy.get('.expansion-panel-icon').should('have.class', 'mdi-chevron-up')
+  it('hides ActionPanel in view mode and shows Next/Cancel in edit mode', () => {
+    mountPanel((_, app) => {
+      app.setViewMode(PROJECTION_VIEW_MODE.VIEW)
     })
+    cy.contains('button', 'Next').should('not.exist')
+    cy.contains('button', 'Cancel').should('not.exist')
 
-    it('shows mdi-chevron-down when the panel is closed', () => {
-      mountPanel((modelStore) => {
-        modelStore.panelOpenStates.reportDetails = CONSTANTS.PANEL.CLOSE
-      })
-      cy.get('.expansion-panel-icon').should('have.class', 'mdi-chevron-down')
+    mountPanel()
+    cy.contains('button', 'Next').should('exist')
+    cy.contains('button', 'Cancel').should('exist')
+  })
+
+  it('disables Next and Cancel when panel is not editable', () => {
+    mountPanel((modelStore) => {
+      modelStore.panelState.reportDetails.editable = false
+    })
+    cy.contains('button', 'Next').should('be.disabled')
+    cy.contains('button', 'Cancel').should('be.disabled')
+  })
+
+  it('clicking Edit button makes the panel editable', () => {
+    const { modelStore } = mountPanel((modelStore) => {
+      modelStore.panelState.reportDetails.confirmed = true
+      modelStore.panelState.reportDetails.editable = false
+    })
+    cy.contains('button', 'Edit').click({ force: true })
+    cy.then(() => {
+      expect(modelStore.panelState.reportDetails.editable).to.be.true
     })
   })
 
-  describe('Form fields', () => {
-    it('renders "Report Title (Required)" label', () => {
-      mountPanel()
-      cy.contains('label', 'Report Title (Required)').should('exist')
+  it('disables Edit button when projection is RUNNING', () => {
+    mountPanel((modelStore, appStore) => {
+      modelStore.panelState.reportDetails.confirmed = true
+      modelStore.panelState.reportDetails.editable = false
+      appStore.currentProjectionStatus = CONSTANTS.PROJECTION_STATUS.RUNNING
     })
-
-    it('renders the report title text field with placeholder', () => {
-      mountPanel()
-      cy.get('#manualReportTitle').should('have.attr', 'placeholder', 'Enter a report title...')
-    })
-
-    it('renders "Projection Type" label', () => {
-      mountPanel()
-      cy.contains('label', 'Projection Type').should('exist')
-    })
-
-    it('renders "Volume" and "CFS Biomass" radio options', () => {
-      mountPanel()
-      cy.contains('.v-label', 'Volume').should('exist')
-      cy.contains('.v-label', 'CFS Biomass').should('exist')
-    })
-
-    it('renders the description textarea with placeholder', () => {
-      mountPanel()
-      cy.get('#manualReportDescription').should(
-        'have.attr',
-        'placeholder',
-        'Provide a description of this Projection...',
-      )
-    })
-
-    it('shows "0/500" counter when description is empty', () => {
-      mountPanel()
-      cy.contains('.counter', '0/500').should('exist')
-    })
-  })
-
-  describe('Input enabled/disabled state', () => {
-    it('inputs are enabled when the panel is editable (default)', () => {
-      mountPanel()
-      cy.get('#manualReportTitle').should('not.be.disabled')
-      cy.get('#manualReportDescription').should('not.be.disabled')
-    })
-
-    it('inputs are disabled in view/read-only mode', () => {
-      mountPanel((_, app) => {
-        app.setViewMode(PROJECTION_VIEW_MODE.VIEW)
-      })
-      cy.get('#manualReportTitle').should('be.disabled')
-      cy.get('#manualReportDescription').should('be.disabled')
-    })
-
-    it('inputs are disabled when panel is not editable', () => {
-      mountPanel((modelStore) => {
-        modelStore.panelState.reportDetails.editable = false
-      })
-      cy.get('#manualReportTitle').should('be.disabled')
-      cy.get('#manualReportDescription').should('be.disabled')
-    })
-  })
-
-  describe('Title validation', () => {
-    it('shows an error message when the title is empty on blur', () => {
-      mountPanel()
-      cy.get('#manualReportTitle').focus()
-      cy.get('#manualReportTitle').blur()
-      cy.contains('Report Title is required.').should('exist')
-    })
-  })
-
-  describe('Store synchronization', () => {
-    it('reflects the store reportTitle initial value in the text field', () => {
-      mountPanel((modelStore) => {
-        modelStore.reportTitle = 'Stored Title'
-      })
-      cy.get('#manualReportTitle').should('have.value', 'Stored Title')
-    })
-  })
-
-  describe('ActionPanel', () => {
-    it('is not rendered in view/read-only mode', () => {
-      mountPanel((_, app) => {
-        app.setViewMode(PROJECTION_VIEW_MODE.VIEW)
-      })
-      cy.contains('button', 'Next').should('not.exist')
-      cy.contains('button', 'Cancel').should('not.exist')
-    })
-
-    it('renders "Next" and "Cancel" buttons in edit mode', () => {
-      mountPanel()
-      cy.contains('button', 'Next').should('exist')
-      cy.contains('button', 'Cancel').should('exist')
-    })
-
-    it('"Next" and "Cancel" are enabled when the panel is editable (default)', () => {
-      mountPanel()
-      cy.contains('button', 'Next').should('not.be.disabled')
-      cy.contains('button', 'Cancel').should('not.be.disabled')
-    })
-
-    it('"Next" and "Cancel" are disabled when the panel is not editable', () => {
-      mountPanel((modelStore) => {
-        modelStore.panelState.reportDetails.editable = false
-      })
-      cy.contains('button', 'Next').should('be.disabled')
-      cy.contains('button', 'Cancel').should('be.disabled')
-    })
-
-    it('does not render the "Clear" button (hideClearButton=true)', () => {
-      mountPanel()
-      cy.contains('button', 'Clear').should('not.exist')
-    })
-  })
-
-  describe('Edit button in header', () => {
-    it('is visible in non-read-only (create) mode', () => {
-      mountPanel()
-      cy.get('.edit-button-col').should('exist')
-    })
-
-    it('is not visible in read-only (view) mode', () => {
-      mountPanel((_, app) => {
-        app.setViewMode(PROJECTION_VIEW_MODE.VIEW)
-      })
-      cy.get('.edit-button-col').should('not.exist')
-    })
-
-    it('is disabled when the panel is not yet confirmed', () => {
-      mountPanel((modelStore) => {
-        modelStore.panelState.reportDetails.confirmed = false
-        modelStore.panelState.reportDetails.editable = true
-      })
-      cy.contains('button', 'Edit').should('be.disabled')
-    })
-
-    it('is enabled when the panel is confirmed and not editable', () => {
-      mountPanel((modelStore) => {
-        modelStore.panelState.reportDetails.confirmed = true
-        modelStore.panelState.reportDetails.editable = false
-      })
-      cy.contains('button', 'Edit').should('not.be.disabled')
-    })
-
-    it('is disabled when the projection status is RUNNING', () => {
-      mountPanel((modelStore, appStore) => {
-        modelStore.panelState.reportDetails.confirmed = true
-        modelStore.panelState.reportDetails.editable = false
-        appStore.currentProjectionStatus = CONSTANTS.PROJECTION_STATUS.RUNNING
-      })
-      cy.contains('button', 'Edit').should('be.disabled')
-    })
-
-    it('is disabled when the projection status is READY', () => {
-      mountPanel((modelStore, appStore) => {
-        modelStore.panelState.reportDetails.confirmed = true
-        modelStore.panelState.reportDetails.editable = false
-        appStore.currentProjectionStatus = CONSTANTS.PROJECTION_STATUS.READY
-      })
-      cy.contains('button', 'Edit').should('be.disabled')
-    })
-
-    it('clicking Edit makes the panel editable', () => {
-      const { modelStore } = mountPanel((modelStore) => {
-        modelStore.panelState.reportDetails.confirmed = true
-        modelStore.panelState.reportDetails.editable = false
-      })
-      cy.contains('button', 'Edit').click({ force: true })
-      cy.then(() => {
-        expect(modelStore.panelState.reportDetails.editable).to.be.true
-      })
-    })
-  })
-
-  describe('Confirm and cancel behavior', () => {
-    it('clicking "Next" with an empty title shows a validation error and does not confirm', () => {
-      const { modelStore } = mountPanel((modelStore) => {
-        modelStore.reportTitle = null
-      })
-      cy.contains('button', 'Next').click()
-      cy.contains('Report Title is required.').should('exist')
-      cy.then(() => {
-        expect(modelStore.panelState.reportDetails.confirmed).to.be.false
-      })
-    })
-
-    it('clicking "Next" with a whitespace-only title shows a validation error', () => {
-      mountPanel((modelStore) => {
-        modelStore.reportTitle = '   '
-      })
-      cy.contains('button', 'Next').click()
-      cy.contains('Report Title is required.').should('exist')
-    })
+    cy.contains('button', 'Edit').should('be.disabled')
   })
 })

--- a/frontend/src/components/projection/input/report-info/ReportDetailsPanel.stories.ts
+++ b/frontend/src/components/projection/input/report-info/ReportDetailsPanel.stories.ts
@@ -29,14 +29,7 @@ export const Default: Story = {
       modelStore.reportDescription = 'This projection covers the north-east sector stand inventory for the 2024 planning cycle.'
     },
     template: '<ReportDetailsPanel />',
-  }),
-  parameters: {
-    docs: {
-      description: {
-        story: 'Edit mode - panel open with a title and description filled in. The description counter reflects the current character count.',
-      },
-    },
-  },
+  })
 }
 
 export const Confirmed: Story = {
@@ -55,14 +48,7 @@ export const Confirmed: Story = {
       modelStore.reportDescription = 'North-east sector stand inventory.'
     },
     template: '<ReportDetailsPanel />',
-  }),
-  parameters: {
-    docs: {
-      description: {
-        story: 'Confirmed state - all fields are disabled. The action panel shows the Edit button.',
-      },
-    },
-  },
+  })
 }
 
 export const ReadOnly: Story = {
@@ -81,14 +67,7 @@ export const ReadOnly: Story = {
       modelStore.reportDescription = 'North-east sector stand inventory.'
     },
     template: '<ReportDetailsPanel />',
-  }),
-  parameters: {
-    docs: {
-      description: {
-        story: 'Read-only (View) mode - all fields are disabled and the ActionPanel is hidden.',
-      },
-    },
-  },
+  })
 }
 
 export const PanelCollapsed: Story = {
@@ -104,14 +83,7 @@ export const PanelCollapsed: Story = {
       modelStore.panelState.reportDetails.editable = true
     },
     template: '<ReportDetailsPanel />',
-  }),
-  parameters: {
-    docs: {
-      description: {
-        story: 'Panel in collapsed state. Only the "Report Details" header with the chevron icon is visible.',
-      },
-    },
-  },
+  })
 }
 
 export const ProjectionRunning: Story = {
@@ -131,14 +103,7 @@ export const ProjectionRunning: Story = {
       modelStore.reportDescription = 'North-east sector stand inventory.'
     },
     template: '<ReportDetailsPanel />',
-  }),
-  parameters: {
-    docs: {
-      description: {
-        story: 'Projection is currently running - the Edit button in the header is disabled and shows a tooltip explaining that editing is not available during this status.',
-      },
-    },
-  },
+  })
 }
 
 export const TitleValidationError: Story = {
@@ -157,12 +122,5 @@ export const TitleValidationError: Story = {
       modelStore.reportDescription = ''
     },
     template: '<ReportDetailsPanel />',
-  }),
-  parameters: {
-    docs: {
-      description: {
-        story: 'Edit mode with no title entered. Click "Next" or blur the title field to trigger the "Report Title is required." validation error.',
-      },
-    },
-  },
+  })
 }

--- a/frontend/src/components/projection/input/report-info/ReportDetailsPanel.vue
+++ b/frontend/src/components/projection/input/report-info/ReportDetailsPanel.vue
@@ -102,6 +102,7 @@
               :hideClearButton="true"
               :hideEditButton="true"
               :showCancelButton="true"
+              :isCancelEnabled="isDirty"
               @confirm="onConfirm"
               @cancel="onCancel"
             />
@@ -113,7 +114,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch } from 'vue'
+import { ref, computed, watch, nextTick } from 'vue'
 import { useAppStore } from '@/stores/projection/appStore'
 import { useModelParameterStore } from '@/stores/projection/modelParameterStore'
 import { useNotificationStore } from '@/stores/common/notificationStore'
@@ -211,6 +212,14 @@ const descriptionLength = computed(() =>
   localReportDescription.value ? localReportDescription.value.length : 0,
 )
 
+const isDirty = ref(false)
+let suppressDirtyTracking = false
+const markDirty = () => { if (!suppressDirtyTracking) isDirty.value = true }
+
+watch(() => modelParameterStore.panelState[panelName].editable, (editable, wasEditable) => {
+  if (editable && !wasEditable) isDirty.value = false
+})
+
 // Sync store -> local
 watch(() => modelParameterStore.reportTitle, (v) => { localReportTitle.value = v })
 watch(() => modelParameterStore.projectionType, (v) => {
@@ -218,15 +227,15 @@ watch(() => modelParameterStore.projectionType, (v) => {
 })
 watch(() => modelParameterStore.reportDescription, (v) => { localReportDescription.value = v })
 
-// Sync local -> store
-watch(localReportTitle, (v) => { modelParameterStore.reportTitle = v })
+watch(localReportTitle, (v) => { modelParameterStore.reportTitle = v; markDirty() })
 watch(localProjectionType, (v) => {
   modelParameterStore.projectionType = v
   if (v === CONSTANTS.PROJECTION_TYPE.CFS_BIOMASS) {
     modelParameterStore.isBySpeciesEnabled = false
   }
+  markDirty()
 })
-watch(localReportDescription, (v) => { modelParameterStore.reportDescription = v })
+watch(localReportDescription, (v) => { modelParameterStore.reportDescription = v; markDirty() })
 
 const validateTitle = () => {
   if (!localReportTitle.value || localReportTitle.value.trim() === '') {
@@ -251,20 +260,25 @@ const onConfirm = async () => {
     appStore.isSavingProjection = false
   }
 
+  isDirty.value = false
   if (!isConfirmed.value) {
     modelParameterStore.confirmPanel(panelName)
   }
 }
 
 const onCancel = async () => {
+  suppressDirtyTracking = true
   appStore.isSavingProjection = true
   try {
     await revertPanelToSaved(panelName)
+    await nextTick()
+    isDirty.value = false
   } catch (error) {
     console.error(PROJECTION_ERR.REVERT_ERROR_LOG, error)
     notificationStore.showErrorMessage(PROJECTION_ERR.LOAD_FAILED, PROJECTION_ERR.LOAD_FAILED_TITLE)
   } finally {
     appStore.isSavingProjection = false
+    suppressDirtyTracking = false
   }
 }
 </script>

--- a/frontend/src/components/projection/input/report-info/ReportSettingsPanel.cy.ts
+++ b/frontend/src/components/projection/input/report-info/ReportSettingsPanel.cy.ts
@@ -35,225 +35,82 @@ const mountPanel = (
 }
 
 describe('<ReportSettingsPanel />', () => {
-  describe('Panel structure', () => {
-    it('renders the "Report Settings" panel title', () => {
-      mountPanel()
-      cy.contains('.text-h6', 'Report Settings').should('exist')
-    })
-
-    it('panel content is in the DOM when the panel is open', () => {
-      mountPanel()
-      cy.get('[data-testid="starting-age"]').should('exist')
-    })
-
-    it('panel content is not in the DOM when the panel is closed', () => {
-      mountPanel((modelStore) => {
-        modelStore.panelOpenStates.reportSettings = CONSTANTS.PANEL.CLOSE
-      })
-      cy.get('[data-testid="starting-age"]').should('not.exist')
-    })
+  it('renders title and content fields when panel is open', () => {
+    mountPanel()
+    cy.contains('.text-h6', 'Report Settings').should('exist')
+    cy.get('[data-testid="starting-age"]').should('exist')
   })
 
-  describe('Expansion panel chevron icon', () => {
-    it('shows mdi-chevron-up when the panel is open', () => {
-      mountPanel()
-      cy.get('.expansion-panel-icon').should('have.class', 'mdi-chevron-up')
+  it('hides content when panel is closed', () => {
+    mountPanel((modelStore) => {
+      modelStore.panelOpenStates.reportSettings = CONSTANTS.PANEL.CLOSE
     })
-
-    it('shows mdi-chevron-down when the panel is closed', () => {
-      mountPanel((modelStore) => {
-        modelStore.panelOpenStates.reportSettings = CONSTANTS.PANEL.CLOSE
-      })
-      cy.get('.expansion-panel-icon').should('have.class', 'mdi-chevron-down')
-    })
+    cy.get('[data-testid="starting-age"]').should('not.exist')
   })
 
-  describe('Age range fields (default)', () => {
-    it('renders Starting Age, Finishing Age, and Increment fields when Age is selected', () => {
-      mountPanel()
-      cy.get('[data-testid="starting-age"]').should('exist')
-      cy.get('[data-testid="finishing-age"]').should('exist')
-      cy.get('[data-testid="age-increment"]').should('exist')
-    })
-
-    it('does not render Year fields when Age is selected', () => {
-      mountPanel()
-      cy.get('[data-testid="start-year"]').should('not.exist')
-      cy.get('[data-testid="end-year"]').should('not.exist')
-      cy.get('[data-testid="year-increment"]').should('not.exist')
-    })
+  it('shows Age fields and hides Year fields when Age range selected (default)', () => {
+    mountPanel()
+    cy.get('[data-testid="starting-age"]').should('exist')
+    cy.get('[data-testid="finishing-age"]').should('exist')
+    cy.get('[data-testid="age-increment"]').should('exist')
+    cy.get('[data-testid="start-year"]').should('not.exist')
+    cy.get('[data-testid="end-year"]').should('not.exist')
   })
 
-  describe('Year range fields', () => {
-    it('renders Start Year, End Year, and Increment fields when Year is selected', () => {
-      mountPanel((modelStore) => {
-        modelStore.selectedAgeYearRange = CONSTANTS.AGE_YEAR_RANGE.YEAR
-      })
-      cy.get('[data-testid="start-year"]').should('exist')
-      cy.get('[data-testid="end-year"]').should('exist')
-      cy.get('[data-testid="year-increment"]').should('exist')
+  it('shows Year fields and hides Age fields when Year range selected', () => {
+    mountPanel((modelStore) => {
+      modelStore.selectedAgeYearRange = CONSTANTS.AGE_YEAR_RANGE.YEAR
     })
-
-    it('does not render Age fields when Year is selected', () => {
-      mountPanel((modelStore) => {
-        modelStore.selectedAgeYearRange = CONSTANTS.AGE_YEAR_RANGE.YEAR
-      })
-      cy.get('[data-testid="starting-age"]').should('not.exist')
-      cy.get('[data-testid="finishing-age"]').should('not.exist')
-    })
+    cy.get('[data-testid="start-year"]').should('exist')
+    cy.get('[data-testid="end-year"]').should('exist')
+    cy.get('[data-testid="year-increment"]').should('exist')
+    cy.get('[data-testid="starting-age"]').should('not.exist')
+    cy.get('[data-testid="finishing-age"]').should('not.exist')
   })
 
-  describe('Include in Report checkboxes', () => {
-    it('renders all checkboxes', () => {
-      mountPanel()
-      cy.get('[data-testid="is-computed-mai-enabled"]').should('exist')
-      cy.get('[data-testid="is-culmination-values-enabled"]').should('exist')
-      cy.get('[data-testid="is-by-species-enabled"]').should('exist')
-      cy.get('[data-testid="inc-secondary-height"]').should('exist')
+  it('disables Computed MAI and By Species checkboxes when CFS Biomass is selected', () => {
+    mountPanel((modelStore) => {
+      modelStore.projectionType = CONSTANTS.PROJECTION_TYPE.CFS_BIOMASS
     })
-
-    it('disables Computed MAI checkbox when CFS Biomass is selected', () => {
-      mountPanel((modelStore) => {
-        modelStore.projectionType = CONSTANTS.PROJECTION_TYPE.CFS_BIOMASS
-      })
-      cy.get('[data-testid="is-computed-mai-enabled"] input').should('be.disabled')
-    })
-
-    it('disables By Species checkbox when CFS Biomass is selected', () => {
-      mountPanel((modelStore) => {
-        modelStore.projectionType = CONSTANTS.PROJECTION_TYPE.CFS_BIOMASS
-      })
-      cy.get('[data-testid="is-by-species-enabled"] input').should('be.disabled')
-    })
-
-    it('disables Secondary Height checkbox when derivedBy is Volume', () => {
-      mountPanel((modelStore) => {
-        modelStore.derivedBy = CONSTANTS.DERIVED_BY.VOLUME
-      })
-      cy.get('[data-testid="inc-secondary-height"] input').should('be.disabled')
-    })
-
-    it('disables Culmination Values checkbox when age range is not wide enough', () => {
-      mountPanel((modelStore) => {
-        modelStore.startingAge = '50'
-        modelStore.finishingAge = '100'
-      })
-      cy.get('[data-testid="is-culmination-values-enabled"] input').should('be.disabled')
-    })
-
-    it('enables Culmination Values when startingAge <= 10 and finishingAge >= 300', () => {
-      mountPanel((modelStore) => {
-        modelStore.startingAge = '10'
-        modelStore.finishingAge = '300'
-      })
-      cy.get('[data-testid="is-culmination-values-enabled"] input').should('not.be.disabled')
-    })
+    cy.get('[data-testid="is-computed-mai-enabled"] input').should('be.disabled')
+    cy.get('[data-testid="is-by-species-enabled"] input').should('be.disabled')
   })
 
-  describe('Input enabled/disabled state', () => {
-    it('inputs are enabled when the panel is editable (default)', () => {
-      mountPanel()
-      cy.get('[data-testid="starting-age"] input').should('not.be.disabled')
+  it('disables Culmination Values when age range is not wide enough', () => {
+    mountPanel((modelStore) => {
+      modelStore.startingAge = '50'
+      modelStore.finishingAge = '100'
     })
-
-    it('inputs are disabled in view/read-only mode', () => {
-      mountPanel((_, appStore) => {
-        appStore.setViewMode(PROJECTION_VIEW_MODE.VIEW)
-      })
-      cy.get('[data-testid="starting-age"] input').should('be.disabled')
-    })
-
-    it('inputs are disabled when panel is not editable', () => {
-      mountPanel((modelStore) => {
-        modelStore.panelState.reportSettings.editable = false
-      })
-      cy.get('[data-testid="starting-age"] input').should('be.disabled')
-    })
+    cy.get('[data-testid="is-culmination-values-enabled"] input').should('be.disabled')
   })
 
-  describe('Edit button in header', () => {
-    it('is visible in non-read-only mode', () => {
-      mountPanel()
-      cy.get('.edit-button-col').should('exist')
+  it('disables Secondary Height when derivedBy is Volume', () => {
+    mountPanel((modelStore) => {
+      modelStore.derivedBy = CONSTANTS.DERIVED_BY.VOLUME
     })
-
-    it('is not visible in read-only mode', () => {
-      mountPanel((_, appStore) => {
-        appStore.setViewMode(PROJECTION_VIEW_MODE.VIEW)
-      })
-      cy.get('.edit-button-col').should('not.exist')
-    })
-
-    it('is disabled when the panel is not yet confirmed', () => {
-      mountPanel((modelStore) => {
-        modelStore.panelState.reportSettings.confirmed = false
-        modelStore.panelState.reportSettings.editable = true
-      })
-      cy.contains('button', 'Edit').should('be.disabled')
-    })
-
-    it('is enabled when the panel is confirmed and not editable', () => {
-      mountPanel((modelStore) => {
-        modelStore.panelState.reportSettings.confirmed = true
-        modelStore.panelState.reportSettings.editable = false
-      })
-      cy.contains('button', 'Edit').should('not.be.disabled')
-    })
-
-    it('is disabled when projection status is RUNNING', () => {
-      mountPanel((modelStore, appStore) => {
-        modelStore.panelState.reportSettings.confirmed = true
-        modelStore.panelState.reportSettings.editable = false
-        appStore.currentProjectionStatus = CONSTANTS.PROJECTION_STATUS.RUNNING
-      })
-      cy.contains('button', 'Edit').should('be.disabled')
-    })
-
-    it('is disabled when projection status is READY', () => {
-      mountPanel((modelStore, appStore) => {
-        modelStore.panelState.reportSettings.confirmed = true
-        modelStore.panelState.reportSettings.editable = false
-        appStore.currentProjectionStatus = CONSTANTS.PROJECTION_STATUS.READY
-      })
-      cy.contains('button', 'Edit').should('be.disabled')
-    })
+    cy.get('[data-testid="inc-secondary-height"] input').should('be.disabled')
   })
 
-  describe('Store synchronization', () => {
-    it('reflects the store startingAge initial value', () => {
-      mountPanel((modelStore) => {
-        modelStore.startingAge = '20'
-      })
-      cy.get('[data-testid="starting-age"] input').should('have.value', '20')
+  it('disables inputs in view/read-only mode', () => {
+    mountPanel((_, appStore) => {
+      appStore.setViewMode(PROJECTION_VIEW_MODE.VIEW)
     })
-
-    it('reflects the store startYear initial value when Year range is selected', () => {
-      mountPanel((modelStore) => {
-        modelStore.selectedAgeYearRange = CONSTANTS.AGE_YEAR_RANGE.YEAR
-        modelStore.startYear = '2020'
-      })
-      cy.get('[data-testid="start-year"] input').should('have.value', '2020')
-    })
-
-    it('reflects isComputedMAIEnabled checkbox state from store', () => {
-      mountPanel((modelStore) => {
-        modelStore.isComputedMAIEnabled = true
-      })
-      cy.get('[data-testid="is-computed-mai-enabled"] input').should('be.checked')
-    })
-
-    it('reflects isBySpeciesEnabled checkbox state from store', () => {
-      mountPanel((modelStore) => {
-        modelStore.isBySpeciesEnabled = false
-      })
-      cy.get('[data-testid="is-by-species-enabled"] input').should('not.be.checked')
-    })
+    cy.get('[data-testid="starting-age"] input').should('be.disabled')
   })
 
-  describe('Minimum DBH section', () => {
-    it('renders the Min DBH label', () => {
-      mountPanel()
-      cy.get('.min-dbh-limit-species-group-label').should('exist')
+  it('hides Edit button in read-only mode', () => {
+    mountPanel((_, appStore) => {
+      appStore.setViewMode(PROJECTION_VIEW_MODE.VIEW)
     })
+    cy.get('.edit-button-col').should('not.exist')
+  })
+
+  it('disables Edit button when projection is RUNNING', () => {
+    mountPanel((modelStore, appStore) => {
+      modelStore.panelState.reportSettings.confirmed = true
+      modelStore.panelState.reportSettings.editable = false
+      appStore.currentProjectionStatus = CONSTANTS.PROJECTION_STATUS.RUNNING
+    })
+    cy.contains('button', 'Edit').should('be.disabled')
   })
 })

--- a/frontend/src/components/projection/input/report-info/ReportSettingsPanel.vue
+++ b/frontend/src/components/projection/input/report-info/ReportSettingsPanel.vue
@@ -241,7 +241,7 @@
   </v-card>
 </template>
 <script setup lang="ts">
-import { ref, watch, computed, type Ref } from 'vue'
+import { ref, watch, computed, nextTick, type Ref } from 'vue'
 import { useDisplay } from 'vuetify'
 import { BIZCONSTANTS, CONSTANTS, DEFAULTS, MESSAGE, OPTIONS } from '@/constants'
 import { reportInfoValidation } from '@/validation'
@@ -436,6 +436,21 @@ watch(
   },
 )
 
+const isDirty = ref(false)
+let suppressDirtyTracking = false
+const markDirty = () => { if (!suppressDirtyTracking) isDirty.value = true }
+
+watch(() => modelParameterStore.panelState[panelName].editable, (editable, wasEditable) => {
+  if (editable && !wasEditable) isDirty.value = false
+})
+
+const resetDirty = async (): Promise<void> => {
+  suppressDirtyTracking = true
+  await nextTick()
+  isDirty.value = false
+  suppressDirtyTracking = false
+}
+
 // Watch startingAge and finishingAge to manage CulminationValues state
 watch(
   [localStartingAge, localFinishingAge],
@@ -489,32 +504,36 @@ watch(() => modelParameterStore.incSecondaryHeight, (newVal) => {
   }
 })
 
-watch(selectedAgeYearRange, (newVal) => { modelParameterStore.selectedAgeYearRange = newVal })
-watch(localStartingAge, (newVal) => { modelParameterStore.startingAge = newVal })
-watch(localFinishingAge, (newVal) => { modelParameterStore.finishingAge = newVal })
-watch(localAgeIncrement, (newVal) => { modelParameterStore.ageIncrement = newVal })
-watch(localStartYear, (newVal) => { modelParameterStore.startYear = newVal })
-watch(localEndYear, (newVal) => { modelParameterStore.endYear = newVal })
-watch(localYearIncrement, (newVal) => { modelParameterStore.yearIncrement = newVal })
+watch(selectedAgeYearRange, (newVal) => { modelParameterStore.selectedAgeYearRange = newVal; markDirty() })
+watch(localStartingAge, (newVal) => { modelParameterStore.startingAge = newVal; markDirty() })
+watch(localFinishingAge, (newVal) => { modelParameterStore.finishingAge = newVal; markDirty() })
+watch(localAgeIncrement, (newVal) => { modelParameterStore.ageIncrement = newVal; markDirty() })
+watch(localStartYear, (newVal) => { modelParameterStore.startYear = newVal; markDirty() })
+watch(localEndYear, (newVal) => { modelParameterStore.endYear = newVal; markDirty() })
+watch(localYearIncrement, (newVal) => { modelParameterStore.yearIncrement = newVal; markDirty() })
 
 watch(localIsComputedMAIEnabled, (newVal) => {
   if (JSON.stringify(newVal) !== JSON.stringify(modelParameterStore.isComputedMAIEnabled)) {
     modelParameterStore.isComputedMAIEnabled = newVal
+    markDirty()
   }
 })
 watch(localIsCulminationValuesEnabled, (newVal) => {
   if (JSON.stringify(newVal) !== JSON.stringify(modelParameterStore.isCulminationValuesEnabled)) {
     modelParameterStore.isCulminationValuesEnabled = newVal
+    markDirty()
   }
 })
 watch(localIsBySpeciesEnabled, (newVal) => {
   if (JSON.stringify(newVal) !== JSON.stringify(modelParameterStore.isBySpeciesEnabled)) {
     modelParameterStore.isBySpeciesEnabled = newVal
+    markDirty()
   }
 })
 watch(localIncSecondaryHeight, (newVal) => {
   if (JSON.stringify(newVal) !== JSON.stringify(modelParameterStore.incSecondaryHeight)) {
     modelParameterStore.incSecondaryHeight = newVal
+    markDirty()
   }
 })
 
@@ -553,6 +572,7 @@ const updateMinDBH = (index: number, value: number) => {
     const enumValue = utilizationClassOptions[value]?.value
     if (enumValue !== undefined) {
       speciesGroups.value[index].minimumDBHLimit = enumValue
+      isDirty.value = true
     }
   }
 }
@@ -715,13 +735,14 @@ const onConfirm = async (): Promise<boolean> => {
     appStore.isSavingProjection = false
   }
 
+  isDirty.value = false
   if (!isConfirmed.value) {
     modelParameterStore.confirmPanel(panelName)
   }
   return true
 }
 
-defineExpose({ onConfirm })
+defineExpose({ onConfirm, isDirty, resetDirty })
 </script>
 <style scoped>
 /* Top row: age/year fields + include in report section */

--- a/frontend/src/components/projection/input/site-info/SiteIndicesTable.cy.ts
+++ b/frontend/src/components/projection/input/site-info/SiteIndicesTable.cy.ts
@@ -35,266 +35,109 @@ const mountTable = (
 }
 
 describe('<SiteIndicesTable />', () => {
-  describe('Table structure', () => {
-    it('renders the "Site Indices" subtitle', () => {
-      mountTable(false)
-      cy.contains('.text-subtitle-2', 'Site Indices').should('exist')
-    })
+  it('renders subtitle and all column headers', () => {
+    mountTable(false)
+    cy.contains('.text-subtitle-2', 'Site Indices').should('exist')
+    cy.get('thead th').eq(0).should('contain.text', 'Site Species')
+    cy.get('thead th').eq(1).should('contain.text', 'Computed Value')
+    cy.get('thead th').eq(2).should('contain.text', 'Age')
+    cy.get('thead th').eq(3).should('contain.text', 'Height in Meters')
+    cy.get('thead th').eq(4).should('contain.text', 'BHA Site Index')
+  })
 
-    it('renders all column headers', () => {
-      mountTable(false)
-      cy.get('thead th').eq(0).should('contain.text', 'Site Species')
-      cy.get('thead th').eq(1).should('contain.text', 'Computed Value')
-      cy.get('thead th').eq(2).should('contain.text', 'Age')
-      cy.get('thead th').eq(3).should('contain.text', 'Height in Meters')
-      cy.get('thead th').eq(4).should('contain.text', 'BHA Site Index')
+  it('renders one row per store entry with correct species code', () => {
+    mountTable(false, (store) => {
+      store.siteIndexRows = [makeRow('FD'), makeRow('PL'), makeRow('S')]
     })
+    cy.get('tbody tr').should('have.length', 3)
+    cy.get('tbody tr').eq(0).find('td').eq(0).should('contain.text', 'FD')
+    cy.get('tbody tr').eq(1).find('td').eq(0).should('contain.text', 'PL')
+  })
 
-    it('renders no rows when siteIndexRows is empty', () => {
-      mountTable(false)
-      cy.get('tbody tr').should('have.length', 0)
+  it('disables all inputs when isConfirmEnabled is false', () => {
+    mountTable(false, (store) => {
+      store.siteIndexRows = [makeRow('FD')]
     })
-
-    it('renders one row per entry in siteIndexRows', () => {
-      mountTable(false, (store) => {
-        store.siteIndexRows = [makeRow('FD'), makeRow('PL'), makeRow('S')]
-      })
-      cy.get('tbody tr').should('have.length', 3)
-    })
-
-    it('displays the species code in the first cell of each row', () => {
-      mountTable(false, (store) => {
-        store.siteIndexRows = [makeRow('FD'), makeRow('PL')]
-      })
-      cy.get('tbody tr').eq(0).find('td').eq(0).should('contain.text', 'FD')
-      cy.get('tbody tr').eq(1).find('td').eq(0).should('contain.text', 'PL')
+    cy.get('.v-select.v-input--disabled').should('have.length', 1)
+    cy.get('.v-radio-group.v-input--disabled').should('have.length', 1)
+    cy.get('tbody tr').eq(0).find('.site-spin-field input').each(($input) => {
+      cy.wrap($input).should('be.disabled')
     })
   })
 
-  describe('Computed Value select - disabled states', () => {
-    it('is disabled for all rows when isConfirmEnabled is false', () => {
-      mountTable(false, (store) => {
-        store.siteIndexRows = [makeRow('FD')]
-      })
-      cy.get('.v-select.v-input--disabled').should('have.length', 1)
+  it('disables select, radio, age, and height when Supplied; BHA remains enabled', () => {
+    mountTable(true, (store) => {
+      store.siteIndexRows = [makeRow('FD')]
+      store.siteSpeciesValues = CONSTANTS.SITE_SPECIES_VALUES.SUPPLIED
     })
+    cy.get('.v-select.v-input--disabled').should('have.length', 1)
+    cy.get('.v-radio-group.v-input--disabled').should('have.length', 1)
+    cy.get('tbody tr').eq(0).find('.site-spin-field').eq(0).find('input').should('be.disabled')
+    cy.get('tbody tr').eq(0).find('.site-spin-field').eq(1).find('input').should('be.disabled')
+    cy.get('tbody tr').eq(0).find('.site-spin-field').eq(2).find('input').should('not.be.disabled')
+  })
 
-    it('is disabled when siteSpeciesValues is Supplied', () => {
-      mountTable(true, (store) => {
-        store.siteIndexRows = [makeRow('FD')]
-        store.siteSpeciesValues = CONSTANTS.SITE_SPECIES_VALUES.SUPPLIED
-      })
-      cy.get('.v-select.v-input--disabled').should('have.length', 1)
+  it('enables primary row inputs when Computed + isConfirmEnabled', () => {
+    mountTable(true, (store) => {
+      store.siteIndexRows = [makeRow('FD')]
+      store.siteSpeciesValues = CONSTANTS.SITE_SPECIES_VALUES.COMPUTED
     })
+    cy.get('.v-select').first().should('not.have.class', 'v-input--disabled')
+    cy.get('.v-radio-group').first().should('not.have.class', 'v-input--disabled')
+  })
 
-    it('is enabled for the primary row when Computed + isConfirmEnabled', () => {
-      mountTable(true, (store) => {
-        store.siteIndexRows = [makeRow('FD')]
-        store.siteSpeciesValues = CONSTANTS.SITE_SPECIES_VALUES.COMPUTED
-      })
-      cy.get('.v-select').first().should('not.have.class', 'v-input--disabled')
+  it('disables all non-primary row inputs with N/A placeholders when Computed + Volume', () => {
+    mountTable(true, (store) => {
+      store.siteIndexRows = [makeRow('FD'), makeRow('PL', { age: null, height: null, bhaSiteIndex: null })]
+      store.siteSpeciesValues = CONSTANTS.SITE_SPECIES_VALUES.COMPUTED
+      store.derivedBy = CONSTANTS.DERIVED_BY.VOLUME
     })
-
-    it('is disabled for non-primary rows when Computed + Volume + isConfirmEnabled', () => {
-      mountTable(true, (store) => {
-        store.siteIndexRows = [makeRow('FD'), makeRow('PL')]
-        store.siteSpeciesValues = CONSTANTS.SITE_SPECIES_VALUES.COMPUTED
-        store.derivedBy = CONSTANTS.DERIVED_BY.VOLUME
-      })
-      cy.get('.v-select').eq(1).should('have.class', 'v-input--disabled')
+    cy.get('.v-select').eq(1).should('have.class', 'v-input--disabled')
+    cy.get('tbody tr').eq(1).find('.site-spin-field input').each(($input) => {
+      cy.wrap($input).should('be.disabled')
+      cy.wrap($input).should('have.attr', 'placeholder', CONSTANTS.SPECIAL_INDICATORS.NA)
     })
   })
 
-  describe('Age radio group - disabled states', () => {
-    it('is disabled when isConfirmEnabled is false', () => {
-      mountTable(false, (store) => {
-        store.siteIndexRows = [makeRow('FD')]
-      })
-      cy.get('.v-radio-group.v-input--disabled').should('have.length', 1)
+  it('shows Calc. placeholder for the field matching the selected computedValue', () => {
+    mountTable(true, (store) => {
+      store.siteIndexRows = [
+        makeRow('FD', { age: null, computedValue: CONSTANTS.COMPUTED_VALUE.TOTAL_AGE }),
+        makeRow('PL', { height: null, computedValue: CONSTANTS.COMPUTED_VALUE.HEIGHT }),
+        makeRow('S', { bhaSiteIndex: null, computedValue: CONSTANTS.COMPUTED_VALUE.BHA_SITE_INDEX }),
+      ]
+      store.siteSpeciesValues = CONSTANTS.SITE_SPECIES_VALUES.COMPUTED
     })
-
-    it('is disabled when siteSpeciesValues is Supplied', () => {
-      mountTable(true, (store) => {
-        store.siteIndexRows = [makeRow('FD')]
-        store.siteSpeciesValues = CONSTANTS.SITE_SPECIES_VALUES.SUPPLIED
-      })
-      cy.get('.v-radio-group.v-input--disabled').should('have.length', 1)
-    })
-
-    it('is enabled when Computed + isConfirmEnabled', () => {
-      mountTable(true, (store) => {
-        store.siteIndexRows = [makeRow('FD')]
-        store.siteSpeciesValues = CONSTANTS.SITE_SPECIES_VALUES.COMPUTED
-      })
-      cy.get('.v-radio-group').first().should('not.have.class', 'v-input--disabled')
-    })
+    cy.get('tbody tr').eq(0).find('.site-spin-field').eq(0).find('input')
+      .should('have.attr', 'placeholder', CONSTANTS.SPECIAL_INDICATORS.CALC)
+    cy.get('tbody tr').eq(1).find('.site-spin-field').eq(1).find('input')
+      .should('have.attr', 'placeholder', CONSTANTS.SPECIAL_INDICATORS.CALC)
+    cy.get('tbody tr').eq(2).find('.site-spin-field').eq(2).find('input')
+      .should('have.attr', 'placeholder', CONSTANTS.SPECIAL_INDICATORS.CALC)
   })
 
-  describe('Placeholders (N/A and Calc.)', () => {
-    it('shows N/A placeholder for Age when Supplied', () => {
-      mountTable(true, (store) => {
-        store.siteIndexRows = [makeRow('FD', { age: null })]
-        store.siteSpeciesValues = CONSTANTS.SITE_SPECIES_VALUES.SUPPLIED
-      })
-      cy.get('tbody tr').eq(0).find('.site-spin-field').eq(0).find('input')
-        .should('have.attr', 'placeholder', CONSTANTS.SPECIAL_INDICATORS.NA)
+  it('shows N/A placeholder for age and height when Supplied', () => {
+    mountTable(true, (store) => {
+      store.siteIndexRows = [makeRow('FD', { age: null, height: null })]
+      store.siteSpeciesValues = CONSTANTS.SITE_SPECIES_VALUES.SUPPLIED
     })
-
-    it('shows Calc. placeholder for Age when computedValue is Total Age', () => {
-      mountTable(true, (store) => {
-        store.siteIndexRows = [makeRow('FD', { age: null, computedValue: CONSTANTS.COMPUTED_VALUE.TOTAL_AGE })]
-        store.siteSpeciesValues = CONSTANTS.SITE_SPECIES_VALUES.COMPUTED
-      })
-      cy.get('tbody tr').eq(0).find('.site-spin-field').eq(0).find('input')
-        .should('have.attr', 'placeholder', CONSTANTS.SPECIAL_INDICATORS.CALC)
-    })
-
-    it('shows Calc. placeholder for Height when computedValue is Height in Meters', () => {
-      mountTable(true, (store) => {
-        store.siteIndexRows = [makeRow('FD', { height: null, computedValue: CONSTANTS.COMPUTED_VALUE.HEIGHT })]
-        store.siteSpeciesValues = CONSTANTS.SITE_SPECIES_VALUES.COMPUTED
-      })
-      cy.get('tbody tr').eq(0).find('.site-spin-field').eq(1).find('input')
-        .should('have.attr', 'placeholder', CONSTANTS.SPECIAL_INDICATORS.CALC)
-    })
-
-    it('shows Calc. placeholder for BHA Site Index when computedValue is BHA Site Index', () => {
-      mountTable(true, (store) => {
-        store.siteIndexRows = [makeRow('FD', { bhaSiteIndex: null, computedValue: CONSTANTS.COMPUTED_VALUE.BHA_SITE_INDEX })]
-        store.siteSpeciesValues = CONSTANTS.SITE_SPECIES_VALUES.COMPUTED
-      })
-      cy.get('tbody tr').eq(0).find('.site-spin-field').eq(2).find('input')
-        .should('have.attr', 'placeholder', CONSTANTS.SPECIAL_INDICATORS.CALC)
-    })
-
-    it('shows N/A for all spin fields on non-primary rows when Computed + Volume', () => {
-      mountTable(true, (store) => {
-        store.siteIndexRows = [makeRow('FD'), makeRow('PL', { age: null, height: null, bhaSiteIndex: null })]
-        store.siteSpeciesValues = CONSTANTS.SITE_SPECIES_VALUES.COMPUTED
-        store.derivedBy = CONSTANTS.DERIVED_BY.VOLUME
-      })
-      cy.get('tbody tr').eq(1).find('.site-spin-field input').each(($input) => {
-        cy.wrap($input).should('have.attr', 'placeholder', CONSTANTS.SPECIAL_INDICATORS.NA)
-      })
-    })
+    cy.get('tbody tr').eq(0).find('.site-spin-field').eq(0).find('input')
+      .should('have.attr', 'placeholder', CONSTANTS.SPECIAL_INDICATORS.NA)
+    cy.get('tbody tr').eq(0).find('.site-spin-field').eq(1).find('input')
+      .should('have.attr', 'placeholder', CONSTANTS.SPECIAL_INDICATORS.NA)
   })
 
-  describe('Age spin field - disabled states', () => {
-    it('is disabled when isConfirmEnabled is false', () => {
-      mountTable(false, (store) => {
-        store.siteIndexRows = [makeRow('FD')]
-      })
-      cy.get('tbody tr').eq(0).find('.site-spin-field').eq(0).find('input').should('be.disabled')
+  it('resets age and height to N/A when switching to Supplied', () => {
+    mountTable(true, (store) => {
+      store.siteIndexRows = [makeRow('FD')]
+      store.siteSpeciesValues = CONSTANTS.SITE_SPECIES_VALUES.COMPUTED
     })
-
-    it('is disabled when siteSpeciesValues is Supplied', () => {
-      mountTable(true, (store) => {
-        store.siteIndexRows = [makeRow('FD')]
-        store.siteSpeciesValues = CONSTANTS.SITE_SPECIES_VALUES.SUPPLIED
-      })
-      cy.get('tbody tr').eq(0).find('.site-spin-field').eq(0).find('input').should('be.disabled')
+    cy.then(() => {
+      useModelParameterStore().siteSpeciesValues = CONSTANTS.SITE_SPECIES_VALUES.SUPPLIED
     })
-
-    it('is disabled when computedValue is TOTAL_AGE', () => {
-      mountTable(true, (store) => {
-        store.siteIndexRows = [makeRow('FD', { computedValue: CONSTANTS.COMPUTED_VALUE.TOTAL_AGE })]
-        store.siteSpeciesValues = CONSTANTS.SITE_SPECIES_VALUES.COMPUTED
-      })
-      cy.get('tbody tr').eq(0).find('.site-spin-field').eq(0).find('input').should('be.disabled')
-    })
-
-    it('is disabled for non-primary rows when Computed + Volume', () => {
-      mountTable(true, (store) => {
-        store.siteIndexRows = [makeRow('FD'), makeRow('PL')]
-        store.siteSpeciesValues = CONSTANTS.SITE_SPECIES_VALUES.COMPUTED
-        store.derivedBy = CONSTANTS.DERIVED_BY.VOLUME
-      })
-      cy.get('tbody tr').eq(1).find('.site-spin-field').eq(0).find('input').should('be.disabled')
-    })
-  })
-
-  describe('Height spin field - disabled states', () => {
-    it('is disabled when isConfirmEnabled is false', () => {
-      mountTable(false, (store) => {
-        store.siteIndexRows = [makeRow('FD')]
-      })
-      cy.get('tbody tr').eq(0).find('.site-spin-field').eq(1).find('input').should('be.disabled')
-    })
-
-    it('is disabled when siteSpeciesValues is Supplied', () => {
-      mountTable(true, (store) => {
-        store.siteIndexRows = [makeRow('FD')]
-        store.siteSpeciesValues = CONSTANTS.SITE_SPECIES_VALUES.SUPPLIED
-      })
-      cy.get('tbody tr').eq(0).find('.site-spin-field').eq(1).find('input').should('be.disabled')
-    })
-
-    it('is disabled when computedValue is HEIGHT', () => {
-      mountTable(true, (store) => {
-        store.siteIndexRows = [makeRow('FD', { computedValue: CONSTANTS.COMPUTED_VALUE.HEIGHT })]
-        store.siteSpeciesValues = CONSTANTS.SITE_SPECIES_VALUES.COMPUTED
-      })
-      cy.get('tbody tr').eq(0).find('.site-spin-field').eq(1).find('input').should('be.disabled')
-    })
-
-    it('is disabled for non-primary rows when Computed + Volume', () => {
-      mountTable(true, (store) => {
-        store.siteIndexRows = [makeRow('FD'), makeRow('PL')]
-        store.siteSpeciesValues = CONSTANTS.SITE_SPECIES_VALUES.COMPUTED
-        store.derivedBy = CONSTANTS.DERIVED_BY.VOLUME
-      })
-      cy.get('tbody tr').eq(1).find('.site-spin-field').eq(1).find('input').should('be.disabled')
-    })
-  })
-
-  describe('BHA Site Index spin field - disabled states', () => {
-    it('is disabled when isConfirmEnabled is false', () => {
-      mountTable(false, (store) => {
-        store.siteIndexRows = [makeRow('FD')]
-      })
-      cy.get('tbody tr').eq(0).find('.site-spin-field').eq(2).find('input').should('be.disabled')
-    })
-
-    it('is NOT disabled when siteSpeciesValues is Supplied', () => {
-      mountTable(true, (store) => {
-        store.siteIndexRows = [makeRow('FD')]
-        store.siteSpeciesValues = CONSTANTS.SITE_SPECIES_VALUES.SUPPLIED
-      })
-      cy.get('tbody tr').eq(0).find('.site-spin-field').eq(2).find('input').should('not.be.disabled')
-    })
-
-    it('is disabled when computedValue is BHA_SITE_INDEX', () => {
-      mountTable(true, (store) => {
-        store.siteIndexRows = [makeRow('FD', { computedValue: CONSTANTS.COMPUTED_VALUE.BHA_SITE_INDEX })]
-        store.siteSpeciesValues = CONSTANTS.SITE_SPECIES_VALUES.COMPUTED
-      })
-      cy.get('tbody tr').eq(0).find('.site-spin-field').eq(2).find('input').should('be.disabled')
-    })
-
-    it('is disabled for non-primary rows when Computed + Volume', () => {
-      mountTable(true, (store) => {
-        store.siteIndexRows = [makeRow('FD'), makeRow('PL')]
-        store.siteSpeciesValues = CONSTANTS.SITE_SPECIES_VALUES.COMPUTED
-        store.derivedBy = CONSTANTS.DERIVED_BY.VOLUME
-      })
-      cy.get('tbody tr').eq(1).find('.site-spin-field').eq(2).find('input').should('be.disabled')
-    })
-  })
-
-  describe('Watch: siteSpeciesValues -> Supplied resets rows', () => {
-    it('clears age and height when switching to Supplied (DOM: Age input becomes N/A placeholder)', () => {
-      mountTable(true, (store) => {
-        store.siteIndexRows = [makeRow('FD')]
-        store.siteSpeciesValues = CONSTANTS.SITE_SPECIES_VALUES.COMPUTED
-      })
-      cy.then(() => {
-        useModelParameterStore().siteSpeciesValues = CONSTANTS.SITE_SPECIES_VALUES.SUPPLIED
-      })
-      // Cypress retries until Vue flushes the watcher
-      cy.get('tbody tr').eq(0).find('.site-spin-field').eq(0).find('input')
-        .should('have.attr', 'placeholder', CONSTANTS.SPECIAL_INDICATORS.NA)
-      cy.get('tbody tr').eq(0).find('.site-spin-field').eq(1).find('input')
-        .should('have.attr', 'placeholder', CONSTANTS.SPECIAL_INDICATORS.NA)
-    })
+    cy.get('tbody tr').eq(0).find('.site-spin-field').eq(0).find('input')
+      .should('have.attr', 'placeholder', CONSTANTS.SPECIAL_INDICATORS.NA)
+    cy.get('tbody tr').eq(0).find('.site-spin-field').eq(1).find('input')
+      .should('have.attr', 'placeholder', CONSTANTS.SPECIAL_INDICATORS.NA)
   })
 })

--- a/frontend/src/components/projection/input/site-info/SiteIndicesTable.stories.ts
+++ b/frontend/src/components/projection/input/site-info/SiteIndicesTable.stories.ts
@@ -37,14 +37,7 @@ export const Editable: Story = {
       ]
     },
     template: '<SiteIndicesTable :isConfirmEnabled="true" />',
-  }),
-  parameters: {
-    docs: {
-      description: {
-        story: 'Computed + Basal Area: all rows editable. Primary row has BHA Site Index computed (Calc. placeholder). Confirm is enabled.',
-      },
-    },
-  },
+  })
 }
 
 export const Disabled: Story = {
@@ -56,14 +49,7 @@ export const Disabled: Story = {
       store.siteIndexRows = [makeRow('FD'), makeRow('PL'), makeRow('S')]
     },
     template: '<SiteIndicesTable :isConfirmEnabled="false" />',
-  }),
-  parameters: {
-    docs: {
-      description: {
-        story: 'isConfirmEnabled = false: all inputs are disabled regardless of other state.',
-      },
-    },
-  },
+  })
 }
 
 export const Supplied: Story = {
@@ -78,14 +64,7 @@ export const Supplied: Story = {
       ]
     },
     template: '<SiteIndicesTable :isConfirmEnabled="true" />',
-  }),
-  parameters: {
-    docs: {
-      description: {
-        story: 'siteSpeciesValues = Supplied: Computed Value select shows N/A placeholder; Age and Height spin fields show N/A.',
-      },
-    },
-  },
+  })
 }
 
 export const ComputedVolumePrimaryOnly: Story = {
@@ -102,14 +81,7 @@ export const ComputedVolumePrimaryOnly: Story = {
       ]
     },
     template: '<SiteIndicesTable :isConfirmEnabled="true" />',
-  }),
-  parameters: {
-    docs: {
-      description: {
-        story: 'Computed + Volume: only the primary row (FD) is editable. Non-primary rows show N/A in all fields.',
-      },
-    },
-  },
+  })
 }
 
 export const TotalAgeComputed: Story = {
@@ -124,14 +96,7 @@ export const TotalAgeComputed: Story = {
       ]
     },
     template: '<SiteIndicesTable :isConfirmEnabled="true" />',
-  }),
-  parameters: {
-    docs: {
-      description: {
-        story: 'computedValue = Total Age: Age spin shows Calc. placeholder and is disabled; Height and BHA remain editable.',
-      },
-    },
-  },
+  })
 }
 
 export const HeightComputed: Story = {
@@ -146,14 +111,7 @@ export const HeightComputed: Story = {
       ]
     },
     template: '<SiteIndicesTable :isConfirmEnabled="true" />',
-  }),
-  parameters: {
-    docs: {
-      description: {
-        story: 'computedValue = Height in Meters: Height spin shows Calc. placeholder and is disabled; Age and BHA remain editable.',
-      },
-    },
-  },
+  })
 }
 
 export const Empty: Story = {
@@ -164,12 +122,5 @@ export const Empty: Story = {
       store.siteIndexRows = []
     },
     template: '<SiteIndicesTable :isConfirmEnabled="false" />',
-  }),
-  parameters: {
-    docs: {
-      description: {
-        story: 'No species rows - only the header and divider are rendered.',
-      },
-    },
-  },
+  })
 }

--- a/frontend/src/components/projection/input/site-info/SiteInfoPanel.cy.ts
+++ b/frontend/src/components/projection/input/site-info/SiteInfoPanel.cy.ts
@@ -35,137 +35,63 @@ const makeEditable = (modelStore: ReturnType<typeof useModelParameterStore>) => 
 }
 
 describe('<SiteInfoPanel />', () => {
-  describe('Panel structure', () => {
-    it('renders the "Site Information" heading', () => {
-      mountPanel()
-      cy.contains('.text-h6', 'Site Information').should('exist')
-    })
-
-    it('renders BEC Zone label and select', () => {
-      mountPanel((ms) => openPanel(ms))
-      cy.contains('label', 'BEC Zone').should('exist')
-      cy.get('#bec-zone-select').should('exist')
-    })
-
-    it('renders Eco Zone label and select', () => {
-      mountPanel((ms) => openPanel(ms))
-      cy.contains('label', 'Eco Zone').should('exist')
-      cy.get('#eco-zone-select').should('exist')
-    })
-
-    it('renders Site Index radio group', () => {
-      mountPanel((ms) => openPanel(ms))
-      cy.contains('label', 'Site Index:').should('exist')
-      cy.get('.site-index-container .v-radio-group').should('exist')
-    })
+  it('renders the "Site Information" heading', () => {
+    mountPanel()
+    cy.contains('.text-h6', 'Site Information').should('exist')
   })
 
-  describe('Expansion panel toggle', () => {
-    it('shows panel content when open', () => {
-      mountPanel((ms) => openPanel(ms))
-      cy.get('.v-expansion-panel-text').should('be.visible')
-    })
-
-    it('hides panel content when closed', () => {
-      mountPanel()
-      cy.get('.v-expansion-panel-text').should('not.be.visible')
-    })
-
-    it('shows chevron-down icon when panel is closed', () => {
-      mountPanel()
-      cy.get('i.expansion-panel-icon').should('have.class', 'mdi-chevron-down')
-    })
-
-    it('shows chevron-up icon when panel is open', () => {
-      mountPanel((ms) => openPanel(ms))
-      cy.get('i.expansion-panel-icon').should('have.class', 'mdi-chevron-up')
-    })
+  it('shows panel content when open', () => {
+    mountPanel((ms) => openPanel(ms))
+    cy.get('.v-expansion-panel-text').should('be.visible')
   })
 
-  describe('Input disabled states', () => {
-    it('BEC Zone is disabled when panel is not editable', () => {
-      mountPanel((ms) => openPanel(ms))
-      cy.get('#bec-zone-select').closest('.v-select').should('have.class', 'v-input--disabled')
-    })
-
-    it('BEC Zone is enabled when panel is editable', () => {
-      mountPanel((ms) => {
-        openPanel(ms)
-        makeEditable(ms)
-      })
-      cy.get('#bec-zone-select').closest('.v-select').should('not.have.class', 'v-input--disabled')
-    })
-
-    it('Eco Zone is disabled when panel is not editable', () => {
-      mountPanel((ms) => openPanel(ms))
-      cy.get('#eco-zone-select').closest('.v-select').should('have.class', 'v-input--disabled')
-    })
-
-    it('Site Index radio group is disabled when panel is not editable', () => {
-      mountPanel((ms) => openPanel(ms))
-      cy.get('.site-index-container .v-radio-group').should('have.class', 'v-input--disabled')
-    })
-
-    it('Site Index radio group is enabled when panel is editable', () => {
-      mountPanel((ms) => {
-        openPanel(ms)
-        makeEditable(ms)
-        ms.siteSpeciesValues = CONSTANTS.SITE_SPECIES_VALUES.COMPUTED
-      })
-      cy.get('.site-index-container .v-radio-group').should('not.have.class', 'v-input--disabled')
-    })
+  it('hides panel content when closed', () => {
+    mountPanel()
+    cy.get('.v-expansion-panel-text').should('not.be.visible')
   })
 
-  describe('ActionPanel visibility', () => {
-    it('hides ActionPanel buttons in read-only mode', () => {
-      mountPanel((ms, as) => {
-        openPanel(ms)
-        as.viewMode = PROJECTION_VIEW_MODE.VIEW
-      })
-      cy.contains('button', 'Cancel').should('not.exist')
-      cy.contains('button', 'Next').should('not.exist')
-    })
-
-    it('shows ActionPanel buttons in create mode', () => {
-      mountPanel((ms, as) => {
-        openPanel(ms)
-        makeEditable(ms)
-        as.viewMode = PROJECTION_VIEW_MODE.CREATE
-      })
-      cy.contains('button', 'Cancel').should('exist')
-      cy.contains('button', 'Next').should('exist')
-    })
+  it('BEC Zone is disabled when panel is not editable', () => {
+    mountPanel((ms) => openPanel(ms))
+    cy.get('#bec-zone-select').closest('.v-select').should('have.class', 'v-input--disabled')
   })
 
-  describe('Header Edit button', () => {
-    it('renders Edit button in the header when not in read-only mode', () => {
-      mountPanel((ms) => openPanel(ms))
-      cy.get('.edit-button-col').should('exist')
+  it('BEC Zone is enabled when panel is editable', () => {
+    mountPanel((ms) => {
+      openPanel(ms)
+      makeEditable(ms)
     })
-
-    it('does not render Edit button in read-only mode', () => {
-      mountPanel((ms, as) => {
-        openPanel(ms)
-        as.viewMode = PROJECTION_VIEW_MODE.VIEW
-      })
-      cy.get('.edit-button-col').should('not.exist')
-    })
+    cy.get('#bec-zone-select').closest('.v-select').should('not.have.class', 'v-input--disabled')
   })
 
-  describe('SiteIndicesTable (feature flag on)', () => {
-    it('renders SiteIndicesTable subtitle when VITE_SITE_INDICES_TABLE_ENABLED is true', () => {
-      mountPanel((ms) => openPanel(ms))
-      cy.contains('.text-subtitle-2', 'Site Indices').should('exist')
-    })
+  it('Site Index radio group is disabled when panel is not editable', () => {
+    mountPanel((ms) => openPanel(ms))
+    cy.get('.site-index-container .v-radio-group').should('have.class', 'v-input--disabled')
+  })
 
-    it('renders the site indices table', () => {
-      mountPanel((ms) => openPanel(ms))
-      cy.get('table').should('exist')
+  it('hides ActionPanel buttons in read-only mode', () => {
+    mountPanel((ms, as) => {
+      openPanel(ms)
+      as.viewMode = PROJECTION_VIEW_MODE.VIEW
     })
+    cy.contains('button', 'Cancel').should('not.exist')
+    cy.contains('button', 'Next').should('not.exist')
+  })
 
-    it('does not render Site Species select in new layout', () => {
-      mountPanel((ms) => openPanel(ms))
-      cy.get('[data-testid="selected-site-species"]').should('not.exist')
+  it('shows ActionPanel buttons in create mode', () => {
+    mountPanel((ms, as) => {
+      openPanel(ms)
+      makeEditable(ms)
+      as.viewMode = PROJECTION_VIEW_MODE.CREATE
     })
+    cy.contains('button', 'Cancel').should('exist')
+    cy.contains('button', 'Next').should('exist')
+  })
+
+  it('does not render Edit button in read-only mode', () => {
+    mountPanel((ms, as) => {
+      openPanel(ms)
+      as.viewMode = PROJECTION_VIEW_MODE.VIEW
+    })
+    cy.get('.edit-button-col').should('not.exist')
   })
 })

--- a/frontend/src/components/projection/input/site-info/SiteInfoPanel.stories.ts
+++ b/frontend/src/components/projection/input/site-info/SiteInfoPanel.stories.ts
@@ -49,14 +49,7 @@ export const EditableComputed: Story = {
       ]
     },
     template: '<SiteInfoPanel />',
-  }),
-  parameters: {
-    docs: {
-      description: {
-        story: 'Editable state with Site Index = Computed and three species rows. BHA Site Index is the computed field for the primary row (FD).',
-      },
-    },
-  },
+  })
 }
 
 export const EditableSupplied: Story = {
@@ -82,14 +75,7 @@ export const EditableSupplied: Story = {
       ]
     },
     template: '<SiteInfoPanel />',
-  }),
-  parameters: {
-    docs: {
-      description: {
-        story: 'Editable state with Site Index = Supplied. Age and Height columns are N/A; BHA Site Index is entered directly.',
-      },
-    },
-  },
+  })
 }
 
 export const Confirmed: Story = {
@@ -116,14 +102,7 @@ export const Confirmed: Story = {
       ]
     },
     template: '<SiteInfoPanel />',
-  }),
-  parameters: {
-    docs: {
-      description: {
-        story: 'Confirmed state - all inputs are disabled and the ActionPanel shows the Edit button.',
-      },
-    },
-  },
+  })
 }
 
 export const ReadOnly: Story = {
@@ -147,14 +126,7 @@ export const ReadOnly: Story = {
       modelStore.siteIndexRows = [makeRow('S'), makeRow('FD')]
     },
     template: '<SiteInfoPanel />',
-  }),
-  parameters: {
-    docs: {
-      description: {
-        story: 'Read-only (view) mode - all inputs are disabled and the ActionPanel is hidden entirely.',
-      },
-    },
-  },
+  })
 }
 
 export const ComputedVolume: Story = {
@@ -182,14 +154,7 @@ export const ComputedVolume: Story = {
       ]
     },
     template: '<SiteInfoPanel />',
-  }),
-  parameters: {
-    docs: {
-      description: {
-        story: 'Computed + Volume: only the primary row (FD) is editable. Non-primary rows show N/A in all fields.',
-      },
-    },
-  },
+  })
 }
 
 export const PanelCollapsed: Story = {
@@ -205,12 +170,5 @@ export const PanelCollapsed: Story = {
       modelStore.panelState.siteInfo.confirmed = false
     },
     template: '<SiteInfoPanel />',
-  }),
-  parameters: {
-    docs: {
-      description: {
-        story: 'Panel in collapsed state. Only the "Site Information" header with the chevron icon is visible.',
-      },
-    },
-  },
+  })
 }

--- a/frontend/src/components/projection/input/site-info/SiteInfoPanel.vue
+++ b/frontend/src/components/projection/input/site-info/SiteInfoPanel.vue
@@ -248,6 +248,7 @@
               :hideClearButton="true"
               :hideEditButton="true"
               :showCancelButton="true"
+              :isCancelEnabled="isDirty"
               @confirm="onConfirm"
               @cancel="onCancel"
             />
@@ -259,7 +260,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch } from 'vue'
+import { ref, computed, watch, nextTick } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useModelParameterStore } from '@/stores/projection/modelParameterStore'
 import { useAppStore } from '@/stores/projection/appStore'
@@ -324,6 +325,23 @@ const isConfirmed = computed(
 const isInputDisabled = computed(
   () => isReadOnly.value || !modelParameterStore.panelState[panelName].editable,
 )
+
+const isDirty = ref(false)
+let suppressDirtyTracking = false
+const markDirty = () => { if (!suppressDirtyTracking) isDirty.value = true }
+
+watch(() => modelParameterStore.panelState[panelName].editable, (editable, wasEditable) => {
+  if (editable && !wasEditable) isDirty.value = false
+})
+
+watch(selectedSiteSpecies, markDirty)
+watch(becZone, markDirty)
+watch(ecoZone, markDirty)
+watch(siteSpeciesValues, markDirty, { deep: true })
+watch(ageType, markDirty)
+watch(spzAge, markDirty)
+watch(spzHeight, markDirty)
+watch(bha50SiteIndex, markDirty)
 
 const siteSpeciesOptions = computed(() =>
   speciesGroups.value.map((group: SpeciesGroup) => ({
@@ -605,6 +623,7 @@ const onConfirm = async () => {
     appStore.isSavingProjection = false
   }
 
+  isDirty.value = false
   if (!isConfirmed.value) modelParameterStore.confirmPanel(panelName)
 }
 
@@ -666,14 +685,18 @@ const onHeaderEdit = async () => {
 }
 
 const onCancel = async () => {
+  suppressDirtyTracking = true
   appStore.isSavingProjection = true
   try {
     await revertPanelToSaved(panelName)
+    await nextTick()
+    isDirty.value = false
   } catch (error) {
     console.error(PROJECTION_ERR.REVERT_ERROR_LOG, error)
     notificationStore.showErrorMessage(PROJECTION_ERR.LOAD_FAILED, PROJECTION_ERR.LOAD_FAILED_TITLE)
   } finally {
     appStore.isSavingProjection = false
+    suppressDirtyTracking = false
   }
 }
 

--- a/frontend/src/components/projection/input/species-info/SpeciesInfoPanel.cy.ts
+++ b/frontend/src/components/projection/input/species-info/SpeciesInfoPanel.cy.ts
@@ -43,63 +43,57 @@ const addSpecies = (modelStore: ReturnType<typeof useModelParameterStore>) => {
 
 describe('<SpeciesInfoPanel />', () => {
   describe('Input disabled states', () => {
-    it('radio group is disabled when panel is not editable', () => {
+    it('inputs are disabled when panel is not editable', () => {
       mountPanel((ms) => openPanel(ms))
       cy.get('.v-radio-group').should('have.class', 'v-input--disabled')
+      cy.contains('button', 'Add Species').should('be.disabled')
     })
 
-    it('radio group is enabled when panel is editable', () => {
+    it('inputs are enabled when panel is editable', () => {
       mountPanel((ms) => {
         openPanel(ms)
         makeEditable(ms)
       })
       cy.get('.v-radio-group').should('not.have.class', 'v-input--disabled')
-    })
-
-    it('"Add Species" button is disabled when panel is not editable', () => {
-      mountPanel((ms) => openPanel(ms))
-      cy.contains('button', 'Add Species').should('be.disabled')
-    })
-
-    it('"Add Species" button is enabled when panel is editable', () => {
-      mountPanel((ms) => {
-        openPanel(ms)
-        makeEditable(ms)
-      })
       cy.contains('button', 'Add Species').should('not.be.disabled')
     })
   })
 
-  describe('Add Species button visibility', () => {
-    it('shows "Add Species" button in create mode', () => {
+  describe('Add Species and Edit button visibility', () => {
+    it('shows "Add Species" and Edit buttons in create mode', () => {
       mountPanel((ms, as) => {
         openPanel(ms)
         as.viewMode = PROJECTION_VIEW_MODE.CREATE
       })
       cy.contains('button', 'Add Species').should('exist')
+      cy.get('.edit-button-col').should('exist')
     })
 
-    it('hides "Add Species" button in read-only mode', () => {
+    it('hides "Add Species" and Edit buttons in read-only mode', () => {
       mountPanel((ms, as) => {
         openPanel(ms)
         as.viewMode = PROJECTION_VIEW_MODE.VIEW
       })
       cy.get('.add-species-btn-col').should('not.exist')
+      cy.get('.edit-button-col').should('not.exist')
+    })
+
+    it('Edit button is disabled when panel is not confirmed', () => {
+      mountPanel((ms) => {
+        openPanel(ms)
+        ms.panelState.speciesInfo.confirmed = false
+        ms.panelState.speciesInfo.editable = true
+      })
+      cy.get('.edit-button-col button').should('be.disabled')
     })
   })
 
   describe('Total species percent display', () => {
-    it('shows total species percentage when species are present', () => {
-      mountPanel((ms) => {
-        openPanel(ms)
-        addSpecies(ms)
-      })
-      cy.contains('Total Species Percentage:').should('be.visible')
-    })
-
-    it('does not show total percentage row when no species are added', () => {
-      mountPanel((ms) => openPanel(ms))
+    it('shows total percentage when species are present, hides when none', () => {
+      const { modelStore } = mountPanel((ms) => openPanel(ms))
       cy.contains('Total Species Percentage:').should('not.exist')
+      cy.then(() => addSpecies(modelStore))
+      cy.contains('Total Species Percentage:').should('be.visible')
     })
 
     it('shows percentage error when total does not equal 100', () => {
@@ -109,20 +103,6 @@ describe('<SpeciesInfoPanel />', () => {
         ms.speciesList = [{ species: 'FD', percent: '50.0' }]
       })
       cy.contains('Percentages must add up to 100%').should('be.visible')
-    })
-
-    it('does not show percentage error when total equals 100', () => {
-      const { modelStore } = mountPanel((ms) => {
-        openPanel(ms)
-        makeEditable(ms)
-      })
-      cy.then(() => {
-        modelStore.speciesList = [
-          { species: 'FD', percent: '60.0' },
-          { species: 'PL', percent: '40.0' },
-        ]
-      })
-      cy.contains('Percentages must add up to 100%').should('not.exist')
     })
   })
 
@@ -144,30 +124,6 @@ describe('<SpeciesInfoPanel />', () => {
       })
       cy.contains('button', 'Cancel').should('exist')
       cy.contains('button', 'Next').should('exist')
-    })
-  })
-
-  describe('Header Edit button', () => {
-    it('renders Edit button in the header when not in read-only mode', () => {
-      mountPanel((ms) => openPanel(ms))
-      cy.get('.edit-button-col').should('exist')
-    })
-
-    it('does not render Edit button in read-only mode', () => {
-      mountPanel((ms, as) => {
-        openPanel(ms)
-        as.viewMode = PROJECTION_VIEW_MODE.VIEW
-      })
-      cy.get('.edit-button-col').should('not.exist')
-    })
-
-    it('Edit button is disabled when panel is not confirmed', () => {
-      mountPanel((ms) => {
-        openPanel(ms)
-        ms.panelState.speciesInfo.confirmed = false
-        ms.panelState.speciesInfo.editable = true
-      })
-      cy.get('.edit-button-col button').should('be.disabled')
     })
   })
 })

--- a/frontend/src/components/projection/input/species-info/SpeciesInfoPanel.vue
+++ b/frontend/src/components/projection/input/species-info/SpeciesInfoPanel.vue
@@ -118,6 +118,7 @@
               :hideClearButton="true"
               :hideEditButton="true"
               :showCancelButton="true"
+              :isCancelEnabled="isDirty"
               @confirm="onConfirm"
               @cancel="onCancel"
             />
@@ -128,7 +129,7 @@
   </v-card>
 </template>
 <script setup lang="ts">
-import { ref, watch, computed } from 'vue'
+import { ref, watch, computed, nextTick } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useModelParameterStore } from '@/stores/projection/modelParameterStore'
 import { useAppStore } from '@/stores/projection/appStore'
@@ -203,6 +204,17 @@ const showPercentageError = computed(
 const updateSpeciesGroup = modelParameterStore.updateSpeciesGroup
 
 watch(speciesList, () => updateSpeciesGroup(), { deep: true })
+
+const isDirty = ref(false)
+let suppressDirtyTracking = false
+const markDirty = () => { if (!suppressDirtyTracking) isDirty.value = true }
+
+watch(() => modelParameterStore.panelState[panelName].editable, (editable, wasEditable) => {
+  if (editable && !wasEditable) isDirty.value = false
+})
+
+watch(speciesList, markDirty, { deep: true })
+watch(derivedBy, markDirty)
 
 // --- Modal ---
 const modalOpen = ref(false)
@@ -291,6 +303,7 @@ const onConfirm = async () => {
     appStore.isSavingProjection = false
   }
 
+  isDirty.value = false
   if (!isConfirmed.value) {
     modelParameterStore.confirmPanel(panelName)
   }
@@ -362,14 +375,18 @@ const onHeaderEdit = async () => {
 }
 
 const onCancel = async () => {
+  suppressDirtyTracking = true
   appStore.isSavingProjection = true
   try {
     await revertPanelToSaved(panelName)
+    await nextTick()
+    isDirty.value = false
   } catch (error) {
     console.error(PROJECTION_ERR.REVERT_ERROR_LOG, error)
     notificationStore.showErrorMessage(PROJECTION_ERR.LOAD_FAILED, PROJECTION_ERR.LOAD_FAILED_TITLE)
   } finally {
     appStore.isSavingProjection = false
+    suppressDirtyTracking = false
   }
 }
 

--- a/frontend/src/components/projection/input/stand-info/StandInfoPanel.cy.ts
+++ b/frontend/src/components/projection/input/stand-info/StandInfoPanel.cy.ts
@@ -35,41 +35,17 @@ const makeEditable = (modelStore: ReturnType<typeof useModelParameterStore>) => 
 }
 
 describe('<StandInfoPanel />', () => {
-  describe('Panel structure', () => {
-    it('renders the "Stand Information" heading', () => {
-      mountPanel()
-      cy.contains('.text-h6', 'Stand Information').should('exist')
-    })
-
-    it('renders all four input fields when panel is open', () => {
-      mountPanel((ms) => openPanel(ms))
-      cy.get('[data-testid="percent-stockable-area"]').should('exist')
-      cy.get('[data-testid="crown-closure"]').should('exist')
-      cy.get('[data-testid="basal-area"]').should('exist')
-      cy.get('[data-testid="trees-per-hectare"]').should('exist')
-    })
+  it('renders all four input fields when panel is open', () => {
+    mountPanel((ms) => openPanel(ms))
+    cy.get('[data-testid="percent-stockable-area"]').should('exist')
+    cy.get('[data-testid="crown-closure"]').should('exist')
+    cy.get('[data-testid="basal-area"]').should('exist')
+    cy.get('[data-testid="trees-per-hectare"]').should('exist')
   })
 
-  describe('Expansion panel toggle', () => {
-    it('shows panel content when open', () => {
-      mountPanel((ms) => openPanel(ms))
-      cy.get('.v-expansion-panel-text').should('be.visible')
-    })
-
-    it('hides panel content when closed', () => {
-      mountPanel()
-      cy.get('.v-expansion-panel-text').should('not.be.visible')
-    })
-
-    it('shows chevron-down icon when panel is closed', () => {
-      mountPanel()
-      cy.get('i.expansion-panel-icon').should('have.class', 'mdi-chevron-down')
-    })
-
-    it('shows chevron-up icon when panel is open', () => {
-      mountPanel((ms) => openPanel(ms))
-      cy.get('i.expansion-panel-icon').should('have.class', 'mdi-chevron-up')
-    })
+  it('shows panel content when open', () => {
+    mountPanel((ms) => openPanel(ms))
+    cy.get('.v-expansion-panel-text').should('be.visible')
   })
 
   describe('Input disabled states', () => {
@@ -136,62 +112,24 @@ describe('<StandInfoPanel />', () => {
     })
   })
 
-  describe('Header Edit button', () => {
-    it('renders Edit button in the header when not in read-only mode', () => {
-      mountPanel((ms) => openPanel(ms))
-      cy.get('.edit-button-col').should('exist')
+  it('shows required error when Percent Stockable Area is empty', () => {
+    mountPanel((ms) => {
+      openPanel(ms)
+      makeEditable(ms)
+      ms.percentStockableArea = null
+      ms.derivedBy = CONSTANTS.DERIVED_BY.BASAL_AREA
+      ms.siteSpeciesValues = CONSTANTS.SITE_SPECIES_VALUES.COMPUTED
     })
-
-    it('does not render Edit button in read-only mode', () => {
-      mountPanel((ms, as) => {
-        openPanel(ms)
-        as.viewMode = PROJECTION_VIEW_MODE.VIEW
-      })
-      cy.get('.edit-button-col').should('not.exist')
-    })
+    cy.contains('button', 'Next').click()
+    cy.get('[data-testid="percent-stockable-area"]')
+      .find('.v-messages__message')
+      .should('contain.text', MESSAGE.MDL_PRM_INPUT_ERR.DENSITY_VLD_PCT_STCB_AREA_REQ)
   })
 
-  describe('Confirm validation errors', () => {
-    it('shows required error when Percent Stockable Area is empty', () => {
-      mountPanel((ms) => {
-        openPanel(ms)
-        makeEditable(ms)
-        ms.percentStockableArea = null
-        ms.derivedBy = CONSTANTS.DERIVED_BY.BASAL_AREA
-        ms.siteSpeciesValues = CONSTANTS.SITE_SPECIES_VALUES.COMPUTED
-      })
-      cy.contains('button', 'Next').click()
-      cy.get('[data-testid="percent-stockable-area"]')
-        .find('.v-messages__message')
-        .should('contain.text', MESSAGE.MDL_PRM_INPUT_ERR.DENSITY_VLD_PCT_STCB_AREA_REQ)
-    })
-
-    it('shows range error when Percent Stockable Area is out of range', () => {
-      mountPanel((ms) => {
-        openPanel(ms)
-        makeEditable(ms)
-        ms.percentStockableArea = '150'
-        ms.derivedBy = CONSTANTS.DERIVED_BY.BASAL_AREA
-        ms.siteSpeciesValues = CONSTANTS.SITE_SPECIES_VALUES.COMPUTED
-      })
-      cy.contains('button', 'Next').click()
-      cy.get('[data-testid="percent-stockable-area"]')
-        .find('.v-messages__message')
-        .should('contain.text', MESSAGE.MDL_PRM_INPUT_ERR.DENSITY_VLD_PCT_STCB_AREA_RNG)
-    })
-  })
-
-  describe('Min DBH Limit display', () => {
-    it('does not render min-dbh-limit block when minDBHLimit is null', () => {
-      mountPanel((ms) => openPanel(ms))
-      cy.get('[data-testid="min-dbh-limit"]').should('not.exist')
-    })
-
-    it('renders min-dbh-limit block when minDBHLimit is set', () => {
-      const { modelStore } = mountPanel((ms) => openPanel(ms))
-      cy.then(() => { modelStore.minDBHLimit = '12.5 cm' })
-      cy.get('[data-testid="min-dbh-limit"]').should('exist')
-      cy.get('.min-dbh-value').should('contain', '12.5 cm')
-    })
+  it('renders min-dbh-limit block when minDBHLimit is set', () => {
+    const { modelStore } = mountPanel((ms) => openPanel(ms))
+    cy.then(() => { modelStore.minDBHLimit = '12.5 cm' })
+    cy.get('[data-testid="min-dbh-limit"]').should('exist')
+    cy.get('.min-dbh-value').should('contain', '12.5 cm')
   })
 })

--- a/frontend/src/components/projection/input/stand-info/StandInfoPanel.vue
+++ b/frontend/src/components/projection/input/stand-info/StandInfoPanel.vue
@@ -137,6 +137,7 @@
               :hideClearButton="true"
               :hideEditButton="true"
               :showCancelButton="true"
+              :isCancelEnabled="isDirty"
               @confirm="onConfirm"
               @cancel="onCancel"
             />
@@ -148,7 +149,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch } from 'vue'
+import { ref, computed, watch, nextTick } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useModelParameterStore } from '@/stores/projection/modelParameterStore'
 import { useAppStore } from '@/stores/projection/appStore'
@@ -210,6 +211,21 @@ const isConfirmed = computed(
 const isInputDisabled = computed(
   () => isReadOnly.value || !modelParameterStore.panelState[panelName].editable,
 )
+
+const isDirty = ref(false)
+let suppressDirtyTracking = false
+const markDirty = () => { if (!suppressDirtyTracking) isDirty.value = true }
+
+watch(() => modelParameterStore.panelState[panelName].editable, (editable, wasEditable) => {
+  if (editable && !wasEditable) isDirty.value = false
+})
+
+watch(percentStockableArea, markDirty)
+watch(basalArea, markDirty)
+watch(treesPerHectare, markDirty)
+watch(crownClosure, markDirty)
+watch(minDBHLimit, markDirty)
+watch(currentDiameter, markDirty)
 
 const isCrownClosureDisabled = ref(false)
 const isBasalAreaDisabled = ref(false)
@@ -489,6 +505,7 @@ const onConfirm = async () => {
     appStore.isSavingProjection = false
   }
 
+  isDirty.value = false
   if (!isConfirmed.value) {
     modelParameterStore.confirmPanel(panelName)
   }
@@ -552,14 +569,18 @@ const onHeaderEdit = async () => {
 }
 
 const onCancel = async () => {
+  suppressDirtyTracking = true
   appStore.isSavingProjection = true
   try {
     await revertPanelToSaved(panelName)
+    await nextTick()
+    isDirty.value = false
   } catch (error) {
     console.error(PROJECTION_ERR.REVERT_ERROR_LOG, error)
     notificationStore.showErrorMessage(PROJECTION_ERR.LOAD_FAILED, PROJECTION_ERR.LOAD_FAILED_TITLE)
   } finally {
     appStore.isSavingProjection = false
+    suppressDirtyTracking = false
   }
 }
 </script>

--- a/frontend/src/components/projection/list/ProjectionPagination.cy.ts
+++ b/frontend/src/components/projection/list/ProjectionPagination.cy.ts
@@ -35,193 +35,87 @@ describe('ProjectionPagination.vue', () => {
     })
   }
 
-  describe('rendering', () => {
-    it('renders the pagination container', () => {
-      mountComponent()
+  it('displays correct pagination info', () => {
+    mountComponent({ currentPage: 1, itemsPerPage: 10, totalItems: 100 })
 
-      cy.get('.pagination-container').should('exist')
-    })
-
-    it('displays correct pagination info', () => {
-      mountComponent({ currentPage: 1, itemsPerPage: 10, totalItems: 100 })
-
-      cy.get('.pagination-info-left').should(
-        'contain.text',
-        'Showing 1 to 10 of 100',
-      )
-    })
-
-    it('displays correct pagination info for middle page', () => {
-      mountComponent({ currentPage: 3, itemsPerPage: 10, totalItems: 100 })
-
-      cy.get('.pagination-info-left').should(
-        'contain.text',
-        'Showing 21 to 30 of 100',
-      )
-    })
-
-    it('displays correct pagination info for last page with partial items', () => {
-      mountComponent({ currentPage: 5, itemsPerPage: 10, totalItems: 45 })
-
-      cy.get('.pagination-info-left').should(
-        'contain.text',
-        'Showing 41 to 45 of 45',
-      )
-    })
-
-    it('renders page number buttons', () => {
-      mountComponent({ currentPage: 1, itemsPerPage: 10, totalItems: 50 })
-
-      cy.get('.pagination-number').should('have.length.at.least', 1)
-    })
-
-    it('renders navigation arrows', () => {
-      mountComponent()
-
-      cy.get('.pagination-arrow').should('have.length', 2)
-    })
+    cy.get('.pagination-info-left').should('contain.text', 'Showing 1 to 10 of 100')
   })
 
-  describe('navigation', () => {
-    it('disables previous arrow on first page', () => {
-      mountComponent({ currentPage: 1 })
+  it('displays correct pagination info for last page with partial items', () => {
+    mountComponent({ currentPage: 5, itemsPerPage: 10, totalItems: 45 })
 
-      cy.get('.pagination-arrow').first().should('be.disabled')
-    })
-
-    it('disables next arrow on last page', () => {
-      mountComponent({ currentPage: 10, itemsPerPage: 10, totalItems: 100 })
-
-      cy.get('.pagination-arrow').last().should('be.disabled')
-    })
-
-    it('disables next arrow when totalItems is 0', () => {
-      mountComponent({ currentPage: 1, itemsPerPage: 10, totalItems: 0 })
-
-      cy.get('.pagination-arrow').last().should('be.disabled')
-    })
-
-    it('disables previous arrow when totalItems is 0', () => {
-      mountComponent({ currentPage: 1, itemsPerPage: 10, totalItems: 0 })
-
-      cy.get('.pagination-arrow').first().should('be.disabled')
-    })
-
-    it('enables both arrows on middle page', () => {
-      mountComponent({ currentPage: 5, itemsPerPage: 10, totalItems: 100 })
-
-      cy.get('.pagination-arrow').first().should('not.be.disabled')
-      cy.get('.pagination-arrow').last().should('not.be.disabled')
-    })
-
-    it('emits update:currentPage when clicking previous arrow', () => {
-      const onUpdateCurrentPage = cy.spy().as('updateCurrentPageSpy')
-      mountComponent({ currentPage: 5 }, { 'onUpdate:currentPage': onUpdateCurrentPage })
-
-      cy.get('.pagination-arrow').first().click()
-      cy.get('@updateCurrentPageSpy').should('have.been.calledWith', 4)
-    })
-
-    it('emits update:currentPage when clicking next arrow', () => {
-      const onUpdateCurrentPage = cy.spy().as('updateCurrentPageSpy')
-      mountComponent({ currentPage: 5 }, { 'onUpdate:currentPage': onUpdateCurrentPage })
-
-      cy.get('.pagination-arrow').last().click()
-      cy.get('@updateCurrentPageSpy').should('have.been.calledWith', 6)
-    })
-
-    it('emits update:currentPage when clicking page number', () => {
-      const onUpdateCurrentPage = cy.spy().as('updateCurrentPageSpy')
-      mountComponent(
-        { currentPage: 1, itemsPerPage: 10, totalItems: 50 },
-        { 'onUpdate:currentPage': onUpdateCurrentPage },
-      )
-
-      cy.get('.pagination-number').contains('3').click()
-      cy.get('@updateCurrentPageSpy').should('have.been.calledWith', 3)
-    })
-
-    it('does not emit update:currentPage when clicking the current active page', () => {
-      const onUpdateCurrentPage = cy.spy().as('updateCurrentPageSpy')
-      mountComponent(
-        { currentPage: 3, itemsPerPage: 10, totalItems: 50 },
-        { 'onUpdate:currentPage': onUpdateCurrentPage },
-      )
-
-      cy.get('.pagination-number').contains('3').click()
-      cy.get('@updateCurrentPageSpy').should('not.have.been.called')
-    })
+    cy.get('.pagination-info-left').should('contain.text', 'Showing 41 to 45 of 45')
   })
 
-  describe('active page highlighting', () => {
-    it('highlights current page with active class', () => {
-      mountComponent({ currentPage: 3, itemsPerPage: 10, totalItems: 50 })
+  it('disables previous arrow on first page and next arrow on last page', () => {
+    mountComponent({ currentPage: 1, itemsPerPage: 10, totalItems: 100 })
+    cy.get('.pagination-arrow').first().should('be.disabled')
 
-      cy.get('.pagination-number').contains('3').should('have.class', 'active')
-    })
-
-    it('does not highlight other pages', () => {
-      mountComponent({ currentPage: 3, itemsPerPage: 10, totalItems: 50 })
-
-      cy.get('.pagination-number').contains('1').should('not.have.class', 'active')
-      cy.get('.pagination-number').contains('2').should('not.have.class', 'active')
-    })
+    mountComponent({ currentPage: 10, itemsPerPage: 10, totalItems: 100 })
+    cy.get('.pagination-arrow').last().should('be.disabled')
   })
 
-  describe('visiblePages', () => {
-    it('shows all pages when totalPages is 7 or fewer', () => {
-      mountComponent({ currentPage: 1, itemsPerPage: 10, totalItems: 70 })
+  it('disables both arrows when totalItems is 0', () => {
+    mountComponent({ currentPage: 1, itemsPerPage: 10, totalItems: 0 })
 
-      // totalPages = 7: [1, 2, 3, 4, 5, 6, 7]
-      cy.get('.pagination-number').should('have.length', 7)
-      cy.get('.pagination-number').first().should('contain.text', '1')
-      cy.get('.pagination-number').last().should('contain.text', '7')
-    })
-
-    it('shows 5 leading pages, ellipsis, and last page when current page <= 4', () => {
-      mountComponent({ currentPage: 2, itemsPerPage: 10, totalItems: 200 })
-
-      // totalPages = 20, current <= 4: [1, 2, 3, 4, 5, -1, 20]
-      cy.get('.pagination-number').should('have.length', 7)
-      cy.get('.pagination-number').eq(0).should('contain.text', '1')
-      cy.get('.pagination-number').eq(4).should('contain.text', '5')
-      cy.get('.pagination-number').eq(5).should('contain.text', '-1')
-      cy.get('.pagination-number').eq(6).should('contain.text', '20')
-    })
-
-    it('shows first page, ellipsis, and 5 trailing pages when current page is near end', () => {
-      mountComponent({ currentPage: 18, itemsPerPage: 10, totalItems: 200 })
-
-      // totalPages = 20, current >= 17: [1, -1, 16, 17, 18, 19, 20]
-      cy.get('.pagination-number').should('have.length', 7)
-      cy.get('.pagination-number').eq(0).should('contain.text', '1')
-      cy.get('.pagination-number').eq(1).should('contain.text', '-1')
-      cy.get('.pagination-number').eq(2).should('contain.text', '16')
-      cy.get('.pagination-number').last().should('contain.text', '20')
-    })
-
-    it('shows first page, ellipsis, 3 middle pages, ellipsis, and last page for middle pages', () => {
-      mountComponent({ currentPage: 10, itemsPerPage: 10, totalItems: 200 })
-
-      // totalPages = 20, middle: [1, -1, 9, 10, 11, -1, 20]
-      cy.get('.pagination-number').should('have.length', 7)
-      cy.get('.pagination-number').eq(0).should('contain.text', '1')
-      cy.get('.pagination-number').eq(1).should('contain.text', '-1')
-      cy.get('.pagination-number').eq(2).should('contain.text', '9')
-      cy.get('.pagination-number').eq(3).should('contain.text', '10')
-      cy.get('.pagination-number').eq(4).should('contain.text', '11')
-      cy.get('.pagination-number').eq(5).should('contain.text', '-1')
-      cy.get('.pagination-number').eq(6).should('contain.text', '20')
-    })
+    cy.get('.pagination-arrow').first().should('be.disabled')
+    cy.get('.pagination-arrow').last().should('be.disabled')
   })
 
-  describe('items per page', () => {
-    it('renders items per page selector', () => {
-      mountComponent()
+  it('enables both arrows on middle page', () => {
+    mountComponent({ currentPage: 5, itemsPerPage: 10, totalItems: 100 })
 
-      cy.get('.items-per-page-select').should('exist')
-      cy.get('.pagination-controls').should('contain.text', 'Show')
-      cy.get('.pagination-controls').should('contain.text', 'entries')
-    })
+    cy.get('.pagination-arrow').first().should('not.be.disabled')
+    cy.get('.pagination-arrow').last().should('not.be.disabled')
+  })
+
+  it('emits update:currentPage when clicking previous arrow', () => {
+    const onUpdateCurrentPage = cy.spy().as('updateCurrentPageSpy')
+    mountComponent({ currentPage: 5 }, { 'onUpdate:currentPage': onUpdateCurrentPage })
+
+    cy.get('.pagination-arrow').first().click()
+    cy.get('@updateCurrentPageSpy').should('have.been.calledWith', 4)
+  })
+
+  it('emits update:currentPage when clicking next arrow', () => {
+    const onUpdateCurrentPage = cy.spy().as('updateCurrentPageSpy')
+    mountComponent({ currentPage: 5 }, { 'onUpdate:currentPage': onUpdateCurrentPage })
+
+    cy.get('.pagination-arrow').last().click()
+    cy.get('@updateCurrentPageSpy').should('have.been.calledWith', 6)
+  })
+
+  it('emits update:currentPage when clicking page number, not when clicking current page', () => {
+    const onUpdateCurrentPage = cy.spy().as('updateCurrentPageSpy')
+    mountComponent(
+      { currentPage: 3, itemsPerPage: 10, totalItems: 50 },
+      { 'onUpdate:currentPage': onUpdateCurrentPage },
+    )
+
+    cy.get('.pagination-number').contains('3').click()
+    cy.get('@updateCurrentPageSpy').should('not.have.been.called')
+
+    cy.get('.pagination-number').contains('1').click()
+    cy.get('@updateCurrentPageSpy').should('have.been.calledWith', 1)
+  })
+
+  it('highlights current page with active class', () => {
+    mountComponent({ currentPage: 3, itemsPerPage: 10, totalItems: 50 })
+
+    cy.get('.pagination-number').contains('3').should('have.class', 'active')
+    cy.get('.pagination-number').contains('1').should('not.have.class', 'active')
+  })
+
+  it('shows first, ellipsis, 3 middle pages, ellipsis, and last for middle page', () => {
+    mountComponent({ currentPage: 10, itemsPerPage: 10, totalItems: 200 })
+
+    cy.get('.pagination-number').should('have.length', 7)
+    cy.get('.pagination-number').eq(0).should('contain.text', '1')
+    cy.get('.pagination-number').eq(1).should('contain.text', '-1')
+    cy.get('.pagination-number').eq(2).should('contain.text', '9')
+    cy.get('.pagination-number').eq(3).should('contain.text', '10')
+    cy.get('.pagination-number').eq(4).should('contain.text', '11')
+    cy.get('.pagination-number').eq(5).should('contain.text', '-1')
+    cy.get('.pagination-number').eq(6).should('contain.text', '20')
   })
 })

--- a/frontend/src/components/projection/list/ProjectionPagination.stories.ts
+++ b/frontend/src/components/projection/list/ProjectionPagination.stories.ts
@@ -24,32 +24,7 @@ const meta: Meta<typeof ProjectionPagination> = {
       control: { type: 'object' },
       description: 'Array of options for items per page dropdown.',
     },
-  },
-  parameters: {
-    docs: {
-      description: {
-        component: `
-A pagination component for navigating through pages of data.
-
-**Features:**
-- Displays current range of items being shown (e.g., "Showing 1 to 10 of 100")
-- Page number buttons with smart ellipsis for large page counts
-- Previous/Next navigation arrows
-- Configurable items per page dropdown
-
-**Smart Page Display:**
-- Shows all pages when total pages ≤ 7
-- Uses ellipsis (...) for large page counts
-- Always shows first and last page
-- Shows current page with neighbors
-
-**Events:**
-- \`update:currentPage\` - Emitted when page changes
-- \`update:itemsPerPage\` - Emitted when items per page changes
-        `,
-      },
-    },
-  },
+  }
 }
 
 export default meta
@@ -90,14 +65,7 @@ export const Default: Story = {
     itemsPerPage: 10,
     totalItems: 35,
     itemsPerPageOptions: [10, 20, 50, 100],
-  },
-  parameters: {
-    docs: {
-      description: {
-        story: 'Pagination with only 4 pages - shows all page numbers without ellipsis.',
-      },
-    },
-  },
+  }
 }
 
 export const SinglePage: Story = {
@@ -134,14 +102,7 @@ export const SinglePage: Story = {
     itemsPerPage: 10,
     totalItems: 5,
     itemsPerPageOptions: [10, 20, 50, 100],
-  },
-  parameters: {
-    docs: {
-      description: {
-        story: 'Pagination with only one page - both arrows are disabled.',
-      },
-    },
-  },
+  }
 }
 
 // totalItems = 0  ->  totalPages = 0, both arrows disabled, no page buttons
@@ -179,13 +140,5 @@ export const EmptyState: Story = {
     itemsPerPage: 10,
     totalItems: 0,
     itemsPerPageOptions: [10, 20, 50, 100],
-  },
-  parameters: {
-    docs: {
-      description: {
-        story:
-          'No items available (totalItems = 0): both arrows are disabled and no page number buttons are rendered.',
-      },
-    },
-  },
+  }
 }

--- a/frontend/src/stores/projection/fileUploadStore.cy.ts
+++ b/frontend/src/stores/projection/fileUploadStore.cy.ts
@@ -37,145 +37,75 @@ describe('File Upload Store Unit Tests', () => {
   })
 
   describe('Initial State', () => {
-    it('should open reportConfig panel and close others', () => {
+    it('should open only reportConfig panel and mark it editable', () => {
       expect(store.panelOpenStates.reportConfig).to.equal(CONSTANTS.PANEL.OPEN)
       expect(store.panelOpenStates.minimumDBH).to.equal(CONSTANTS.PANEL.CLOSE)
       expect(store.panelOpenStates.attachments).to.equal(CONSTANTS.PANEL.CLOSE)
-    })
-
-    it('should set reportConfig as editable and others as non-editable', () => {
       expect(store.panelState.reportConfig).to.deep.equal({ confirmed: false, editable: true })
       expect(store.panelState.minimumDBH).to.deep.equal({ confirmed: false, editable: false })
       expect(store.panelState.attachments).to.deep.equal({ confirmed: false, editable: false })
     })
 
-    it('should initialize runModelEnabled as false', () => {
+    it('should initialize all data fields to defaults', () => {
       expect(store.runModelEnabled).to.be.false
-    })
-
-    it('should initialize selectedAgeYearRange to the default value', () => {
       expect(store.selectedAgeYearRange).to.equal(DEFAULTS.DEFAULT_VALUES.SELECTED_AGE_YEAR_RANGE)
-    })
-
-    it('should initialize all age/year fields as null', () => {
-      expect(store.startingAge).to.be.null
-      expect(store.finishingAge).to.be.null
-      expect(store.ageIncrement).to.be.null
-      expect(store.startYear).to.be.null
-      expect(store.endYear).to.be.null
-      expect(store.yearIncrement).to.be.null
-    })
-
-    it('should initialize all boolean flags as false', () => {
-      expect(store.isForwardGrowEnabled).to.be.false
-      expect(store.isBackwardGrowEnabled).to.be.false
-      expect(store.isComputedMAIEnabled).to.be.false
-      expect(store.isCulminationValuesEnabled).to.be.false
-      expect(store.isBySpeciesEnabled).to.be.false
-      expect(store.isProjectionModeEnabled).to.be.false
-      expect(store.isPolygonIDEnabled).to.be.false
-      expect(store.isCurrentYearEnabled).to.be.false
-      expect(store.isReferenceYearEnabled).to.be.false
-      expect(store.incSecondaryHeight).to.be.false
-    })
-
-    it('should initialize projectionType to the default value', () => {
       expect(store.projectionType).to.equal(DEFAULTS.DEFAULT_VALUES.PROJECTION_TYPE)
-    })
-
-    it('should initialize reportTitle and reportDescription as null', () => {
       expect(store.reportTitle).to.be.null
-      expect(store.reportDescription).to.be.null
-    })
-
-    it('should initialize file-related state as null/false', () => {
-      expect(store.polygonFile).to.be.null
-      expect(store.layerFile).to.be.null
       expect(store.polygonFileInfo).to.be.null
       expect(store.layerFileInfo).to.be.null
-      expect(store.isUploadingPolygon).to.be.false
-      expect(store.isUploadingLayer).to.be.false
-      expect(store.isDeletingFile).to.be.false
-    })
-
-    it('should initialize fileUploadSpeciesGroup as empty array', () => {
       expect(store.fileUploadSpeciesGroup).to.deep.equal([])
+      expect(store.isForwardGrowEnabled).to.be.false
+      expect(store.isBackwardGrowEnabled).to.be.false
     })
   })
 
   describe('confirmPanel', () => {
-    it('should mark reportConfig as confirmed and close it', () => {
+    it('should confirm a panel, close it, and open the next sequential panel', () => {
       store.confirmPanel('reportConfig')
 
-      expect(store.panelState.reportConfig.confirmed).to.be.true
-      expect(store.panelState.reportConfig.editable).to.be.false
+      expect(store.panelState.reportConfig).to.deep.equal({ confirmed: true, editable: false })
       expect(store.panelOpenStates.reportConfig).to.equal(CONSTANTS.PANEL.CLOSE)
-    })
-
-    it('should open minimumDBH and make it editable when reportConfig is confirmed', () => {
-      store.confirmPanel('reportConfig')
-
       expect(store.panelOpenStates.minimumDBH).to.equal(CONSTANTS.PANEL.OPEN)
       expect(store.panelState.minimumDBH.editable).to.be.true
     })
 
-    it('should open attachments panel when minimumDBH (last sequential panel) is confirmed', () => {
-      store.confirmPanel('reportConfig')
-      store.confirmPanel('minimumDBH')
-
-      expect(store.panelOpenStates.attachments).to.equal(CONSTANTS.PANEL.OPEN)
-    })
-
-    it('should not enable runModelEnabled when panels confirmed but no files uploaded', () => {
-      store.confirmPanel('reportConfig')
-      store.confirmPanel('minimumDBH')
-
-      expect(store.runModelEnabled).to.be.false
-    })
-
-    it('should enable runModelEnabled when all sequential panels confirmed and both files uploaded', () => {
+    it('should open attachments and enable runModel when all panels confirmed and both files uploaded', () => {
       store.setPolygonFileInfo({ filename: 'poly.csv', fileMappingGUID: 'poly-guid', fileSetGUID: 'set-1' })
       store.setLayerFileInfo({ filename: 'layer.csv', fileMappingGUID: 'layer-guid', fileSetGUID: 'set-1' })
       store.confirmPanel('reportConfig')
       store.confirmPanel('minimumDBH')
 
+      expect(store.panelOpenStates.attachments).to.equal(CONSTANTS.PANEL.OPEN)
       expect(store.runModelEnabled).to.be.true
+    })
+
+    it('should not enable runModelEnabled when panels confirmed but files are missing', () => {
+      store.confirmPanel('reportConfig')
+      store.confirmPanel('minimumDBH')
+
+      expect(store.runModelEnabled).to.be.false
     })
   })
 
   describe('editPanel', () => {
     beforeEach(() => {
-      // Fully confirm both sequential panels first
       store.confirmPanel('reportConfig')
       store.confirmPanel('minimumDBH')
     })
 
-    it('should unconfirm reportConfig and open it for editing', () => {
+    it('should unconfirm the panel, reopen it, and reset all subsequent panels', () => {
       store.editPanel('reportConfig')
 
-      expect(store.panelState.reportConfig.confirmed).to.be.false
-      expect(store.panelState.reportConfig.editable).to.be.true
+      expect(store.panelState.reportConfig).to.deep.equal({ confirmed: false, editable: true })
       expect(store.panelOpenStates.reportConfig).to.equal(CONSTANTS.PANEL.OPEN)
-    })
-
-    it('should close and disable subsequent sequential panels when editing reportConfig', () => {
-      store.editPanel('reportConfig')
-
-      expect(store.panelState.minimumDBH.confirmed).to.be.false
-      expect(store.panelState.minimumDBH.editable).to.be.false
+      expect(store.panelState.minimumDBH).to.deep.equal({ confirmed: false, editable: false })
       expect(store.panelOpenStates.minimumDBH).to.equal(CONSTANTS.PANEL.CLOSE)
-    })
-
-    it('should close the attachments panel when editing any sequential panel', () => {
-      store.editPanel('reportConfig')
-
       expect(store.panelOpenStates.attachments).to.equal(CONSTANTS.PANEL.CLOSE)
     })
 
     it('should set runModelEnabled to false when editing a panel', () => {
       store.setPolygonFileInfo({ filename: 'poly.csv', fileMappingGUID: 'poly-guid', fileSetGUID: 'set-1' })
       store.setLayerFileInfo({ filename: 'layer.csv', fileMappingGUID: 'layer-guid', fileSetGUID: 'set-1' })
-      // watch is async - call explicitly to sync state before asserting
       store.updateRunModelEnabled()
       expect(store.runModelEnabled).to.be.true
 
@@ -183,56 +113,20 @@ describe('File Upload Store Unit Tests', () => {
 
       expect(store.runModelEnabled).to.be.false
     })
-
-    it('should only close panels after minimumDBH when editing minimumDBH (no subsequent sequential panels)', () => {
-      store.editPanel('minimumDBH')
-
-      expect(store.panelState.minimumDBH.confirmed).to.be.false
-      expect(store.panelState.minimumDBH.editable).to.be.true
-      expect(store.panelOpenStates.minimumDBH).to.equal(CONSTANTS.PANEL.OPEN)
-      // Attachments must close too
-      expect(store.panelOpenStates.attachments).to.equal(CONSTANTS.PANEL.CLOSE)
-    })
   })
 
   describe('updateRunModelEnabled', () => {
-    it('should be false when no panels confirmed and no files', () => {
-      store.updateRunModelEnabled()
-
-      expect(store.runModelEnabled).to.be.false
-    })
-
-    it('should be false when only panels are confirmed but no files', () => {
-      store.confirmPanel('reportConfig')
-      store.confirmPanel('minimumDBH')
-
-      expect(store.runModelEnabled).to.be.false
-    })
-
-    it('should be false when files uploaded but no panels confirmed', () => {
+    it('should require all sequential panels confirmed AND both files uploaded', () => {
       store.setPolygonFileInfo({ filename: 'p.csv', fileMappingGUID: 'p-guid', fileSetGUID: 'set-1' })
       store.setLayerFileInfo({ filename: 'l.csv', fileMappingGUID: 'l-guid', fileSetGUID: 'set-1' })
+      expect(store.runModelEnabled).to.be.false // panels not confirmed yet
 
-      expect(store.runModelEnabled).to.be.false
-    })
-
-    it('should be false when only polygon file is set (layer missing)', () => {
       store.confirmPanel('reportConfig')
       store.confirmPanel('minimumDBH')
-      store.setPolygonFileInfo({ filename: 'p.csv', fileMappingGUID: 'p-guid', fileSetGUID: 'set-1' })
-
-      expect(store.runModelEnabled).to.be.false
+      expect(store.runModelEnabled).to.be.true
     })
 
-    it('should be false when only layer file is set (polygon missing)', () => {
-      store.confirmPanel('reportConfig')
-      store.confirmPanel('minimumDBH')
-      store.setLayerFileInfo({ filename: 'l.csv', fileMappingGUID: 'l-guid', fileSetGUID: 'set-1' })
-
-      expect(store.runModelEnabled).to.be.false
-    })
-
-    it('should become false again when a file is removed after being enabled', () => {
+    it('should become false when a file is removed after being enabled', () => {
       store.setPolygonFileInfo({ filename: 'p.csv', fileMappingGUID: 'p-guid', fileSetGUID: 'set-1' })
       store.setLayerFileInfo({ filename: 'l.csv', fileMappingGUID: 'l-guid', fileSetGUID: 'set-1' })
       store.confirmPanel('reportConfig')
@@ -240,7 +134,6 @@ describe('File Upload Store Unit Tests', () => {
       expect(store.runModelEnabled).to.be.true
 
       store.setPolygonFileInfo(null)
-      // watch is async - call explicitly to sync state before asserting
       store.updateRunModelEnabled()
 
       expect(store.runModelEnabled).to.be.false
@@ -248,61 +141,40 @@ describe('File Upload Store Unit Tests', () => {
   })
 
   describe('setPolygonFileInfo / setLayerFileInfo', () => {
-    it('should update polygonFileInfo', () => {
-      const info = { filename: 'poly.csv', fileMappingGUID: 'abc-guid', fileSetGUID: 'set-1' }
-      store.setPolygonFileInfo(info)
+    it('should update and clear file info', () => {
+      const polyInfo = { filename: 'poly.csv', fileMappingGUID: 'abc-guid', fileSetGUID: 'set-1' }
+      const layerInfo = { filename: 'layer.csv', fileMappingGUID: 'xyz-guid', fileSetGUID: 'set-1' }
 
-      expect(store.polygonFileInfo).to.deep.equal(info)
-    })
+      store.setPolygonFileInfo(polyInfo)
+      store.setLayerFileInfo(layerInfo)
+      expect(store.polygonFileInfo).to.deep.equal(polyInfo)
+      expect(store.layerFileInfo).to.deep.equal(layerInfo)
 
-    it('should update layerFileInfo', () => {
-      const info = { filename: 'layer.csv', fileMappingGUID: 'xyz-guid', fileSetGUID: 'set-1' }
-      store.setLayerFileInfo(info)
-
-      expect(store.layerFileInfo).to.deep.equal(info)
-    })
-
-    it('should set polygonFileInfo back to null', () => {
-      store.setPolygonFileInfo({ filename: 'poly.csv', fileMappingGUID: 'abc-guid', fileSetGUID: 'set-1' })
       store.setPolygonFileInfo(null)
-
-      expect(store.polygonFileInfo).to.be.null
-    })
-
-    it('should set layerFileInfo back to null', () => {
-      store.setLayerFileInfo({ filename: 'layer.csv', fileMappingGUID: 'xyz-guid', fileSetGUID: 'set-1' })
       store.setLayerFileInfo(null)
-
+      expect(store.polygonFileInfo).to.be.null
       expect(store.layerFileInfo).to.be.null
     })
   })
 
   describe('initializeSpeciesGroups', () => {
-    it('should create 16 species groups matching BIZCONSTANTS.SPECIES_GROUPS', () => {
+    it('should create groups matching BIZCONSTANTS with volume utilization defaults', () => {
       store.initializeSpeciesGroups()
 
       expect(store.fileUploadSpeciesGroup).to.have.length(BIZCONSTANTS.SPECIES_GROUPS.length)
-      BIZCONSTANTS.SPECIES_GROUPS.forEach((group, i) => {
-        expect(store.fileUploadSpeciesGroup[i].group).to.equal(group)
-      })
-    })
-
-    it('should assign volume utilization defaults to all groups', () => {
-      store.initializeSpeciesGroups()
-
       store.fileUploadSpeciesGroup.forEach(({ group, minimumDBHLimit }) => {
+        expect(group).to.be.oneOf(BIZCONSTANTS.SPECIES_GROUPS)
         expect(minimumDBHLimit).to.equal(DEFAULTS.SPECIES_GROUP_VOLUME_UTILIZATION_MAP[group])
       })
     })
   })
-
 
   describe('updateSpeciesGroupsForProjectionType', () => {
     beforeEach(() => {
       store.initializeSpeciesGroups()
     })
 
-    it('should set CFS Biomass utilization map when type is CFS_BIOMASS', () => {
+    it('should apply CFS Biomass utilization map when type is CFS_BIOMASS', () => {
       store.updateSpeciesGroupsForProjectionType(CONSTANTS.PROJECTION_TYPE.CFS_BIOMASS)
 
       store.fileUploadSpeciesGroup.forEach(({ group, minimumDBHLimit }) => {
@@ -310,19 +182,15 @@ describe('File Upload Store Unit Tests', () => {
       })
     })
 
-    it('should set Volume utilization map when type is Volume', () => {
-      // Switch to CFS Biomass first, then back to Volume
+    it('should apply Volume utilization map when type is Volume or null', () => {
       store.updateSpeciesGroupsForProjectionType(CONSTANTS.PROJECTION_TYPE.CFS_BIOMASS)
       store.updateSpeciesGroupsForProjectionType(CONSTANTS.PROJECTION_TYPE.VOLUME)
 
       store.fileUploadSpeciesGroup.forEach(({ group, minimumDBHLimit }) => {
         expect(minimumDBHLimit).to.equal(DEFAULTS.SPECIES_GROUP_VOLUME_UTILIZATION_MAP[group])
       })
-    })
 
-    it('should set Volume utilization map when type is null', () => {
       store.updateSpeciesGroupsForProjectionType(null)
-
       store.fileUploadSpeciesGroup.forEach(({ group, minimumDBHLimit }) => {
         expect(minimumDBHLimit).to.equal(DEFAULTS.SPECIES_GROUP_VOLUME_UTILIZATION_MAP[group])
       })
@@ -330,317 +198,148 @@ describe('File Upload Store Unit Tests', () => {
   })
 
   describe('resetStore', () => {
-    it('should reset panel open states', () => {
+    it('should restore all state to initial defaults', () => {
+      store.setPolygonFileInfo({ filename: 'p.csv', fileMappingGUID: 'p-guid', fileSetGUID: 'set-1' })
+      store.setLayerFileInfo({ filename: 'l.csv', fileMappingGUID: 'l-guid', fileSetGUID: 'set-1' })
       store.confirmPanel('reportConfig')
+      store.confirmPanel('minimumDBH')
+      store.isForwardGrowEnabled = true
+      store.selectedAgeYearRange = CONSTANTS.AGE_YEAR_RANGE.YEAR
+      store.initializeSpeciesGroups()
+
       store.resetStore()
 
       expect(store.panelOpenStates.reportConfig).to.equal(CONSTANTS.PANEL.OPEN)
       expect(store.panelOpenStates.minimumDBH).to.equal(CONSTANTS.PANEL.CLOSE)
-      expect(store.panelOpenStates.attachments).to.equal(CONSTANTS.PANEL.CLOSE)
-    })
-
-    it('should reset panel confirmed/editable states', () => {
-      store.confirmPanel('reportConfig')
-      store.confirmPanel('minimumDBH')
-      store.resetStore()
-
       expect(store.panelState.reportConfig).to.deep.equal({ confirmed: false, editable: true })
       expect(store.panelState.minimumDBH).to.deep.equal({ confirmed: false, editable: false })
-      expect(store.panelState.attachments).to.deep.equal({ confirmed: false, editable: false })
-    })
-
-    it('should reset runModelEnabled to false', () => {
-      store.setPolygonFileInfo({ filename: 'p.csv', fileMappingGUID: 'p-guid', fileSetGUID: 'set-1' })
-      store.setLayerFileInfo({ filename: 'l.csv', fileMappingGUID: 'l-guid', fileSetGUID: 'set-1' })
-      store.confirmPanel('reportConfig')
-      store.confirmPanel('minimumDBH')
-      expect(store.runModelEnabled).to.be.true
-
-      store.resetStore()
-
       expect(store.runModelEnabled).to.be.false
-    })
-
-    it('should reset selectedAgeYearRange to default', () => {
-      store.selectedAgeYearRange = CONSTANTS.AGE_YEAR_RANGE.YEAR
-      store.resetStore()
-
       expect(store.selectedAgeYearRange).to.equal(DEFAULTS.DEFAULT_VALUES.SELECTED_AGE_YEAR_RANGE)
-    })
-
-    it('should reset file info and upload states', () => {
-      store.setPolygonFileInfo({ filename: 'p.csv', fileMappingGUID: 'p-guid', fileSetGUID: 'set-1' })
-      store.setLayerFileInfo({ filename: 'l.csv', fileMappingGUID: 'l-guid', fileSetGUID: 'set-1' })
-      store.isUploadingPolygon = true
-      store.isUploadingLayer = true
-      store.isDeletingFile = true
-      store.resetStore()
-
       expect(store.polygonFileInfo).to.be.null
       expect(store.layerFileInfo).to.be.null
-      expect(store.isUploadingPolygon).to.be.false
-      expect(store.isUploadingLayer).to.be.false
-      expect(store.isDeletingFile).to.be.false
-    })
-
-    it('should clear fileUploadSpeciesGroup', () => {
-      store.initializeSpeciesGroups()
-      expect(store.fileUploadSpeciesGroup).to.have.length.greaterThan(0)
-
-      store.resetStore()
-
-      expect(store.fileUploadSpeciesGroup).to.deep.equal([])
-    })
-
-    it('should reset all boolean options to false', () => {
-      store.isForwardGrowEnabled = true
-      store.isBackwardGrowEnabled = true
-      store.isComputedMAIEnabled = true
-      store.isCulminationValuesEnabled = true
-      store.resetStore()
-
       expect(store.isForwardGrowEnabled).to.be.false
-      expect(store.isBackwardGrowEnabled).to.be.false
-      expect(store.isComputedMAIEnabled).to.be.false
-      expect(store.isCulminationValuesEnabled).to.be.false
+      expect(store.fileUploadSpeciesGroup).to.deep.equal([])
     })
   })
 
   describe('restoreFromProjectionParams (view mode)', () => {
-    const params = makeParsedParams({
-      reportTitle: 'My Report',
-      ageStart: '10',
-      ageEnd: '100',
-      ageIncrement: '5',
-      selectedExecutionOptions: [
-        ExecutionOptionsEnum.ForwardGrowEnabled,
-        ExecutionOptionsEnum.DoIncludeProjectedMOFVolumes,
-      ],
-      utils: [{ s: 'AC', u: UtilizationClassSetEnum._125 }],
+    it('should open all panels as confirmed and non-editable', () => {
+      store.restoreFromProjectionParams(makeParsedParams({ reportTitle: 'My Report' }), true)
+
+      expect(store.panelOpenStates.reportConfig).to.equal(CONSTANTS.PANEL.OPEN)
+      expect(store.panelOpenStates.minimumDBH).to.equal(CONSTANTS.PANEL.OPEN)
+      expect(store.panelOpenStates.attachments).to.equal(CONSTANTS.PANEL.OPEN)
+      expect(store.panelState.reportConfig).to.deep.equal({ confirmed: true, editable: false })
+      expect(store.panelState.minimumDBH).to.deep.equal({ confirmed: true, editable: false })
+      expect(store.runModelEnabled).to.be.false
     })
 
-    beforeEach(() => {
-      store.restoreFromProjectionParams(params, true)
-    })
+    it('should restore data fields and age range from params', () => {
+      store.restoreFromProjectionParams(
+        makeParsedParams({
+          reportTitle: 'My Report',
+          ageStart: '10',
+          ageEnd: '100',
+          ageIncrement: '5',
+          selectedExecutionOptions: [ExecutionOptionsEnum.ForwardGrowEnabled],
+        }),
+        true,
+      )
 
-    it('should restore reportTitle', () => {
       expect(store.reportTitle).to.equal('My Report')
-    })
-
-    it('should restore age range values', () => {
       expect(store.startingAge).to.equal('10')
       expect(store.finishingAge).to.equal('100')
       expect(store.ageIncrement).to.equal('5')
       expect(store.selectedAgeYearRange).to.equal(CONSTANTS.AGE_YEAR_RANGE.AGE)
-    })
-
-    it('should restore execution options flags', () => {
       expect(store.isForwardGrowEnabled).to.be.true
       expect(store.isBackwardGrowEnabled).to.be.false
-    })
-
-    it('should open all panels in view mode', () => {
-      expect(store.panelOpenStates.reportConfig).to.equal(CONSTANTS.PANEL.OPEN)
-      expect(store.panelOpenStates.minimumDBH).to.equal(CONSTANTS.PANEL.OPEN)
-      expect(store.panelOpenStates.attachments).to.equal(CONSTANTS.PANEL.OPEN)
-    })
-
-    it('should confirm all panels but keep them non-editable in view mode', () => {
-      expect(store.panelState.reportConfig).to.deep.equal({ confirmed: true, editable: false })
-      expect(store.panelState.minimumDBH).to.deep.equal({ confirmed: true, editable: false })
-      expect(store.panelState.attachments).to.deep.equal({ confirmed: true, editable: false })
-    })
-
-    it('should keep runModelEnabled false in view mode', () => {
-      expect(store.runModelEnabled).to.be.false
     })
   })
 
   describe('restoreFromProjectionParams (edit mode)', () => {
-    it('should open reportConfig and close others when reportTitle is null', () => {
+    it('should progressively open panels based on data completeness', () => {
       store.restoreFromProjectionParams(makeParsedParams({ reportTitle: null }), false)
-
       expect(store.panelOpenStates.reportConfig).to.equal(CONSTANTS.PANEL.OPEN)
-      expect(store.panelOpenStates.minimumDBH).to.equal(CONSTANTS.PANEL.CLOSE)
-      expect(store.panelOpenStates.attachments).to.equal(CONSTANTS.PANEL.CLOSE)
       expect(store.panelState.reportConfig.confirmed).to.be.false
-    })
+      expect(store.panelOpenStates.minimumDBH).to.equal(CONSTANTS.PANEL.CLOSE)
 
-    it('should confirm reportConfig and open minimumDBH when only reportTitle is set', () => {
-      store.restoreFromProjectionParams(
-        makeParsedParams({ reportTitle: 'My Title', utils: [] }),
-        false,
-      )
-
+      store.restoreFromProjectionParams(makeParsedParams({ reportTitle: 'My Title', utils: [] }), false)
       expect(store.panelState.reportConfig.confirmed).to.be.true
       expect(store.panelOpenStates.minimumDBH).to.equal(CONSTANTS.PANEL.OPEN)
-      expect(store.panelState.minimumDBH.editable).to.be.true
       expect(store.panelOpenStates.attachments).to.equal(CONSTANTS.PANEL.CLOSE)
-    })
 
-    it('should confirm both sequential panels and open attachments when both are fully specified', () => {
       store.restoreFromProjectionParams(
-        makeParsedParams({
-          reportTitle: 'My Title',
-          utils: [{ s: 'AC', u: UtilizationClassSetEnum._125 }],
-        }),
+        makeParsedParams({ reportTitle: 'My Title', utils: [{ s: 'AC', u: UtilizationClassSetEnum._125 }] }),
         false,
       )
-
-      expect(store.panelState.reportConfig.confirmed).to.be.true
       expect(store.panelState.minimumDBH.confirmed).to.be.true
       expect(store.panelOpenStates.attachments).to.equal(CONSTANTS.PANEL.OPEN)
     })
 
-    it('should keep runModelEnabled false in edit mode (no files)', () => {
-      store.restoreFromProjectionParams(
-        makeParsedParams({
-          reportTitle: 'My Title',
-          utils: [{ s: 'AC', u: UtilizationClassSetEnum._125 }],
-        }),
-        false,
-      )
-
-      expect(store.runModelEnabled).to.be.false
-    })
-
-    it('should restore year range when only year params are present', () => {
-      store.restoreFromProjectionParams(
-        makeParsedParams({ yearStart: '2020', yearEnd: '2050' }),
-        false,
-      )
+    it('should set selectedAgeYearRange to YEAR when year params are present', () => {
+      store.restoreFromProjectionParams(makeParsedParams({ yearStart: '2020', yearEnd: '2050' }), false)
 
       expect(store.selectedAgeYearRange).to.equal(CONSTANTS.AGE_YEAR_RANGE.YEAR)
     })
   })
 
   describe('restoreExecutionOptions (via restoreFromProjectionParams)', () => {
-    const allOptions = [
-      ExecutionOptionsEnum.ForwardGrowEnabled,
-      ExecutionOptionsEnum.BackGrowEnabled,
-      ExecutionOptionsEnum.DoIncludeSpeciesProjection,
-      ExecutionOptionsEnum.DoIncludePolygonRecordIdInYieldTable,
-      ExecutionOptionsEnum.DoIncludeProjectionModeInYieldTable,
-      ExecutionOptionsEnum.DoForceCurrentYearInclusionInYieldTables,
-      ExecutionOptionsEnum.DoForceReferenceYearInclusionInYieldTables,
-      ExecutionOptionsEnum.DoIncludeSecondarySpeciesDominantHeightInYieldTable,
-      ExecutionOptionsEnum.ReportIncludeVolumeMAI,
-      ExecutionOptionsEnum.ReportIncludeCulminationValues,
-    ]
-
-    beforeEach(() => {
+    it('should set all execution option flags from params', () => {
       store.restoreFromProjectionParams(
-        makeParsedParams({ selectedExecutionOptions: allOptions }),
+        makeParsedParams({
+          selectedExecutionOptions: [
+            ExecutionOptionsEnum.ForwardGrowEnabled,
+            ExecutionOptionsEnum.BackGrowEnabled,
+            ExecutionOptionsEnum.DoIncludeSpeciesProjection,
+            ExecutionOptionsEnum.DoIncludePolygonRecordIdInYieldTable,
+            ExecutionOptionsEnum.DoIncludeProjectionModeInYieldTable,
+            ExecutionOptionsEnum.DoForceCurrentYearInclusionInYieldTables,
+            ExecutionOptionsEnum.DoForceReferenceYearInclusionInYieldTables,
+            ExecutionOptionsEnum.DoIncludeSecondarySpeciesDominantHeightInYieldTable,
+            ExecutionOptionsEnum.ReportIncludeVolumeMAI,
+            ExecutionOptionsEnum.ReportIncludeCulminationValues,
+          ],
+        }),
         true,
       )
-    })
 
-    it('should set isForwardGrowEnabled', () => {
       expect(store.isForwardGrowEnabled).to.be.true
-    })
-
-    it('should set isBackwardGrowEnabled', () => {
       expect(store.isBackwardGrowEnabled).to.be.true
-    })
-
-    it('should set isBySpeciesEnabled', () => {
       expect(store.isBySpeciesEnabled).to.be.true
-    })
-
-    it('should set isPolygonIDEnabled', () => {
       expect(store.isPolygonIDEnabled).to.be.true
-    })
-
-    it('should set isProjectionModeEnabled', () => {
       expect(store.isProjectionModeEnabled).to.be.true
-    })
-
-    it('should set isCurrentYearEnabled', () => {
       expect(store.isCurrentYearEnabled).to.be.true
-    })
-
-    it('should set isReferenceYearEnabled', () => {
       expect(store.isReferenceYearEnabled).to.be.true
-    })
-
-    it('should set incSecondaryHeight', () => {
       expect(store.incSecondaryHeight).to.be.true
-    })
-
-    it('should set isComputedMAIEnabled', () => {
       expect(store.isComputedMAIEnabled).to.be.true
-    })
-
-    it('should set isCulminationValuesEnabled', () => {
       expect(store.isCulminationValuesEnabled).to.be.true
     })
   })
 
   describe('restoreProjectionTypeAndSpeciesGroups (via restoreFromProjectionParams)', () => {
-    it('should set projectionType to CFS_BIOMASS', () => {
+    it('should set projectionType to CFS_BIOMASS with corresponding utilization', () => {
       store.restoreFromProjectionParams(
-        makeParsedParams({
-          selectedExecutionOptions: [ExecutionOptionsEnum.DoIncludeProjectedCFSBiomass],
-        }),
+        makeParsedParams({ selectedExecutionOptions: [ExecutionOptionsEnum.DoIncludeProjectedCFSBiomass] }),
         true,
       )
 
       expect(store.projectionType).to.equal(CONSTANTS.PROJECTION_TYPE.CFS_BIOMASS)
+      const acGroup = store.fileUploadSpeciesGroup.find((g) => g.group === 'AC')
+      expect(acGroup?.minimumDBHLimit).to.equal(DEFAULTS.SPECIES_GROUP_CFO_BIOMASS_UTILIZATION_MAP['AC'])
     })
 
     it('should set projectionType to VOLUME', () => {
       store.restoreFromProjectionParams(
-        makeParsedParams({
-          selectedExecutionOptions: [ExecutionOptionsEnum.DoIncludeProjectedMOFVolumes],
-        }),
+        makeParsedParams({ selectedExecutionOptions: [ExecutionOptionsEnum.DoIncludeProjectedMOFVolumes] }),
         true,
       )
 
       expect(store.projectionType).to.equal(CONSTANTS.PROJECTION_TYPE.VOLUME)
     })
-
-    it('should initialize species groups with CFS Biomass utilization when type is CFS_BIOMASS', () => {
-      store.restoreFromProjectionParams(
-        makeParsedParams({
-          selectedExecutionOptions: [ExecutionOptionsEnum.DoIncludeProjectedCFSBiomass],
-        }),
-        true,
-      )
-
-      expect(store.fileUploadSpeciesGroup).to.have.length(BIZCONSTANTS.SPECIES_GROUPS.length)
-      const acGroup = store.fileUploadSpeciesGroup.find((g) => g.group === 'AC')
-      expect(acGroup?.minimumDBHLimit).to.equal(DEFAULTS.SPECIES_GROUP_CFO_BIOMASS_UTILIZATION_MAP['AC'])
-    })
   })
 
   describe('restoreUtilizationLevels (via restoreFromProjectionParams)', () => {
-    it('should override species group utilization with values from params.utils', () => {
-      store.restoreFromProjectionParams(
-        makeParsedParams({
-          selectedExecutionOptions: [ExecutionOptionsEnum.DoIncludeProjectedMOFVolumes],
-          utils: [{ s: 'F', u: UtilizationClassSetEnum._175 }],
-        }),
-        true,
-      )
-
-      const fGroup = store.fileUploadSpeciesGroup.find((g) => g.group === 'F')
-      expect(fGroup?.minimumDBHLimit).to.equal(UtilizationClassSetEnum._175)
-    })
-
-    it('should not change species groups when utils array is empty', () => {
-      store.restoreFromProjectionParams(
-        makeParsedParams({
-          selectedExecutionOptions: [ExecutionOptionsEnum.DoIncludeProjectedMOFVolumes],
-          utils: [],
-        }),
-        true,
-      )
-
-      const acGroup = store.fileUploadSpeciesGroup.find((g) => g.group === 'AC')
-      expect(acGroup?.minimumDBHLimit).to.equal(DEFAULTS.SPECIES_GROUP_VOLUME_UTILIZATION_MAP['AC'])
-    })
-
-    it('should only override species that appear in utils (others remain unchanged)', () => {
+    it('should override only the species listed in params.utils, leaving others unchanged', () => {
       store.restoreFromProjectionParams(
         makeParsedParams({
           selectedExecutionOptions: [ExecutionOptionsEnum.DoIncludeProjectedMOFVolumes],

--- a/frontend/src/stores/projection/modelParameterStore.cy.ts
+++ b/frontend/src/stores/projection/modelParameterStore.cy.ts
@@ -29,7 +29,56 @@ const makeParsedParams = (overrides: Partial<ParsedProjectionParameters> = {}): 
   ...overrides,
 })
 
-describe('Model Parameter Store Unit Tests', () => {
+const makeModelParams = (overrides: Partial<ModelParameters> = {}): ModelParameters => ({
+  derivedBy: 'Volume',
+  species: [
+    { code: 'PL', percent: 70 },
+    { code: 'AC', percent: 30 },
+  ],
+  siteSpecies: 'PL',
+  becZone: 'CWH',
+  ecoZone: 'MH',
+  siteIndex: 'Supplied',
+  compute: null,
+  ageYears: 'Total',
+  speciesAge: '50',
+  speciesHeight: '18.5',
+  bha50SiteIndex: '16.3',
+  compute2: null,
+  ageYears2: null,
+  age2: null,
+  height2: null,
+  si2: null,
+  compute3: null,
+  ageYears3: null,
+  age3: null,
+  height3: null,
+  si3: null,
+  compute4: null,
+  ageYears4: null,
+  age4: null,
+  height4: null,
+  si4: null,
+  compute5: null,
+  ageYears5: null,
+  age5: null,
+  height5: null,
+  si5: null,
+  compute6: null,
+  ageYears6: null,
+  age6: null,
+  height6: null,
+  si6: null,
+  stockable: 55,
+  cc: 60,
+  BA: 25,
+  TPH: 800,
+  minDBHLimit: '7.5 cm+',
+  currentDiameter: null,
+  ...overrides,
+})
+
+describe('Model Parameter Store', () => {
   let store: ReturnType<typeof useModelParameterStore>
 
   beforeEach(() => {
@@ -38,113 +87,46 @@ describe('Model Parameter Store Unit Tests', () => {
   })
 
   describe('Initial State', () => {
-    it('should open detailsInfo panel and close all others', () => {
+    it('should initialize panel states: reportDetails open+editable, others closed+non-editable', () => {
       expect(store.panelOpenStates.reportDetails).to.equal(CONSTANTS.PANEL.OPEN)
-      expect(store.panelOpenStates.speciesInfo).to.equal(CONSTANTS.PANEL.CLOSE)
-      expect(store.panelOpenStates.siteInfo).to.equal(CONSTANTS.PANEL.CLOSE)
-      expect(store.panelOpenStates.standInfo).to.equal(CONSTANTS.PANEL.CLOSE)
-      expect(store.panelOpenStates.reportSettings).to.equal(CONSTANTS.PANEL.CLOSE)
-    })
-
-    it('should set detailsInfo as editable and all others as non-editable', () => {
       expect(store.panelState.reportDetails).to.deep.equal({ confirmed: false, editable: true })
-      expect(store.panelState.speciesInfo).to.deep.equal({ confirmed: false, editable: false })
-      expect(store.panelState.siteInfo).to.deep.equal({ confirmed: false, editable: false })
-      expect(store.panelState.standInfo).to.deep.equal({ confirmed: false, editable: false })
-      expect(store.panelState.reportSettings).to.deep.equal({ confirmed: false, editable: false })
+      ;(['speciesInfo', 'siteInfo', 'standInfo', 'reportSettings'] as const).forEach((panel) => {
+        expect(store.panelOpenStates[panel]).to.equal(CONSTANTS.PANEL.CLOSE)
+        expect(store.panelState[panel]).to.deep.equal({ confirmed: false, editable: false })
+      })
     })
 
-    it('should initialize runModelEnabled as false', () => {
+    it('should initialize key defaults', () => {
       expect(store.runModelEnabled).to.be.false
-    })
-
-    it('should initialize speciesGroups as empty array', () => {
       expect(store.speciesGroups).to.deep.equal([])
-    })
-
-    it('should initialize selectedAgeYearRange to the default value', () => {
+      expect(store.siteIndexRows).to.deep.equal([])
       expect(store.selectedAgeYearRange).to.equal(DEFAULTS.DEFAULT_VALUES.SELECTED_AGE_YEAR_RANGE)
-    })
-
-    it('should initialize projectionType to the default value', () => {
       expect(store.projectionType).to.equal(DEFAULTS.DEFAULT_VALUES.PROJECTION_TYPE)
-    })
-
-    it('should initialize boolean report flags to their default values', () => {
       expect(store.isForwardGrowEnabled).to.be.true
       expect(store.isBackwardGrowEnabled).to.be.true
       expect(store.isByLayerEnabled).to.be.true
       expect(store.isComputedMAIEnabled).to.be.false
-      expect(store.isCulminationValuesEnabled).to.be.false
-      expect(store.isBySpeciesEnabled).to.be.false
-      expect(store.isProjectionModeEnabled).to.be.false
-      expect(store.isPolygonIDEnabled).to.be.false
-      expect(store.isCurrentYearEnabled).to.be.false
-      expect(store.isReferenceYearEnabled).to.be.false
-      expect(store.incSecondaryHeight).to.be.false
-    })
-
-    it('should initialize nullable fields as null', () => {
-      expect(store.derivedBy).to.be.null
-      expect(store.becZone).to.be.null
-      expect(store.ecoZone).to.be.null
-      expect(store.startingAge).to.be.null
-      expect(store.finishingAge).to.be.null
-      expect(store.reportTitle).to.be.null
-    })
-
-    it('should initialize siteIndexRows as empty array', () => {
-      expect(store.siteIndexRows).to.deep.equal([])
     })
   })
 
   describe('confirmPanel', () => {
-    it('should mark detailsInfo as confirmed and close it', () => {
+    it('should close the confirmed panel and open the next one', () => {
       store.confirmPanel('reportDetails')
 
-      expect(store.panelState.reportDetails.confirmed).to.be.true
-      expect(store.panelState.reportDetails.editable).to.be.false
+      expect(store.panelState.reportDetails).to.deep.equal({ confirmed: true, editable: false })
       expect(store.panelOpenStates.reportDetails).to.equal(CONSTANTS.PANEL.CLOSE)
-    })
-
-    it('should open speciesInfo and make it editable when detailsInfo is confirmed', () => {
-      store.confirmPanel('reportDetails')
-
       expect(store.panelOpenStates.speciesInfo).to.equal(CONSTANTS.PANEL.OPEN)
       expect(store.panelState.speciesInfo.editable).to.be.true
     })
 
-    it('should open siteInfo when speciesInfo is confirmed', () => {
+    it('should enable runModelEnabled only when all panels are confirmed', () => {
       store.confirmPanel('reportDetails')
       store.confirmPanel('speciesInfo')
-
-      expect(store.panelOpenStates.siteInfo).to.equal(CONSTANTS.PANEL.OPEN)
-      expect(store.panelState.siteInfo.editable).to.be.true
-    })
-
-    it('should open standInfo when siteInfo is confirmed', () => {
-      store.confirmPanel('reportDetails')
-      store.confirmPanel('speciesInfo')
-      store.confirmPanel('siteInfo')
-
-      expect(store.panelOpenStates.standInfo).to.equal(CONSTANTS.PANEL.OPEN)
-      expect(store.panelState.standInfo.editable).to.be.true
-    })
-
-    it('should not enable runModelEnabled when only some panels are confirmed', () => {
-      store.confirmPanel('reportDetails')
-      store.confirmPanel('speciesInfo')
-
       expect(store.runModelEnabled).to.be.false
-    })
 
-    it('should enable runModelEnabled when all panels are confirmed', () => {
-      store.confirmPanel('reportDetails')
-      store.confirmPanel('speciesInfo')
       store.confirmPanel('siteInfo')
       store.confirmPanel('standInfo')
       store.confirmPanel('reportSettings')
-
       expect(store.runModelEnabled).to.be.true
     })
   })
@@ -158,41 +140,22 @@ describe('Model Parameter Store Unit Tests', () => {
       store.confirmPanel('reportSettings')
     })
 
-    it('should unconfirm detailsInfo and open it for editing', () => {
+    it('should reopen the panel unconfirmed and reset all subsequent panels', () => {
       store.editPanel('reportDetails')
 
-      expect(store.panelState.reportDetails.confirmed).to.be.false
-      expect(store.panelState.reportDetails.editable).to.be.true
+      expect(store.panelState.reportDetails).to.deep.equal({ confirmed: false, editable: true })
       expect(store.panelOpenStates.reportDetails).to.equal(CONSTANTS.PANEL.OPEN)
-    })
-
-    it('should disable all subsequent panels when editing detailsInfo', () => {
-      store.editPanel('reportDetails')
-
-      const subsequentPanels = ['speciesInfo', 'siteInfo', 'standInfo', 'reportSettings'] as const
-      subsequentPanels.forEach((panel) => {
+      ;(['speciesInfo', 'siteInfo', 'standInfo', 'reportSettings'] as const).forEach((panel) => {
         expect(store.panelState[panel].confirmed).to.be.false
         expect(store.panelState[panel].editable).to.be.false
         expect(store.panelOpenStates[panel]).to.equal(CONSTANTS.PANEL.CLOSE)
       })
     })
 
-    it('should set runModelEnabled to false when editing a panel', () => {
-      expect(store.runModelEnabled).to.be.true
-
+    it('should set runModelEnabled to false when editing any panel', () => {
       store.editPanel('speciesInfo')
 
       expect(store.runModelEnabled).to.be.false
-    })
-
-    it('should only close panels after standInfo when editing standInfo', () => {
-      store.editPanel('standInfo')
-
-      expect(store.panelState.standInfo.confirmed).to.be.false
-      expect(store.panelState.standInfo.editable).to.be.true
-      expect(store.panelOpenStates.standInfo).to.equal(CONSTANTS.PANEL.OPEN)
-      expect(store.panelState.reportSettings.confirmed).to.be.false
-      expect(store.panelOpenStates.reportSettings).to.equal(CONSTANTS.PANEL.CLOSE)
     })
   })
 
@@ -203,64 +166,40 @@ describe('Model Parameter Store Unit Tests', () => {
   })
 
   describe('updateSpeciesGroup', () => {
-    it('should group species with same code and sum their percentages', () => {
-      store.speciesList[0] = { species: 'PL', percent: '60' }
-      store.speciesList[1] = { species: 'PL', percent: '20' }
-      store.speciesList[2] = { species: 'AC', percent: '20' }
-      store.updateSpeciesGroup()
-
-      const plGroup = store.speciesGroups.find((g) => g.siteSpecies === 'PL')
-      const acGroup = store.speciesGroups.find((g) => g.siteSpecies === 'AC')
-      expect(Number.parseFloat(plGroup!.percent)).to.equal(80)
-      expect(Number.parseFloat(acGroup!.percent)).to.equal(20)
-    })
-
-    it('should sort species groups by descending percent', () => {
+    it('should group same-code species, sum percentages, sort descending, and set highestPercentSpecies', () => {
       store.speciesList[0] = { species: 'AC', percent: '30' }
-      store.speciesList[1] = { species: 'PL', percent: '70' }
+      store.speciesList[1] = { species: 'PL', percent: '50' }
+      store.speciesList[2] = { species: 'PL', percent: '20' }
       store.updateSpeciesGroup()
 
       expect(store.speciesGroups[0].siteSpecies).to.equal('PL')
+      expect(Number.parseFloat(store.speciesGroups[0].percent)).to.equal(70)
       expect(store.speciesGroups[1].siteSpecies).to.equal('AC')
-    })
-
-    it('should set highestPercentSpecies to the top species', () => {
-      store.speciesList[0] = { species: 'AC', percent: '30' }
-      store.speciesList[1] = { species: 'PL', percent: '70' }
-      store.updateSpeciesGroup()
-
       expect(store.highestPercentSpecies).to.equal('PL')
       expect(store.selectedSiteSpecies).to.equal('PL')
     })
 
-    it('should produce empty groups when all species are null', () => {
+    it('should produce empty groups and null highestPercentSpecies when all species are null', () => {
       store.updateSpeciesGroup()
 
       expect(store.speciesGroups).to.deep.equal([])
       expect(store.highestPercentSpecies).to.be.null
     })
 
-    it('should create siteIndexRows entries for each species group', () => {
+    it('should create siteIndexRows per group and preserve existing row data across updates', () => {
       store.speciesList[0] = { species: 'PL', percent: '60' }
       store.speciesList[1] = { species: 'AC', percent: '40' }
-      store.updateSpeciesGroup()
-
-      expect(store.siteIndexRows).to.have.length(2)
-      expect(store.siteIndexRows[0].speciesCode).to.equal('PL')
-      expect(store.siteIndexRows[1].speciesCode).to.equal('AC')
-    })
-
-    it('should preserve existing siteIndexRow data when species are unchanged', () => {
-      store.speciesList[0] = { species: 'PL', percent: '100' }
       store.updateSpeciesGroup()
       store.siteIndexRows[0].bhaSiteIndex = '25.0'
 
       store.updateSpeciesGroup()
 
+      expect(store.siteIndexRows).to.have.length(2)
+      expect(store.siteIndexRows[0].speciesCode).to.equal('PL')
       expect(store.siteIndexRows[0].bhaSiteIndex).to.equal('25.0')
     })
 
-    it('should null out non-primary rows when Volume+Computed is active', () => {
+    it('should apply mode-specific siteIndexRow defaults: Volume+Computed nulls non-primary rows, Supplied sets bhaSiteIndex', () => {
       store.siteSpeciesValues = CONSTANTS.SITE_SPECIES_VALUES.COMPUTED
       store.derivedBy = CONSTANTS.DERIVED_BY.VOLUME
       store.speciesList[0] = { species: 'PL', percent: '60' }
@@ -269,15 +208,9 @@ describe('Model Parameter Store Unit Tests', () => {
 
       expect(store.siteIndexRows[0].computedValue).to.equal(CONSTANTS.COMPUTED_VALUE.BHA_SITE_INDEX)
       expect(store.siteIndexRows[1].computedValue).to.be.null
-      expect(store.siteIndexRows[1].age).to.be.null
-      expect(store.siteIndexRows[1].height).to.be.null
       expect(store.siteIndexRows[1].bhaSiteIndex).to.be.null
-    })
 
-    it('should set bhaSiteIndex default and null out other fields for all rows when Supplied is active', () => {
       store.siteSpeciesValues = CONSTANTS.SITE_SPECIES_VALUES.SUPPLIED
-      store.speciesList[0] = { species: 'PL', percent: '60' }
-      store.speciesList[1] = { species: 'AC', percent: '40' }
       store.updateSpeciesGroup()
 
       store.siteIndexRows.forEach((row) => {
@@ -290,216 +223,124 @@ describe('Model Parameter Store Unit Tests', () => {
   })
 
   describe('isVolumeComputed and isSupplied', () => {
-    it('isVolumeComputed should be true when siteSpeciesValues is Computed and derivedBy is Volume', () => {
+    it('isVolumeComputed is true only when both Computed and Volume conditions are met', () => {
       store.siteSpeciesValues = CONSTANTS.SITE_SPECIES_VALUES.COMPUTED
       store.derivedBy = CONSTANTS.DERIVED_BY.VOLUME
-
       expect(store.isVolumeComputed).to.be.true
-    })
 
-    it('isVolumeComputed should be false when derivedBy is not Volume', () => {
-      store.siteSpeciesValues = CONSTANTS.SITE_SPECIES_VALUES.COMPUTED
       store.derivedBy = CONSTANTS.DERIVED_BY.BASAL_AREA
-
       expect(store.isVolumeComputed).to.be.false
-    })
 
-    it('isVolumeComputed should be false when siteSpeciesValues is Supplied even if derivedBy is Volume', () => {
       store.siteSpeciesValues = CONSTANTS.SITE_SPECIES_VALUES.SUPPLIED
       store.derivedBy = CONSTANTS.DERIVED_BY.VOLUME
-
       expect(store.isVolumeComputed).to.be.false
     })
 
-    it('isSupplied should be true when siteSpeciesValues is Supplied', () => {
+    it('isSupplied reflects siteSpeciesValues', () => {
       store.siteSpeciesValues = CONSTANTS.SITE_SPECIES_VALUES.SUPPLIED
-
       expect(store.isSupplied).to.be.true
-    })
 
-    it('isSupplied should be false when siteSpeciesValues is Computed', () => {
       store.siteSpeciesValues = CONSTANTS.SITE_SPECIES_VALUES.COMPUTED
-
       expect(store.isSupplied).to.be.false
     })
   })
 
   describe('resetStore', () => {
-    it('should reset panel open states to initial values', () => {
-      store.confirmPanel('reportDetails')
-      store.resetStore()
-
-      expect(store.panelOpenStates.reportDetails).to.equal(CONSTANTS.PANEL.OPEN)
-      expect(store.panelOpenStates.speciesInfo).to.equal(CONSTANTS.PANEL.CLOSE)
-    })
-
-    it('should reset panel confirmed/editable states', () => {
+    it('should reset panel states to initial values', () => {
       store.confirmPanel('reportDetails')
       store.confirmPanel('speciesInfo')
       store.resetStore()
 
+      expect(store.panelOpenStates.reportDetails).to.equal(CONSTANTS.PANEL.OPEN)
       expect(store.panelState.reportDetails).to.deep.equal({ confirmed: false, editable: true })
+      expect(store.panelOpenStates.speciesInfo).to.equal(CONSTANTS.PANEL.CLOSE)
       expect(store.panelState.speciesInfo).to.deep.equal({ confirmed: false, editable: false })
     })
 
-    it('should reset runModelEnabled to false', () => {
+    it('should reset all data fields and scalar values', () => {
+      store.speciesList[0] = { species: 'PL', percent: '100' }
+      store.updateSpeciesGroup()
+      store.selectedAgeYearRange = CONSTANTS.AGE_YEAR_RANGE.YEAR
+      store.reportTitle = 'Custom Title'
+      store.ageType = 'SomeType'
       store.confirmPanel('reportDetails')
       store.confirmPanel('speciesInfo')
       store.confirmPanel('siteInfo')
       store.confirmPanel('standInfo')
       store.confirmPanel('reportSettings')
-      expect(store.runModelEnabled).to.be.true
 
       store.resetStore()
 
       expect(store.runModelEnabled).to.be.false
-    })
-
-    it('should reset speciesGroups to empty array', () => {
-      store.speciesList[0] = { species: 'PL', percent: '100' }
-      store.updateSpeciesGroup()
-      expect(store.speciesGroups).to.have.length.greaterThan(0)
-
-      store.resetStore()
-
       expect(store.speciesGroups).to.deep.equal([])
-    })
-
-    it('should reset selectedAgeYearRange to default', () => {
-      store.selectedAgeYearRange = CONSTANTS.AGE_YEAR_RANGE.YEAR
-      store.resetStore()
-
-      expect(store.selectedAgeYearRange).to.equal(DEFAULTS.DEFAULT_VALUES.SELECTED_AGE_YEAR_RANGE)
-    })
-
-    it('should reset reportTitle to default value', () => {
-      store.reportTitle = 'Custom Title'
-      store.resetStore()
-
-      expect(store.reportTitle).to.equal(DEFAULTS.DEFAULT_VALUES.REPORT_TITLE)
-    })
-
-    it('should reset ageType to default value', () => {
-      store.ageType = 'SomeType'
-      store.resetStore()
-
-      expect(store.ageType).to.equal(DEFAULTS.DEFAULT_VALUES.AGE_TYPE)
-    })
-
-    it('should reset siteIndexRows to empty array', () => {
-      store.speciesList[0] = { species: 'PL', percent: '100' }
-      store.updateSpeciesGroup()
-      expect(store.siteIndexRows).to.have.length.greaterThan(0)
-
-      store.resetStore()
-
       expect(store.siteIndexRows).to.deep.equal([])
+      expect(store.selectedAgeYearRange).to.equal(DEFAULTS.DEFAULT_VALUES.SELECTED_AGE_YEAR_RANGE)
+      expect(store.reportTitle).to.equal(DEFAULTS.DEFAULT_VALUES.REPORT_TITLE)
+      expect(store.ageType).to.equal(DEFAULTS.DEFAULT_VALUES.AGE_TYPE)
     })
   })
 
-  describe('restoreFromProjectionParams (view mode)', () => {
-    const params = makeParsedParams({
-      reportTitle: 'My Report',
-      copyTitle: 'Copy Title',
-      ageStart: '20',
-      ageEnd: '200',
-      ageIncrement: '10',
-      selectedExecutionOptions: [
-        ExecutionOptionsEnum.ForwardGrowEnabled,
-        ExecutionOptionsEnum.DoIncludeProjectedMOFVolumes,
-      ],
-    })
-
-    beforeEach(() => {
+  describe('restoreFromProjectionParams', () => {
+    it('should restore all fields and set panels open, confirmed, non-editable in view mode', () => {
+      const params = makeParsedParams({
+        reportTitle: 'My Report',
+        copyTitle: 'Copy Title',
+        ageStart: '20',
+        ageEnd: '200',
+        ageIncrement: '10',
+        selectedExecutionOptions: [ExecutionOptionsEnum.ForwardGrowEnabled],
+      })
       store.restoreFromProjectionParams(params, true)
-    })
 
-    it('should restore reportTitle and copyTitle', () => {
       expect(store.reportTitle).to.equal('My Report')
       expect(store.copyTitle).to.equal('Copy Title')
-    })
-
-    it('should restore age range values', () => {
       expect(store.startingAge).to.equal('20')
-      expect(store.finishingAge).to.equal('200')
-      expect(store.ageIncrement).to.equal('10')
-    })
-
-    it('should restore execution options flags', () => {
-      expect(store.isForwardGrowEnabled).to.be.true
-      expect(store.isBackwardGrowEnabled).to.be.false
-      expect(store.projectionType).to.equal(CONSTANTS.PROJECTION_TYPE.VOLUME)
-    })
-
-    it('should open all panels in view mode', () => {
-      const panels = ['reportDetails', 'speciesInfo', 'siteInfo', 'standInfo', 'reportSettings'] as const
-      panels.forEach((panel) => {
+      expect(store.runModelEnabled).to.be.true
+      ;(['reportDetails', 'speciesInfo', 'siteInfo', 'standInfo', 'reportSettings'] as const).forEach((panel) => {
         expect(store.panelOpenStates[panel]).to.equal(CONSTANTS.PANEL.OPEN)
-      })
-    })
-
-    it('should confirm all panels but keep them non-editable in view mode', () => {
-      const panels = ['reportDetails', 'speciesInfo', 'siteInfo', 'standInfo', 'reportSettings'] as const
-      panels.forEach((panel) => {
         expect(store.panelState[panel]).to.deep.equal({ confirmed: true, editable: false })
       })
     })
 
-    it('should keep runModelEnabled true in view mode', () => {
-      expect(store.runModelEnabled).to.be.true
-    })
-  })
-
-  describe('restoreFromProjectionParams (edit mode)', () => {
-    it('should open detailsInfo when reportTitle is null', () => {
+    it('should open reportDetails unconfirmed when reportTitle is null (edit mode)', () => {
       store.restoreFromProjectionParams(makeParsedParams({ reportTitle: null }), false)
 
       expect(store.panelOpenStates.reportDetails).to.equal(CONSTANTS.PANEL.OPEN)
       expect(store.panelState.reportDetails.confirmed).to.be.false
     })
 
-    it('should confirm detailsInfo and open speciesInfo when only reportTitle is set', () => {
+    it('should confirm reportDetails and open speciesInfo when reportTitle is set (edit mode)', () => {
       store.restoreFromProjectionParams(makeParsedParams({ reportTitle: 'Title' }), false)
 
       expect(store.panelState.reportDetails.confirmed).to.be.true
       expect(store.panelOpenStates.speciesInfo).to.equal(CONSTANTS.PANEL.OPEN)
-      expect(store.panelState.speciesInfo.editable).to.be.true
     })
 
-    it('should enable runModelEnabled when all panels fully populated', () => {
+    it('should enable runModelEnabled when all panels populated and set projectionType from options (edit mode)', () => {
       store.speciesList[0] = { species: 'PL', percent: '100' }
       store.updateSpeciesGroup()
       store.becZone = 'CWH'
       store.percentStockableArea = '55'
 
       store.restoreFromProjectionParams(
-        makeParsedParams({ reportTitle: 'Title', ageStart: '20' }),
-        false,
-      )
-
-      expect(store.runModelEnabled).to.be.true
-    })
-
-    it('should set projectionType to CFS_BIOMASS when option is present', () => {
-      store.restoreFromProjectionParams(
         makeParsedParams({
+          reportTitle: 'Title',
+          ageStart: '20',
           selectedExecutionOptions: [ExecutionOptionsEnum.DoIncludeProjectedCFSBiomass],
         }),
         false,
       )
 
+      expect(store.runModelEnabled).to.be.true
       expect(store.projectionType).to.equal(CONSTANTS.PROJECTION_TYPE.CFS_BIOMASS)
     })
   })
 
   describe('restoreUtilizationLevels (via restoreFromProjectionParams)', () => {
-    beforeEach(() => {
-      store.speciesList[0] = { species: 'FD', percent: '60' }
-      store.speciesList[1] = { species: 'AC', percent: '40' }
-      store.updateSpeciesGroup()
-    })
-
     it('should override minimumDBHLimit for matching species group', () => {
+      store.speciesList[0] = { species: 'FD', percent: '100' }
+      store.updateSpeciesGroup()
+
       store.restoreFromProjectionParams(
         makeParsedParams({ utils: [{ s: 'F', u: UtilizationClassSetEnum._175 }] }),
         false,
@@ -508,107 +349,29 @@ describe('Model Parameter Store Unit Tests', () => {
       const fGroup = store.speciesGroups.find((g) => g.group === 'F')
       expect(fGroup?.minimumDBHLimit).to.equal(UtilizationClassSetEnum._175)
     })
-
-    it('should not change groups when utils array is empty', () => {
-      const original = store.speciesGroups.find((g) => g.group === 'AC')?.minimumDBHLimit
-
-      store.restoreFromProjectionParams(makeParsedParams({ utils: [] }), false)
-
-      const acGroup = store.speciesGroups.find((g) => g.group === 'AC')
-      expect(acGroup?.minimumDBHLimit).to.equal(original)
-    })
   })
 
   describe('restoreFromModelParameters', () => {
-    const makeModelParams = (overrides: Partial<ModelParameters> = {}): ModelParameters => ({
-      derivedBy: 'Volume',
-      species: [
-        { code: 'PL', percent: 70 },
-        { code: 'AC', percent: 30 },
-      ],
-      siteSpecies: 'PL',
-      becZone: 'CWH',
-      ecoZone: 'MH',
-      siteIndex: 'Supplied',
-      compute: null,
-      ageYears: 'Total',
-      speciesAge: '50',
-      speciesHeight: '18.5',
-      bha50SiteIndex: '16.3',
-      compute2: null,
-      ageYears2: null,
-      age2: null,
-      height2: null,
-      si2: null,
-      compute3: null,
-      ageYears3: null,
-      age3: null,
-      height3: null,
-      si3: null,
-      compute4: null,
-      ageYears4: null,
-      age4: null,
-      height4: null,
-      si4: null,
-      compute5: null,
-      ageYears5: null,
-      age5: null,
-      height5: null,
-      si5: null,
-      compute6: null,
-      ageYears6: null,
-      age6: null,
-      height6: null,
-      si6: null,
-      stockable: 55,
-      cc: 60,
-      BA: 25,
-      TPH: 800,
-      minDBHLimit: '7.5 cm+',
-      currentDiameter: null,
-      ...overrides,
-    })
-
-    it('should restore derivedBy', () => {
+    it('should restore all data fields', () => {
       store.restoreFromModelParameters(makeModelParams())
 
       expect(store.derivedBy).to.equal('Volume')
-    })
-
-    it('should restore site info fields', () => {
-      store.restoreFromModelParameters(makeModelParams())
-
       expect(store.becZone).to.equal('CWH')
       expect(store.ecoZone).to.equal('MH')
       expect(store.spzAge).to.equal('50')
       expect(store.spzHeight).to.equal('18.5')
       expect(store.bha50SiteIndex).to.equal('16.3')
-    })
-
-    it('should restore stand info fields', () => {
-      store.restoreFromModelParameters(makeModelParams())
-
       expect(store.percentStockableArea).to.equal('55')
       expect(store.crownClosure).to.equal('60')
       expect(store.basalArea).to.equal('25')
       expect(store.treesPerHectare).to.equal('800')
       expect(store.minDBHLimit).to.equal('7.5 cm+')
-    })
-
-    it('should set highestPercentSpecies from siteSpecies field', () => {
-      store.restoreFromModelParameters(makeModelParams({ siteSpecies: 'PL' }))
-
       expect(store.highestPercentSpecies).to.equal('PL')
       expect(store.selectedSiteSpecies).to.equal('PL')
-    })
-
-    it('should set referenceYear to current year when not already set', () => {
-      store.restoreFromModelParameters(makeModelParams())
-
       expect(store.referenceYear).to.equal(new Date().getFullYear())
     })
 
-    it('should restore primary siteIndexRow with null computedValue in Supplied mode', () => {
+    it('should restore primary siteIndexRow in Supplied mode', () => {
       store.restoreFromModelParameters(makeModelParams({ siteIndex: CONSTANTS.SITE_SPECIES_VALUES.SUPPLIED }))
 
       expect(store.siteIndexRows[0].computedValue).to.be.null
@@ -617,28 +380,24 @@ describe('Model Parameter Store Unit Tests', () => {
       expect(store.siteIndexRows[0].height).to.be.null
     })
 
-    it('should restore primary siteIndexRow with BHA_SITE_INDEX computed and null bhaSiteIndex', () => {
+    it('should restore primary siteIndexRow in Computed mode for BHA_SITE_INDEX and HEIGHT', () => {
       store.restoreFromModelParameters(makeModelParams({
         siteIndex: CONSTANTS.SITE_SPECIES_VALUES.COMPUTED,
         compute: CONSTANTS.COMPUTED_VALUE.BHA_SITE_INDEX,
       }))
-
       expect(store.siteIndexRows[0].computedValue).to.equal(CONSTANTS.COMPUTED_VALUE.BHA_SITE_INDEX)
       expect(store.siteIndexRows[0].bhaSiteIndex).to.be.null
-    })
 
-    it('should restore primary siteIndexRow with HEIGHT computed and null height', () => {
       store.restoreFromModelParameters(makeModelParams({
         siteIndex: CONSTANTS.SITE_SPECIES_VALUES.COMPUTED,
         compute: CONSTANTS.COMPUTED_VALUE.HEIGHT,
       }))
-
       expect(store.siteIndexRows[0].computedValue).to.equal(CONSTANTS.COMPUTED_VALUE.HEIGHT)
       expect(store.siteIndexRows[0].height).to.be.null
       expect(store.siteIndexRows[0].bhaSiteIndex).to.equal('16.3')
     })
 
-    it('should restore per-species rows using VDYP-1076 fields in Computed mode', () => {
+    it('should restore secondary species rows in Computed mode', () => {
       store.restoreFromModelParameters(makeModelParams({
         siteIndex: CONSTANTS.SITE_SPECIES_VALUES.COMPUTED,
         compute: CONSTANTS.COMPUTED_VALUE.BHA_SITE_INDEX,
@@ -656,7 +415,7 @@ describe('Model Parameter Store Unit Tests', () => {
       expect(store.siteIndexRows[1].bhaSiteIndex).to.equal('20.0')
     })
 
-    it('should restore per-species rows with provided si value in Supplied mode', () => {
+    it('should restore secondary species rows in Supplied mode', () => {
       store.restoreFromModelParameters(makeModelParams({
         siteIndex: CONSTANTS.SITE_SPECIES_VALUES.SUPPLIED,
         si2: '22.5',

--- a/frontend/src/utils/util.cy.ts
+++ b/frontend/src/utils/util.cy.ts
@@ -14,7 +14,6 @@ import {
   increaseItemBySpinButton,
   decrementItemBySpinButton,
   downloadFile,
-  downloadURL,
   extractZipFileName,
   checkZipForErrors,
   sanitizeFileName,
@@ -31,163 +30,94 @@ import { ExecutionOptionsEnum } from '@/services/vdyp-api'
 
 describe('Util Functions Unit Tests', () => {
   describe('trimValue', () => {
-    it('should trim whitespace from strings', () => {
+    it('should trim strings and pass through non-string values unchanged', () => {
       expect(trimValue('  hello  ')).to.equal('hello')
-      expect(trimValue('no spaces')).to.equal('no spaces')
       expect(trimValue('')).to.equal('')
-    })
-
-    it('should return non-string values unchanged', () => {
       expect(trimValue(123)).to.equal(123)
       expect(trimValue(null)).to.be.null
       expect(trimValue(undefined)).to.be.undefined
-      expect(trimValue({ key: 'value' })).to.deep.equal({ key: 'value' })
-      expect(trimValue(true)).to.be.true
     })
   })
 
   describe('isBlank', () => {
-    it('should return true for blank values', () => {
+    it('should return true for blank values and false for non-blank', () => {
       expect(isBlank(undefined)).to.be.true
       expect(isBlank(null)).to.be.true
       expect(isBlank(Number.NaN)).to.be.true
       expect(isBlank([])).to.be.true
-      expect(isBlank('  ')).to.be.true
       expect(isBlank('')).to.be.true
-    })
-
-    it('should return false for non-blank values', () => {
       expect(isBlank('text')).to.be.false
       expect(isBlank(0)).to.be.false
       expect(isBlank(false)).to.be.false
-      expect(isBlank([1, 2])).to.be.false
-      expect(isBlank({})).to.be.false
-      expect(isBlank(-1)).to.be.false
     })
   })
 
   describe('isZeroValue', () => {
-    it('should return true for zero values', () => {
+    it('should return true for zero values and false otherwise', () => {
       expect(isZeroValue(0)).to.be.true
       expect(isZeroValue('0')).to.be.true
       expect(isZeroValue(' 0 ')).to.be.true
-    })
-
-    it('should return false for non-zero values', () => {
+      expect(isZeroValue('-0')).to.be.true
       expect(isZeroValue(1)).to.be.false
-      expect(isZeroValue('1')).to.be.false
-      expect(isZeroValue('')).to.be.false
       expect(isZeroValue(null)).to.be.false
-      expect(isZeroValue(undefined)).to.be.false
       expect(isZeroValue('abc')).to.be.false
-      expect(isZeroValue({})).to.be.false
-      expect(isZeroValue(Number.NaN)).to.be.false
-      expect(isZeroValue('-0')).to.be.true // Edge case: "-0" is considered 0
     })
   })
 
   describe('isEmptyOrZero', () => {
-    it('should return true for empty or zero values', () => {
+    it('should return true for empty or zero values and false otherwise', () => {
       expect(isEmptyOrZero(0)).to.be.true
       expect(isEmptyOrZero('0')).to.be.true
       expect(isEmptyOrZero('')).to.be.true
       expect(isEmptyOrZero(null)).to.be.true
-      expect(isEmptyOrZero('  ')).to.be.true
-    })
-
-    it('should return false for non-empty and non-zero values', () => {
       expect(isEmptyOrZero(1)).to.be.false
-      expect(isEmptyOrZero('1')).to.be.false
       expect(isEmptyOrZero('text')).to.be.false
-      expect(isEmptyOrZero(-1)).to.be.false
     })
   })
 
   describe('parseNumberOrNull', () => {
-    it('should parse valid numbers', () => {
+    it('should parse valid numbers and return null for invalid inputs', () => {
       expect(parseNumberOrNull('123')).to.equal(123)
       expect(parseNumberOrNull(456)).to.equal(456)
-      expect(parseNumberOrNull('0')).to.equal(0)
       expect(parseNumberOrNull('-5')).to.equal(-5)
-    })
-
-    it('should return null for invalid or empty inputs', () => {
       expect(parseNumberOrNull('')).to.be.null
       expect(parseNumberOrNull(null)).to.be.null
       expect(parseNumberOrNull('abc')).to.be.null
-      expect(parseNumberOrNull('12.34.56')).to.be.null // Edge case: invalid number format
     })
   })
 
   describe('formatDateTimeDisplay', () => {
     it('should format ISO date string to display format', () => {
-      expect(formatDateTimeDisplay('2026-01-10T14:30:00')).to.equal(
-        'Jan 10 / 14:30',
-      )
-      expect(formatDateTimeDisplay('2026-02-28T09:15:00')).to.equal(
-        'Feb 28 / 09:15',
-      )
-    })
-
-    it('should handle midnight correctly', () => {
-      expect(formatDateTimeDisplay('2026-01-01T00:00:00')).to.equal(
-        'Jan 01 / 00:00',
-      )
-    })
-
-    it('should handle end of day correctly', () => {
-      expect(formatDateTimeDisplay('2026-12-31T23:59:00')).to.equal(
-        'Dec 31 / 23:59',
-      )
+      expect(formatDateTimeDisplay('2026-01-10T14:30:00')).to.equal('Jan 10 / 14:30')
+      expect(formatDateTimeDisplay('2026-12-31T23:59:00')).to.equal('Dec 31 / 23:59')
     })
   })
 
   describe('formatDateDisplay', () => {
     it('should format ISO date string to short display format', () => {
-      // Use ISO datetime format to avoid timezone issues
       expect(formatDateDisplay('2026-01-15T12:00:00')).to.equal('Jan 15')
-      expect(formatDateDisplay('2026-02-28T12:00:00')).to.equal('Feb 28')
-    })
-
-    it('should handle first and last day of year', () => {
-      expect(formatDateDisplay('2026-01-01T12:00:00')).to.equal('Jan 01')
-      expect(formatDateDisplay('2026-12-31T12:00:00')).to.equal('Dec 31')
-    })
-
-    it('should handle leap year date', () => {
       expect(formatDateDisplay('2024-02-29T12:00:00')).to.equal('Feb 29')
     })
   })
 
   describe('getStatusIcon', () => {
-    it('should return icon URL for valid statuses', () => {
+    it('should return icon URL for valid statuses and empty string otherwise', () => {
       expect(getStatusIcon('Draft')).to.include('Draft_Icon_Status.png')
-      expect(getStatusIcon('Ready')).to.include('Ready_Icon_Status.png')
-      expect(getStatusIcon('Running')).to.include('Running_Icon_Status.png')
       expect(getStatusIcon('Failed')).to.include('Failed_Icon_Status.png')
-    })
-
-    it('should return empty string for unknown status', () => {
       expect(getStatusIcon('Unknown')).to.equal('')
       expect(getStatusIcon('')).to.equal('')
     })
   })
 
   describe('formatUnixTimestampToDate', () => {
-    it('should convert valid timestamps to Date objects', () => {
+    it('should convert a valid timestamp to a Date and return an invalid Date for NaN', () => {
       const date = formatUnixTimestampToDate(1677655800)
       expect(date).to.be.instanceOf(Date)
       expect(date?.getTime()).to.equal(1677655800 * 1000)
-    })
 
-    it('should return null for invalid timestamps', () => {
-      // Updated to expect Invalid Date for NaN
       const invalidDate = formatUnixTimestampToDate(Number.NaN)
-      expect(invalidDate).to.be.instanceOf(Date) // Invalid Date is still a Date object
-      expect(Number.isNaN(invalidDate!.getTime())).to.be.true // Verify it's invalid
-      // Negative timestamp is valid
-      const negDate = formatUnixTimestampToDate(-1)
-      expect(negDate).to.be.instanceOf(Date)
+      expect(invalidDate).to.be.instanceOf(Date)
+      expect(Number.isNaN(invalidDate!.getTime())).to.be.true
     })
   })
 
@@ -195,95 +125,62 @@ describe('Util Functions Unit Tests', () => {
     it('should resolve after the specified delay', (done) => {
       const start = Date.now()
       delay(100).then(() => {
-        const end = Date.now()
-        expect(end - start).to.be.at.least(100)
-        done()
-      })
-    })
-
-    it('should handle zero or negative delay', (done) => {
-      delay(0).then(() => {
-        expect(true).to.be.true // Simply resolves immediately
+        expect(Date.now() - start).to.be.at.least(100)
         done()
       })
     })
   })
 
   describe('increaseItemBySpinButton', () => {
-    it('should increase the value correctly', () => {
+    it('should increase the value, clamp to bounds, and reset null/invalid inputs to min', () => {
       expect(increaseItemBySpinButton('10', 20, 0, 5)).to.equal(15)
-      expect(increaseItemBySpinButton(null, 20, 0, 5)).to.equal(0)
-      expect(increaseItemBySpinButton('10a', 20, 0, 5)).to.equal(15)
       expect(increaseItemBySpinButton('25', 20, 0, 5)).to.equal(20)
       expect(increaseItemBySpinButton('-5', 20, 0, 5)).to.equal(0)
+      expect(increaseItemBySpinButton(null, 20, 0, 5)).to.equal(0)
     })
 
-    it('should throw an error for non-positive step', () => {
-      expect(() => increaseItemBySpinButton('10', 20, 0, 0)).to.throw(
-        'Step must be a positive number',
-      )
-      expect(() => increaseItemBySpinButton('10', 20, 0, -1)).to.throw(
-        'Step must be a positive number',
-      )
-    })
-
-    it('should handle decimal values', () => {
-      expect(increaseItemBySpinButton('10.5', 20, 0, 1.5)).to.equal(12)
+    it('should throw for non-positive step', () => {
+      expect(() => increaseItemBySpinButton('10', 20, 0, 0)).to.throw('Step must be a positive number')
+      expect(() => increaseItemBySpinButton('10', 20, 0, -1)).to.throw('Step must be a positive number')
     })
   })
 
   describe('decrementItemBySpinButton', () => {
-    it('should decrease the value correctly', () => {
+    it('should decrease the value, clamp to bounds, and reset null/invalid inputs to min', () => {
       expect(decrementItemBySpinButton('10', 20, 0, 5)).to.equal(5)
-      expect(decrementItemBySpinButton(null, 20, 0, 5)).to.equal(0)
-      expect(decrementItemBySpinButton('10a', 20, 0, 5)).to.equal(5)
       expect(decrementItemBySpinButton('2', 20, 0, 5)).to.equal(0)
       expect(decrementItemBySpinButton('25', 20, 0, 5)).to.equal(20)
+      expect(decrementItemBySpinButton(null, 20, 0, 5)).to.equal(0)
     })
 
-    it('should throw an error for non-positive step', () => {
-      expect(() => decrementItemBySpinButton('10', 20, 0, 0)).to.throw(
-        'Step must be a positive number',
-      )
-      expect(() => decrementItemBySpinButton('10', 20, 0, -1)).to.throw(
-        'Step must be a positive number',
-      )
-    })
-
-    it('should handle decimal values', () => {
-      expect(decrementItemBySpinButton('10.5', 20, 0, 1.5)).to.equal(9)
+    it('should throw for non-positive step', () => {
+      expect(() => decrementItemBySpinButton('10', 20, 0, 0)).to.throw('Step must be a positive number')
+      expect(() => decrementItemBySpinButton('10', 20, 0, -1)).to.throw('Step must be a positive number')
     })
   })
 
   describe('downloadFile', () => {
     it('should trigger a file download', () => {
       const blob = new Blob(['test content'], { type: 'text/plain' })
-      const fileName = 'test.txt'
 
-      // Use cy.stub with alias and return value in correct order
       cy.stub(URL, 'createObjectURL').as('createObjectURL').returns('mock-url')
       cy.stub(URL, 'revokeObjectURL').as('revokeObjectURL')
 
-      // Create a mock anchor element with a spy on click and remove
-      let mockAnchor: HTMLAnchorElement | null = null
       const originalCreateElement = document.createElement.bind(document)
-
       cy.stub(document, 'createElement').callsFake((tagName: string) => {
         const element = originalCreateElement(tagName)
         if (tagName === 'a') {
-          mockAnchor = element as HTMLAnchorElement
-          cy.spy(mockAnchor, 'click').as('click')
-          cy.spy(mockAnchor, 'remove').as('remove')
+          cy.spy(element as HTMLAnchorElement, 'click').as('click')
+          cy.spy(element as HTMLAnchorElement, 'remove').as('remove')
         }
         return element
       }).as('createElement')
 
       cy.spy(document.body, 'appendChild').as('appendChild')
 
-      downloadFile(blob, fileName)
+      downloadFile(blob, 'test.txt')
 
       cy.get('@createObjectURL').should('have.been.calledWith', blob)
-      cy.get('@createElement').should('have.been.calledWith', 'a')
       cy.get('@appendChild').should('have.been.called')
       cy.get('@click').should('have.been.called')
       cy.get('@remove').should('have.been.called')
@@ -291,56 +188,16 @@ describe('Util Functions Unit Tests', () => {
     })
   })
 
-  describe('downloadURL', () => {
-    it('should trigger a file download with a URL string', () => {
-      const url = 'mock-url'
-      const fileName = 'test.txt'
-
-      let mockAnchor: HTMLAnchorElement | null = null
-      const originalCreateElement = document.createElement.bind(document)
-
-      cy.stub(document, 'createElement').callsFake((tagName: string) => {
-        const element = originalCreateElement(tagName)
-        if (tagName === 'a') {
-          mockAnchor = element as HTMLAnchorElement
-          cy.spy(mockAnchor, 'click').as('click')
-          cy.spy(mockAnchor, 'remove').as('remove')
-        }
-        return element
-      }).as('createElement')
-
-      cy.stub(URL, 'revokeObjectURL').as('revokeObjectURL')
-      cy.spy(document.body, 'appendChild').as('appendChild')
-
-      downloadURL(url, fileName)
-
-      cy.get('@createElement').should('have.been.calledWith', 'a')
-      cy.get('@appendChild').should('have.been.called')
-      cy.get('@click').should('have.been.called')
-      cy.get('@remove').should('have.been.called')
-      cy.get('@revokeObjectURL').should('have.been.calledWith', url)
-    })
-  })
-
   describe('extractZipFileName', () => {
-    it('should extract file name from headers (plain object)', () => {
-      const headers = {
-        'content-disposition': 'attachment; filename="test.zip"',
-      }
-      expect(extractZipFileName(headers)).to.equal('test.zip')
-    })
+    it('should extract filename from plain object and Headers instance, and return null if absent', () => {
+      expect(extractZipFileName({ 'content-disposition': 'attachment; filename="test.zip"' })).to.equal('test.zip')
 
-    it('should extract file name from Headers instance', () => {
       const headers = new Headers()
       headers.set('content-disposition', 'attachment; filename="test.zip"')
       expect(extractZipFileName(headers)).to.equal('test.zip')
-    })
 
-    it('should return null if no file name is found', () => {
-      const headers = {}
-      expect(extractZipFileName(headers)).to.be.null
-      const headersNoMatch = { 'content-disposition': 'attachment' }
-      expect(extractZipFileName(headersNoMatch)).to.be.null
+      expect(extractZipFileName({})).to.be.null
+      expect(extractZipFileName({ 'content-disposition': 'attachment' })).to.be.null
     })
   })
 
@@ -348,139 +205,61 @@ describe('Util Functions Unit Tests', () => {
     it('should return true if Error.txt has content', async () => {
       const zip = new JSZip()
       zip.file(CONSTANTS.FILE_NAME.ERROR_TXT, 'Error content')
-      const zipBlob = await zip.generateAsync({ type: 'blob' })
-
-      const result = await checkZipForErrors(zipBlob)
+      const result = await checkZipForErrors(await zip.generateAsync({ type: 'blob' }))
       expect(result).to.be.true
     })
 
-    it('should return false if Error.txt is missing or empty', async () => {
+    it('should return false if Error.txt is missing, empty, or only whitespace/null', async () => {
       const zip = new JSZip()
-      const zipBlob = await zip.generateAsync({ type: 'blob' })
-
-      const result = await checkZipForErrors(zipBlob)
-      expect(result).to.be.false
+      expect(await checkZipForErrors(await zip.generateAsync({ type: 'blob' }))).to.be.false
 
       zip.file(CONSTANTS.FILE_NAME.ERROR_TXT, '')
-      const zipBlobEmpty = await zip.generateAsync({ type: 'blob' })
-      const resultEmpty = await checkZipForErrors(zipBlobEmpty)
-      expect(resultEmpty).to.be.false
-    })
+      expect(await checkZipForErrors(await zip.generateAsync({ type: 'blob' }))).to.be.false
 
-    it('should handle Error.txt with only whitespace or "null"', async () => {
-      const zip = new JSZip()
       zip.file(CONSTANTS.FILE_NAME.ERROR_TXT, '  \n  \nnull\n  ')
-      const zipBlob = await zip.generateAsync({ type: 'blob' })
-
-      const result = await checkZipForErrors(zipBlob)
-      expect(result).to.be.false
+      expect(await checkZipForErrors(await zip.generateAsync({ type: 'blob' }))).to.be.false
     })
   })
 
   describe('sanitizeFileName', () => {
-    it('should sanitize file name by allowing only alphanumeric characters, dot, underscore, and hyphen', () => {
-      expect(sanitizeFileName('test__file!.zip')).to.equal('test_file.zip')
+    it('should replace special characters with underscore and preserve valid chars', () => {
       expect(sanitizeFileName('file@name#$.zip')).to.equal('file_name.zip')
-      expect(sanitizeFileName('valid.file_name-123')).to.equal(
-        'valid.file_name-123',
-      )
-    })
-
-    it('should remove consecutive underscores', () => {
-      expect(sanitizeFileName('test___file')).to.equal('test_file')
-      expect(sanitizeFileName('__multiple___underscores__')).to.equal(
-        'multiple_underscores',
-      )
-    })
-
-    it('should remove leading and trailing underscores', () => {
-      expect(sanitizeFileName('__test')).to.equal('test')
-      expect(sanitizeFileName('test__')).to.equal('test')
-      expect(sanitizeFileName('__test__')).to.equal('test')
-    })
-
-    it('should handle empty or null-like inputs', () => {
+      expect(sanitizeFileName('valid.file_name-123')).to.equal('valid.file_name-123')
       expect(sanitizeFileName('')).to.equal('')
-      expect(sanitizeFileName('   ')).to.equal('')
     })
 
-    it('should handle special characters and maintain valid filename structure', () => {
-      expect(sanitizeFileName('file/name/path')).to.equal('file_name_path')
-      expect(sanitizeFileName(String.raw`file\name\path`)).to.equal('file_name_path')
-      expect(sanitizeFileName('file<name>path')).to.equal('file_name_path')
-    })
-
-    it('should handle filenames with extensions correctly', () => {
+    it('should collapse consecutive underscores and trim leading/trailing underscores', () => {
+      expect(sanitizeFileName('test___file')).to.equal('test_file')
+      expect(sanitizeFileName('__test__')).to.equal('test')
       expect(sanitizeFileName('test__file!.zip')).to.equal('test_file.zip')
-      expect(sanitizeFileName('file@name#$.zip')).to.equal('file_name.zip')
-      expect(sanitizeFileName('valid.file_name-123.zip')).to.equal(
-        'valid.file_name-123.zip',
-      )
-      expect(sanitizeFileName('test__file_.zip')).to.equal('test_file.zip')
     })
   })
 
   describe('convertToNumberSafely', () => {
-    it('should convert valid string numbers to numbers', () => {
+    it('should convert valid numbers and return null for blank or invalid inputs', () => {
       expect(convertToNumberSafely('123')).to.equal(123)
-      expect(convertToNumberSafely('0')).to.equal(0)
-      expect(convertToNumberSafely('-5.5')).to.equal(-5.5)
-    })
-
-    it('should return null for blank inputs', () => {
+      expect(convertToNumberSafely(-5.5)).to.equal(-5.5)
+      expect(convertToNumberSafely('  10  ')).to.equal(10)
       expect(convertToNumberSafely('')).to.be.null
       expect(convertToNumberSafely(null)).to.be.null
-      expect(convertToNumberSafely('  ')).to.be.null
-    })
-
-    it('should return null for invalid strings', () => {
       expect(convertToNumberSafely('abc')).to.be.null
-      expect(convertToNumberSafely('12.34.56')).to.be.null
-    })
-
-    it('should preserve existing numbers', () => {
-      expect(convertToNumberSafely(42)).to.equal(42)
-      expect(convertToNumberSafely(-10.5)).to.equal(-10.5)
-    })
-
-    it('should handle mixed input types', () => {
-      expect(convertToNumberSafely('  10  ')).to.equal(10)
-      expect(convertToNumberSafely('  -5.0  ')).to.equal(-5)
     })
   })
 
   describe('extractLeadingNumber', () => {
-    it('should extract leading number from valid strings', () => {
+    it('should extract a leading number and return null if absent', () => {
       expect(extractLeadingNumber('123abc')).to.equal(123)
       expect(extractLeadingNumber('-12.5test')).to.equal(-12.5)
-      expect(extractLeadingNumber('10.0more')).to.equal(10)
-    })
-
-    it('should return null for invalid or no leading number', () => {
-      expect(extractLeadingNumber('abc123')).to.be.null
-      expect(extractLeadingNumber('')).to.be.null
-      expect(extractLeadingNumber(null)).to.be.null
-    })
-
-    it('should handle whitespace', () => {
       expect(extractLeadingNumber('  15text')).to.equal(15)
-      expect(extractLeadingNumber('  -5.5text')).to.equal(-5.5)
-    })
-
-    it('should ignore subsequent non-numeric characters', () => {
-      expect(extractLeadingNumber('12.34abc')).to.equal(12.34)
-      expect(extractLeadingNumber('-10.5xyz')).to.equal(-10.5)
+      expect(extractLeadingNumber('abc123')).to.be.null
+      expect(extractLeadingNumber(null)).to.be.null
     })
   })
 
   describe('normalizeNum', () => {
-    it('should normalize string and number values to number', () => {
+    it('should normalize to number and return null for invalid inputs', () => {
       expect(normalizeNum('100.0')).to.equal(100)
       expect(normalizeNum(100)).to.equal(100)
-      expect(normalizeNum('0')).to.equal(0)
-    })
-
-    it('should return null for null, undefined, empty string, or NaN', () => {
       expect(normalizeNum(null)).to.be.null
       expect(normalizeNum(undefined)).to.be.null
       expect(normalizeNum('')).to.be.null
@@ -489,54 +268,26 @@ describe('Util Functions Unit Tests', () => {
   })
 
   describe('numEq', () => {
-    it('should return true for numerically equal values', () => {
+    it('should compare numerically, treating null as equal to null only', () => {
       expect(numEq('100.0', 100)).to.be.true
-      expect(numEq('0', 0)).to.be.true
       expect(numEq(null, null)).to.be.true
-    })
-
-    it('should return false for unequal or mismatched null values', () => {
       expect(numEq('1', null)).to.be.false
-      expect(numEq(null, 0)).to.be.false
       expect(numEq('1', 2)).to.be.false
     })
   })
 
   describe('strEq', () => {
-    it('should return true for equal strings and null/null', () => {
+    it('should compare strings and treat null/undefined as equivalent', () => {
       expect(strEq('AT', 'AT')).to.be.true
       expect(strEq(null, null)).to.be.true
       expect(strEq(undefined, null)).to.be.true
-    })
-
-    it('should return false for different strings or null mismatch', () => {
       expect(strEq(null, 'AT')).to.be.false
       expect(strEq('AT', 'BT')).to.be.false
     })
   })
 
   describe('addExecutionOptionsFromMappings', () => {
-    it('should add option to selected when flag is true', () => {
-      const selected: ExecutionOptionsEnum[] = []
-      const excluded: ExecutionOptionsEnum[] = []
-      addExecutionOptionsFromMappings(selected, excluded, [
-        { flag: true, option: ExecutionOptionsEnum.BackGrowEnabled },
-      ])
-      expect(selected).to.deep.equal([ExecutionOptionsEnum.BackGrowEnabled])
-      expect(excluded).to.be.empty
-    })
-
-    it('should add option to excluded when flag is false', () => {
-      const selected: ExecutionOptionsEnum[] = []
-      const excluded: ExecutionOptionsEnum[] = []
-      addExecutionOptionsFromMappings(selected, excluded, [
-        { flag: false, option: ExecutionOptionsEnum.ForwardGrowEnabled },
-      ])
-      expect(selected).to.be.empty
-      expect(excluded).to.deep.equal([ExecutionOptionsEnum.ForwardGrowEnabled])
-    })
-
-    it('should handle multiple mappings correctly', () => {
+    it('should distribute multiple mappings to selected or excluded based on flag', () => {
       const selected: ExecutionOptionsEnum[] = []
       const excluded: ExecutionOptionsEnum[] = []
       addExecutionOptionsFromMappings(selected, excluded, [

--- a/frontend/src/views/ProjectionDetail.vue
+++ b/frontend/src/views/ProjectionDetail.vue
@@ -265,7 +265,7 @@ const router = useRouter()
 const { isLoading: isProjectionLoading, loadProjection } = useProjectionLoader()
 const alertDialogStore = useAlertDialogStore()
 
-const reportSettingsPanelRef = ref<{ onConfirm: () => Promise<boolean> }>()
+const reportSettingsPanelRef = ref<{ onConfirm: () => Promise<boolean>; isDirty: boolean; resetDirty: () => Promise<void> }>()
 
 const isProgressVisible = ref(false)
 const progressMessage = ref('')
@@ -371,15 +371,16 @@ onUnmounted(() => {
   stopPolling()
 })
 
-// Cancel button for ReportSettings panel: enabled when user is actively editing that panel
-const isCancelDisabled = computed(() =>
-  !modelParameterStore.panelState[CONSTANTS.MANUAL_INPUT_PANEL.REPORT_SETTINGS].editable,
-)
+const isCancelDisabled = computed(() => {
+  if (!modelParameterStore.panelState[CONSTANTS.MANUAL_INPUT_PANEL.REPORT_SETTINGS].editable) return true
+  return !(reportSettingsPanelRef.value?.isDirty ?? false)
+})
 
 const onRevertCancel = async () => {
   appStore.isSavingProjection = true
   try {
     await revertPanelToSaved(CONSTANTS.MANUAL_INPUT_PANEL.REPORT_SETTINGS as PanelName)
+    await reportSettingsPanelRef.value?.resetDirty()
   } catch (error) {
     console.error('Error reverting report settings to saved state:', error)
     notificationStore.showErrorMessage(MESSAGE.PROJECTION_ERR.LOAD_FAILED, MESSAGE.PROJECTION_ERR.LOAD_FAILED_TITLE)


### PR DESCRIPTION
- Added dirty tracking to all panels with a Cancel button in both File Upload and Manual Input modes
- Cancel button is now disabled until the user makes a change, and re-disabled after Cancel or Next