### PR TITLE
Feature/VDYP-1140: Clear unsaved changes on Cancel when no projection exists yet

### DIFF
--- a/frontend/src/services/projection/fileUploadService.ts
+++ b/frontend/src/services/projection/fileUploadService.ts
@@ -327,7 +327,11 @@ export const revertPanelToSaved = async (panelName: FileUploadPanelName): Promis
   const fileUploadStore = useFileUploadStore()
 
   const projectionGUID = appStore.getCurrentProjectionGUID
-  if (!projectionGUID) return
+  if (!projectionGUID) {
+    fileUploadStore.resetStore()
+    fileUploadStore.initializeSpeciesGroups()
+    return
+  }
 
   const projectionModel = await getProjectionById(projectionGUID)
   const params = parseProjectionParams(projectionModel.projectionParameters)

--- a/frontend/src/services/projection/modelParameterService.ts
+++ b/frontend/src/services/projection/modelParameterService.ts
@@ -915,7 +915,10 @@ export const revertPanelToSaved = async (panelName: PanelName): Promise<void> =>
   const modelParameterStore = useModelParameterStore()
 
   const projectionGUID = appStore.getCurrentProjectionGUID
-  if (!projectionGUID) return
+  if (!projectionGUID) {
+    modelParameterStore.resetStore()
+    return
+  }
 
   const projectionModel = await getProjectionById(projectionGUID)
   const params = parseProjectionParams(projectionModel.projectionParameters)


### PR DESCRIPTION
- When no GUID exists, Cancel now resets the store to its initial defaults instead of doing nothing