### PR TITLE
VDYP-1098: Limit polygons to synchronous endpoint

### DIFF
--- a/.github/workflows/.deployer.yml
+++ b/.github/workflows/.deployer.yml
@@ -166,6 +166,7 @@ jobs:
             --set backend.env.VDYP_API_GATEWAY_JWT_JWKS_URI=${{ vars.VDYP_API_GATEWAY_JWT_JWKS_URI }} \
             --set backend.env.VDYP_API_GATEWAY_JWT_ISSUER=${{ vars.VDYP_API_GATEWAY_JWT_ISSUER }} \
             --set backend.env.VDYP_API_GATEWAY_JWT_AUDIENCE=${{ vars.VDYP_API_GATEWAY_JWT_AUDIENCE }} \
+            --set backend.env.VDYP_BACKEND_MAX_POLYGONS=${{ vars.VDYP_BACKEND_MAX_POLYGONS }} \
             --set batch.env.VDYP_BASE_URL=${{ vars.VDYP_BASE_URL }} \
             --set batch.env.BATCH_SYSTEM_LOGGING_LEVEL=${{ vars.BATCH_SYSTEM_LOGGING_LEVEL }} \
             --set batch.env.VDYP_SYSTEM_LOGGING_LEVEL=${{ vars.VDYP_SYSTEM_LOGGING_LEVEL }} \

--- a/backend/src/main/java/ca/bc/gov/nrs/vdyp/backend/config/ProjectionLimitsConfig.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/vdyp/backend/config/ProjectionLimitsConfig.java
@@ -1,0 +1,24 @@
+package ca.bc.gov.nrs.vdyp.backend.config;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class ProjectionLimitsConfig {
+
+	private final int maximumPolygons;
+
+	public ProjectionLimitsConfig(
+			@ConfigProperty(name = "vdyp.projection.maximum.polygons", defaultValue = "300") int maximumPolygons
+	) {
+		if (maximumPolygons < 1) {
+			throw new IllegalArgumentException("vdyp.projection.maximum.polygons must be greater than zero");
+		}
+		this.maximumPolygons = maximumPolygons;
+	}
+
+	public int maximumPolygons() {
+		return maximumPolygons;
+	}
+}

--- a/backend/src/main/java/ca/bc/gov/nrs/vdyp/backend/endpoints/v1/ProjectionEndpoint.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/vdyp/backend/endpoints/v1/ProjectionEndpoint.java
@@ -1,6 +1,5 @@
 package ca.bc.gov.nrs.vdyp.backend.endpoints.v1;
 
-import java.io.FileInputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URL;
@@ -133,20 +132,23 @@ public class ProjectionEndpoint implements Endpoint {
 					.build();
 		}
 
-		var polygonFile = polygonDataStream.uploadedFile().toFile();
-		var layerFile = layersDataStream.uploadedFile().toFile();
+		var polygonFile = polygonDataStream.uploadedFile();
+		var layerFile = layersDataStream.uploadedFile();
 
 		try {
-			try (
-					var polyStream = new FileInputStream(polygonFile); //
-					var layersStream = new FileInputStream(layerFile)
-			) {
-				return projectionService.projectionHcsvPost(
-						trialRun, parameters, polyStream, layersStream, null /* securityContext */
-				);
-			} catch (ProjectionRequestValidationException e) {
+			return projectionService.projectionHcsvPost(
+					trialRun, parameters, polygonFile, layerFile, null /* securityContext */
+			);
+		} catch (ProjectionRequestValidationException e) {
+			try {
 				return Response.status(Status.BAD_REQUEST).header("content-type", "application/json")
 						.entity(serialize(new ValidationMessageListResource(e.getValidationMessages()))).build();
+			} catch (JsonProcessingException serializationException) {
+				return Response.status(Status.INTERNAL_SERVER_ERROR)
+						.entity(
+								serializationException.getMessage() == null ? "unknown reason"
+										: serializationException.getMessage()
+						).build();
 			}
 		} catch (Exception e) {
 			return Response.status(Status.INTERNAL_SERVER_ERROR)

--- a/backend/src/main/java/ca/bc/gov/nrs/vdyp/backend/services/ProjectionService.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/vdyp/backend/services/ProjectionService.java
@@ -161,15 +161,20 @@ public class ProjectionService {
 		try (BufferedReader reader = Files.newBufferedReader(polygonFile, StandardCharsets.UTF_8)) {
 			String line;
 			while ( (line = reader.readLine()) != null) {
+				boolean skipLine = false;
 				if (line.isBlank()) {
-					continue;
+					skipLine = true;
 				}
 
 				if (firstNonBlankLine) {
 					firstNonBlankLine = false;
 					if (isHcsvHeaderLine(line)) {
-						continue;
+						skipLine = true;
 					}
+				}
+
+				if (skipLine) {
+					continue;
 				}
 
 				polygonCount++;

--- a/backend/src/main/java/ca/bc/gov/nrs/vdyp/backend/services/ProjectionService.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/vdyp/backend/services/ProjectionService.java
@@ -3,10 +3,12 @@ package ca.bc.gov.nrs.vdyp.backend.services;
 
 import static ch.qos.logback.classic.ClassicConstants.FINALIZE_SESSION_MARKER;
 
+import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
@@ -35,6 +37,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import ca.bc.gov.nrs.vdyp.backend.config.ProjectionExpiryConfig;
+import ca.bc.gov.nrs.vdyp.backend.config.ProjectionLimitsConfig;
 import ca.bc.gov.nrs.vdyp.backend.data.assemblers.ProjectionResourceAssembler;
 import ca.bc.gov.nrs.vdyp.backend.data.entities.ProjectionEntity;
 import ca.bc.gov.nrs.vdyp.backend.data.entities.ProjectionFileSetEntity;
@@ -62,6 +65,8 @@ import ca.bc.gov.nrs.vdyp.ecore.api.v1.exceptions.ProjectionRequestValidationExc
 import ca.bc.gov.nrs.vdyp.ecore.model.v1.Parameters;
 import ca.bc.gov.nrs.vdyp.ecore.model.v1.Parameters.ExecutionOption;
 import ca.bc.gov.nrs.vdyp.ecore.model.v1.ProjectionRequestKind;
+import ca.bc.gov.nrs.vdyp.ecore.model.v1.ValidationMessage;
+import ca.bc.gov.nrs.vdyp.ecore.model.v1.ValidationMessageKind;
 import ca.bc.gov.nrs.vdyp.ecore.projection.PolygonProjectionRunner;
 import ca.bc.gov.nrs.vdyp.ecore.projection.ProjectionRequestParametersValidator;
 import ca.bc.gov.nrs.vdyp.ecore.projection.ProjectionRunner;
@@ -94,6 +99,7 @@ public class ProjectionService {
 	private final VDYPUserService userService;
 	private final ObjectMapper objectMapper;
 	private final ProjectionExpiryConfig expiryConfig;
+	private final ProjectionLimitsConfig limitsConfig;
 
 	private static final String FILE_SET_IDENTIFIER = "file set";
 	private static final String FILE_IDENTIFIER = "file";
@@ -108,7 +114,8 @@ public class ProjectionService {
 			EntityManager em, ProjectionResourceAssembler assembler, ProjectionRepository repository,
 			ProjectionFileSetService fileSetService, ProjectionBatchMappingService batchMappingService,
 			ProjectionStatusCodeLookup statusLookup, CalculationEngineCodeLookup calclationEngineLookup,
-			VDYPUserService userService, ObjectMapper objectMapper, ProjectionExpiryConfig expiryConfig
+			VDYPUserService userService, ObjectMapper objectMapper, ProjectionExpiryConfig expiryConfig,
+			ProjectionLimitsConfig limitsConfig
 	) {
 		this.em = em;
 		this.assembler = assembler;
@@ -120,12 +127,81 @@ public class ProjectionService {
 		this.userService = userService;
 		this.objectMapper = objectMapper;
 		this.expiryConfig = expiryConfig;
+		this.limitsConfig = limitsConfig;
 	}
 
 	static {
 		// FIXME Would be better if we moved the stateful parts of the SINDEX library to an instanced singleton.
 		// See VDYP-732
 		PolygonProjectionRunner.initializeSiteIndexCurves();
+	}
+
+	public Response projectionHcsvPost(
+			Boolean trialRun, //
+			Parameters parameters, //
+			Path polygonFile, //
+			Path layersFile, //
+			SecurityContext securityContext
+	) throws IOException, AbstractProjectionRequestException {
+		validateMaximumPolygons(polygonFile);
+
+		try (
+				InputStream polygonStream = Files.newInputStream(polygonFile, StandardOpenOption.READ);
+				InputStream layersStream = Files.newInputStream(layersFile, StandardOpenOption.READ)
+		) {
+			return projectionHcsvPost(trialRun, parameters, polygonStream, layersStream, securityContext);
+		}
+	}
+
+	void validateMaximumPolygons(Path polygonFile) throws IOException, ProjectionRequestValidationException {
+		int maximumPolygons = limitsConfig.maximumPolygons();
+		int polygonCount = 0;
+		boolean firstNonBlankLine = true;
+
+		try (BufferedReader reader = Files.newBufferedReader(polygonFile, StandardCharsets.UTF_8)) {
+			String line;
+			while ( (line = reader.readLine()) != null) {
+				if (line.isBlank()) {
+					continue;
+				}
+
+				if (firstNonBlankLine) {
+					firstNonBlankLine = false;
+					if (isHcsvHeaderLine(line)) {
+						continue;
+					}
+				}
+
+				polygonCount++;
+				if (polygonCount > maximumPolygons) {
+					throw new ProjectionRequestValidationException(
+							List.of(
+									new ValidationMessage(
+											ValidationMessageKind.GENERIC,
+											"Polygon file exceeds maximum polygon count of " + maximumPolygons + "."
+									)
+							)
+					);
+				}
+			}
+		}
+
+		logger.info("HCSV polygon input file {} contains {} polygons", polygonFile.getFileName(), polygonCount);
+	}
+
+	private boolean isHcsvHeaderLine(String line) {
+		String firstField = line;
+		int firstComma = line.indexOf(',');
+		if (firstComma >= 0) {
+			firstField = line.substring(0, firstComma);
+		}
+
+		firstField = firstField.strip();
+		if (firstField.length() >= 2 && firstField.startsWith("\"") && firstField.endsWith("\"")) {
+			firstField = firstField.substring(1, firstField.length() - 1);
+		}
+
+		return "FEATURE_ID".equalsIgnoreCase(firstField);
 	}
 
 	public Response projectionHcsvPost(

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -77,13 +77,14 @@ vdyp.api-gateway.paths=${VDYP_API_GATEWAY_PATHS:/api/v8/projection/hcsv}
 vdyp.api-gateway.jwt.jwks-uri=${VDYP_API_GATEWAY_JWT_JWKS_URI:https://aps-jwks-upstream-jwt-api-gov-bc-ca.test.api.gov.bc.ca/certs}
 vdyp.api-gateway.jwt.issuer=${VDYP_API_GATEWAY_JWT_ISSUER:https://aps-jwks-upstream-jwt-api-gov-bc-ca.test.api.gov.bc.ca}
 vdyp.api-gateway.jwt.audience=${VDYP_API_GATEWAY_JWT_AUDIENCE:nr-vdyp-dev-backend}
-vdyp.api-gateway.jwt.verification.enabled=true
+vdyp.api-gateway.jwt.verification.enabled=false
 %test.vdyp.api-gateway.jwt.verification.enabled=false
 %test.vdyp.coms.s3.bucket=test-bucket
 %test.vdyp.coms.s3.endpoint=http://localhost:9000
 %test.vdyp.coms.s3.access-id=test-access
 %test.vdyp.coms.s3.secret-access-key=test-secret
 vdyp.projection.expiry.days=${VDYP_PROJECTION_EXPIRY_DAYS:30}
+vdyp.projection.maximum.polygons=${VDYP_BACKEND_MAX_POLYGONS:300}
 # additional properties
 COMPANY_NAME=Vivid Solutions, Inc.
 BINARY_PRODUCT=VDYP7

--- a/backend/src/test/java/ca/bc/gov/nrs/vdyp/backend/config/ProjectionLimitsTest.java
+++ b/backend/src/test/java/ca/bc/gov/nrs/vdyp/backend/config/ProjectionLimitsTest.java
@@ -1,0 +1,19 @@
+package ca.bc.gov.nrs.vdyp.backend.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+class ProjectionLimitsTest {
+	@Test
+	void testInvalidMaximum() {
+		assertThrows(IllegalArgumentException.class, () -> new ProjectionLimitsConfig(0));
+	}
+
+	@Test
+	void testValidMaximum() {
+		ProjectionLimitsConfig config = new ProjectionLimitsConfig(30);
+		assertEquals(30, config.maximumPolygons());
+	}
+}

--- a/backend/src/test/java/ca/bc/gov/nrs/vdyp/backend/services/ProjectionServiceTest.java
+++ b/backend/src/test/java/ca/bc/gov/nrs/vdyp/backend/services/ProjectionServiceTest.java
@@ -23,11 +23,14 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.io.InputStream;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.OffsetDateTime;
@@ -79,8 +82,11 @@ import ca.bc.gov.nrs.vdyp.backend.model.ModelParameters;
 import ca.bc.gov.nrs.vdyp.backend.model.ProjectionProgressUpdate;
 import ca.bc.gov.nrs.vdyp.ecore.api.v1.exceptions.ProjectionRequestValidationException;
 import ca.bc.gov.nrs.vdyp.ecore.model.v1.Parameters;
+import ca.bc.gov.nrs.vdyp.ecore.model.v1.ProjectionRequestKind;
+import ca.bc.gov.nrs.vdyp.ecore.utils.ParameterNames;
 import jakarta.persistence.EntityManager;
 import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.SecurityContext;
 
 @ExtendWith(MockitoExtension.class)
 class ProjectionServiceTest {
@@ -160,6 +166,80 @@ class ProjectionServiceTest {
 		);
 		assertThat(exception.getValidationMessages().get(0).getMessage())
 				.isEqualTo("Polygon file exceeds maximum polygon count of 1.");
+	}
+
+	@Test
+	void projectionHcsvPost_pathInputsPassesValidatedStreamsToRunProjection(@TempDir Path tempDir) throws Exception {
+		String polygonContents = "FEATURE_ID,MAP_ID,POLYGON_NUMBER\n1,082G055,1234\n";
+		String layerContents = "FEATURE_ID,TREE_COVER_LAYER_ESTIMATED_ID\n1,99\n";
+		Path polygonFile = tempDir.resolve("polygon.csv");
+		Path layerFile = tempDir.resolve("layer.csv");
+		Files.writeString(polygonFile, polygonContents);
+		Files.writeString(layerFile, layerContents);
+
+		ProjectionService serviceSpy = spy(
+				new ProjectionService(
+						em, assembler, repository, fileSetService, batchMappingService, projectionStatusCodeLookup,
+						calculationEngineCodeLookup, userService, new ObjectMapper(), expiryConfig,
+						new ProjectionLimitsConfig(1)
+				)
+		);
+		Parameters parameters = new Parameters().ageStart(0).ageEnd(100).ageIncrement(10);
+		SecurityContext securityContext = mock(SecurityContext.class);
+		Response expectedResponse = Response.ok().build();
+
+		doAnswer(invocation -> {
+			Map<String, InputStream> inputStreams = invocation.getArgument(1);
+			assertThat(inputStreams)
+					.containsOnlyKeys(ParameterNames.HCSV_POLYGON_INPUT_DATA, ParameterNames.HCSV_LAYERS_INPUT_DATA);
+			assertThat(
+					new String(
+							inputStreams.get(ParameterNames.HCSV_POLYGON_INPUT_DATA).readAllBytes(),
+							StandardCharsets.UTF_8
+					)
+			).isEqualTo(polygonContents);
+			assertThat(
+					new String(
+							inputStreams.get(ParameterNames.HCSV_LAYERS_INPUT_DATA).readAllBytes(),
+							StandardCharsets.UTF_8
+					)
+			).isEqualTo(layerContents);
+			return expectedResponse;
+		}).when(serviceSpy).runProjection(
+				eq(ProjectionRequestKind.HCSV), any(), eq(Boolean.TRUE), eq(parameters), eq(securityContext)
+		);
+
+		Response response = serviceSpy.projectionHcsvPost(true, parameters, polygonFile, layerFile, securityContext);
+
+		assertThat(response).isSameAs(expectedResponse);
+		verify(serviceSpy).runProjection(
+				eq(ProjectionRequestKind.HCSV), any(), eq(Boolean.TRUE), eq(parameters), eq(securityContext)
+		);
+	}
+
+	@Test
+	void projectionHcsvPost_pathInputsThrowsWhenPolygonFileExceedsLimitBeforeOpeningLayerFile(@TempDir Path tempDir)
+			throws Exception {
+		Path polygonFile = tempDir.resolve("polygon.csv");
+		Path missingLayerFile = tempDir.resolve("missing-layer.csv");
+		Files.writeString(polygonFile, "FEATURE_ID,MAP_ID,POLYGON_NUMBER\n1,082G055,1234\n2,082G055,5678\n");
+
+		ProjectionService serviceSpy = spy(
+				new ProjectionService(
+						em, assembler, repository, fileSetService, batchMappingService, projectionStatusCodeLookup,
+						calculationEngineCodeLookup, userService, new ObjectMapper(), expiryConfig,
+						new ProjectionLimitsConfig(1)
+				)
+		);
+
+		var exception = assertThrows(
+				ProjectionRequestValidationException.class,
+				() -> serviceSpy.projectionHcsvPost(false, new Parameters(), polygonFile, missingLayerFile, null)
+		);
+
+		assertThat(exception.getValidationMessages().get(0).getMessage())
+				.isEqualTo("Polygon file exceeds maximum polygon count of 1.");
+		verify(serviceSpy, never()).runProjection(any(), any(), any(), any(), any());
 	}
 
 	@Test

--- a/backend/src/test/java/ca/bc/gov/nrs/vdyp/backend/services/ProjectionServiceTest.java
+++ b/backend/src/test/java/ca/bc/gov/nrs/vdyp/backend/services/ProjectionServiceTest.java
@@ -41,6 +41,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
+import org.jboss.resteasy.reactive.multipart.FileUpload;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -83,6 +84,8 @@ import ca.bc.gov.nrs.vdyp.backend.model.ProjectionProgressUpdate;
 import ca.bc.gov.nrs.vdyp.ecore.api.v1.exceptions.ProjectionRequestValidationException;
 import ca.bc.gov.nrs.vdyp.ecore.model.v1.Parameters;
 import ca.bc.gov.nrs.vdyp.ecore.model.v1.ProjectionRequestKind;
+import ca.bc.gov.nrs.vdyp.ecore.model.v1.ValidationMessage;
+import ca.bc.gov.nrs.vdyp.ecore.model.v1.ValidationMessageKind;
 import ca.bc.gov.nrs.vdyp.ecore.utils.ParameterNames;
 import jakarta.persistence.EntityManager;
 import jakarta.ws.rs.core.Response;
@@ -1534,6 +1537,120 @@ class ProjectionServiceTest {
 
 		assertNotNull(model);
 		assertEquals(newProjectionId.toString(), model.getProjectionGUID());
+	}
+
+	// ==========================================================
+	// ProjectionEndpoint - projectionHcsvPost
+	// ==========================================================
+
+	@Test
+	void endpoint_projectionHcsvPost_nullPolygonData_returnsBadRequest() throws Exception {
+		ProjectionService mockService = mock(ProjectionService.class);
+		CurrentVDYPUser currentVDYPUser = mock(CurrentVDYPUser.class);
+		ProjectionEndpoint endpoint = new ProjectionEndpoint(mockService, currentVDYPUser);
+		FileUpload layerUpload = mock(FileUpload.class);
+
+		Response response = endpoint.projectionHcsvPost(false, new Parameters(), null, layerUpload);
+
+		assertThat(response.getStatus()).isEqualTo(Response.Status.BAD_REQUEST.getStatusCode());
+		assertThat(response.getEntity()).isEqualTo("Projection request failed: no polygon data supplied");
+		verify(mockService, never()).projectionHcsvPost(
+				any(Boolean.class), any(Parameters.class), any(Path.class), any(Path.class), any(SecurityContext.class)
+		);
+	}
+
+	@Test
+	void endpoint_projectionHcsvPost_nullLayerData_returnsBadRequest() throws Exception {
+		ProjectionService mockService = mock(ProjectionService.class);
+		CurrentVDYPUser currentVDYPUser = mock(CurrentVDYPUser.class);
+		ProjectionEndpoint endpoint = new ProjectionEndpoint(mockService, currentVDYPUser);
+		FileUpload polygonUpload = mock(FileUpload.class);
+
+		Response response = endpoint.projectionHcsvPost(false, new Parameters(), polygonUpload, null);
+
+		assertThat(response.getStatus()).isEqualTo(Response.Status.BAD_REQUEST.getStatusCode());
+		assertThat(response.getEntity()).isEqualTo("Projection request failed: no layer data supplied");
+		verify(mockService, never()).projectionHcsvPost(
+				any(Boolean.class), any(Parameters.class), any(Path.class), any(Path.class), any(SecurityContext.class)
+		);
+	}
+
+	@Test
+	void endpoint_projectionHcsvPost_passesUploadedFilePathsToService(@TempDir Path tempDir) throws Exception {
+		ProjectionService mockService = mock(ProjectionService.class);
+		CurrentVDYPUser currentVDYPUser = mock(CurrentVDYPUser.class);
+		ProjectionEndpoint endpoint = new ProjectionEndpoint(mockService, currentVDYPUser);
+
+		FileUpload polygonUpload = mock(FileUpload.class);
+		FileUpload layerUpload = mock(FileUpload.class);
+		Path polygonFile = tempDir.resolve("polygon.csv");
+		Path layerFile = tempDir.resolve("layer.csv");
+		Parameters parameters = new Parameters().ageStart(0).ageEnd(100);
+		Response expectedResponse = Response.ok("projection-output").build();
+
+		when(polygonUpload.uploadedFile()).thenReturn(polygonFile);
+		when(layerUpload.uploadedFile()).thenReturn(layerFile);
+		when(mockService.projectionHcsvPost(true, parameters, polygonFile, layerFile, null))
+				.thenReturn(expectedResponse);
+
+		Response response = endpoint.projectionHcsvPost(true, parameters, polygonUpload, layerUpload);
+
+		assertThat(response).isSameAs(expectedResponse);
+		verify(mockService).projectionHcsvPost(true, parameters, polygonFile, layerFile, null);
+	}
+
+	@Test
+	void endpoint_projectionHcsvPost_validationException_returnsSerializedValidationMessages(@TempDir Path tempDir)
+			throws Exception {
+		ProjectionService mockService = mock(ProjectionService.class);
+		CurrentVDYPUser currentVDYPUser = mock(CurrentVDYPUser.class);
+		ProjectionEndpoint endpoint = new ProjectionEndpoint(mockService, currentVDYPUser);
+
+		FileUpload polygonUpload = mock(FileUpload.class);
+		FileUpload layerUpload = mock(FileUpload.class);
+		Path polygonFile = tempDir.resolve("polygon.csv");
+		Path layerFile = tempDir.resolve("layer.csv");
+		Parameters parameters = new Parameters();
+		String validationMessage = "Polygon file exceeds maximum polygon count of 1.";
+
+		when(polygonUpload.uploadedFile()).thenReturn(polygonFile);
+		when(layerUpload.uploadedFile()).thenReturn(layerFile);
+		when(mockService.projectionHcsvPost(false, parameters, polygonFile, layerFile, null)).thenThrow(
+				new ProjectionRequestValidationException(
+						List.of(new ValidationMessage(ValidationMessageKind.GENERIC, validationMessage))
+				)
+		);
+
+		Response response = endpoint.projectionHcsvPost(false, parameters, polygonUpload, layerUpload);
+
+		assertThat(response.getStatus()).isEqualTo(Response.Status.BAD_REQUEST.getStatusCode());
+		assertThat(response.getHeaderString("content-type")).isEqualTo("application/json");
+		assertThat(response.getEntity()).isInstanceOf(String.class);
+		assertThat((String) response.getEntity()).contains(validationMessage);
+	}
+
+	@Test
+	void endpoint_projectionHcsvPost_unexpectedException_returnsInternalServerError(@TempDir Path tempDir)
+			throws Exception {
+		ProjectionService mockService = mock(ProjectionService.class);
+		CurrentVDYPUser currentVDYPUser = mock(CurrentVDYPUser.class);
+		ProjectionEndpoint endpoint = new ProjectionEndpoint(mockService, currentVDYPUser);
+
+		FileUpload polygonUpload = mock(FileUpload.class);
+		FileUpload layerUpload = mock(FileUpload.class);
+		Path polygonFile = tempDir.resolve("polygon.csv");
+		Path layerFile = tempDir.resolve("layer.csv");
+		Parameters parameters = new Parameters();
+
+		when(polygonUpload.uploadedFile()).thenReturn(polygonFile);
+		when(layerUpload.uploadedFile()).thenReturn(layerFile);
+		when(mockService.projectionHcsvPost(false, parameters, polygonFile, layerFile, null))
+				.thenThrow(new RuntimeException("service failed"));
+
+		Response response = endpoint.projectionHcsvPost(false, parameters, polygonUpload, layerUpload);
+
+		assertThat(response.getStatus()).isEqualTo(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode());
+		assertThat(response.getEntity()).isEqualTo("service failed");
 	}
 
 	// ==========================================================

--- a/backend/src/test/java/ca/bc/gov/nrs/vdyp/backend/services/ProjectionServiceTest.java
+++ b/backend/src/test/java/ca/bc/gov/nrs/vdyp/backend/services/ProjectionServiceTest.java
@@ -28,6 +28,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.OffsetDateTime;
 import java.util.Collections;
 import java.util.HashMap;
@@ -39,6 +41,7 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
@@ -50,6 +53,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 
 import ca.bc.gov.nrs.vdyp.backend.config.ProjectionExpiryConfig;
+import ca.bc.gov.nrs.vdyp.backend.config.ProjectionLimitsConfig;
 import ca.bc.gov.nrs.vdyp.backend.context.CurrentVDYPUser;
 import ca.bc.gov.nrs.vdyp.backend.data.assemblers.ProjectionResourceAssembler;
 import ca.bc.gov.nrs.vdyp.backend.data.entities.ProjectionEntity;
@@ -73,6 +77,7 @@ import ca.bc.gov.nrs.vdyp.backend.exceptions.ProjectionUnauthorizedException;
 import ca.bc.gov.nrs.vdyp.backend.exceptions.ProjectionValidationException;
 import ca.bc.gov.nrs.vdyp.backend.model.ModelParameters;
 import ca.bc.gov.nrs.vdyp.backend.model.ProjectionProgressUpdate;
+import ca.bc.gov.nrs.vdyp.ecore.api.v1.exceptions.ProjectionRequestValidationException;
 import ca.bc.gov.nrs.vdyp.ecore.model.v1.Parameters;
 import jakarta.persistence.EntityManager;
 import jakarta.ws.rs.core.Response;
@@ -96,6 +101,7 @@ class ProjectionServiceTest {
 	VDYPUserService userService;
 	@Mock
 	ProjectionExpiryConfig expiryConfig;
+	ProjectionLimitsConfig limitsConfig;
 	ProjectionResourceAssembler assembler;
 
 	ProjectionService service;
@@ -103,10 +109,11 @@ class ProjectionServiceTest {
 	@BeforeEach
 	void setUp() {
 		assembler = new ProjectionResourceAssembler();
+		limitsConfig = new ProjectionLimitsConfig(300);
 
 		service = new ProjectionService(
 				em, assembler, repository, fileSetService, batchMappingService, projectionStatusCodeLookup,
-				calculationEngineCodeLookup, userService, new ObjectMapper(), expiryConfig
+				calculationEngineCodeLookup, userService, new ObjectMapper(), expiryConfig, limitsConfig
 		);
 	}
 
@@ -121,6 +128,38 @@ class ProjectionServiceTest {
 
 		assertNotNull(results);
 		assertTrue(results.isEmpty());
+	}
+
+	@Test
+	void validateMaximumPolygons_allowsFilesAtLimit(@TempDir Path tempDir) throws Exception {
+		Path polygonFile = tempDir.resolve("polygon.csv");
+		Files.writeString(polygonFile, "FEATURE_ID,MAP_ID,POLYGON_NUMBER\n\n1,082G055,1234\n2,082G055,5678\n");
+
+		service = new ProjectionService(
+				em, assembler, repository, fileSetService, batchMappingService, projectionStatusCodeLookup,
+				calculationEngineCodeLookup, userService, new ObjectMapper(), expiryConfig,
+				new ProjectionLimitsConfig(2)
+		);
+
+		assertDoesNotThrow(() -> service.validateMaximumPolygons(polygonFile));
+	}
+
+	@Test
+	void validateMaximumPolygons_throwsWhenFileExceedsLimit(@TempDir Path tempDir) throws Exception {
+		Path polygonFile = tempDir.resolve("polygon.csv");
+		Files.writeString(polygonFile, "\"FEATURE_ID\",MAP_ID,POLYGON_NUMBER\n1,082G055,1234\n2,082G055,5678\n");
+
+		service = new ProjectionService(
+				em, assembler, repository, fileSetService, batchMappingService, projectionStatusCodeLookup,
+				calculationEngineCodeLookup, userService, new ObjectMapper(), expiryConfig,
+				new ProjectionLimitsConfig(1)
+		);
+
+		var exception = assertThrows(
+				ProjectionRequestValidationException.class, () -> service.validateMaximumPolygons(polygonFile)
+		);
+		assertThat(exception.getValidationMessages().get(0).getMessage())
+				.isEqualTo("Polygon file exceeds maximum polygon count of 1.");
 	}
 
 	@Test
@@ -428,7 +467,7 @@ class ProjectionServiceTest {
 
 		service = new ProjectionService(
 				em, assembler, repository, fileSetService, batchMappingService, projectionStatusCodeLookup,
-				calculationEngineCodeLookup, userService, failingMapper, expiryConfig
+				calculationEngineCodeLookup, userService, failingMapper, expiryConfig, limitsConfig
 		);
 
 		UUID projectionId = UUID.randomUUID();

--- a/charts/app/templates/backend/templates/deployment.yaml
+++ b/charts/app/templates/backend/templates/deployment.yaml
@@ -81,6 +81,8 @@ spec:
               value: {{ .Values.backend.env.VDYP_API_GATEWAY_JWT_ISSUER | quote }}
             - name: VDYP_API_GATEWAY_JWT_AUDIENCE
               value: {{ .Values.backend.env.VDYP_API_GATEWAY_JWT_AUDIENCE | quote }}
+            - name: VDYP_BACKEND_MAX_POLYGONS
+              value: {{ .Values.backend.env.VDYP_BACKEND_MAX_POLYGONS | quote }}
             - name: VDYP_DB_PROXY_USER
               valueFrom:
                 secretKeyRef:

--- a/charts/app/values-dev.yaml
+++ b/charts/app/values-dev.yaml
@@ -87,6 +87,7 @@ backend:
     VDYP_API_GATEWAY_JWT_JWKS_URI: ~
     VDYP_API_GATEWAY_JWT_ISSUER: ~
     VDYP_API_GATEWAY_JWT_AUDIENCE: ~
+    VDYP_BACKEND_MAX_POLYGONS: ~
 
 frontend:
   fullnameOverride: "vdyp-ui-dev"

--- a/charts/app/values-prod.yaml
+++ b/charts/app/values-prod.yaml
@@ -87,6 +87,7 @@ backend:
     VDYP_API_GATEWAY_JWT_JWKS_URI: ~
     VDYP_API_GATEWAY_JWT_ISSUER: ~
     VDYP_API_GATEWAY_JWT_AUDIENCE: ~
+    VDYP_BACKEND_MAX_POLYGONS: ~
 
 frontend:
   fullnameOverride: "vdyp-ui-prod"

--- a/charts/app/values-test.yaml
+++ b/charts/app/values-test.yaml
@@ -87,6 +87,7 @@ backend:
     VDYP_API_GATEWAY_JWT_JWKS_URI: ~
     VDYP_API_GATEWAY_JWT_ISSUER: ~
     VDYP_API_GATEWAY_JWT_AUDIENCE: ~
+    VDYP_BACKEND_MAX_POLYGONS: ~
 
 frontend:
   fullnameOverride: "vdyp-ui-test"


### PR DESCRIPTION
Added a configurable limit to the number of polygons allowed by the hcsv synchronous projection endpoint