### PR TITLE
Feature/VDYP-1151: Show unsaved changes confirmation dialog on panel cancel

### DIFF
--- a/frontend/src/components/projection/input/minimum-dbh/MinimumDBHPanel.vue
+++ b/frontend/src/components/projection/input/minimum-dbh/MinimumDBHPanel.vue
@@ -90,12 +90,14 @@ import { ActionPanel } from '@/components/projection'
 import { CONSTANTS, MESSAGE, OPTIONS } from '@/constants'
 import { saveProjectionOnPanelConfirm, revertPanelToSaved } from '@/services/projection/fileUploadService'
 import { useNotificationStore } from '@/stores/common/notificationStore'
+import { useAlertDialogStore } from '@/stores/common/alertDialogStore'
 import { PROJECTION_ERR } from '@/constants/message'
 
 const { mobile } = useDisplay()
 const appStore = useAppStore()
 const fileUploadStore = useFileUploadStore()
 const notificationStore = useNotificationStore()
+const alertDialogStore = useAlertDialogStore()
 
 const panelName = CONSTANTS.FILE_UPLOAD_PANEL.MINIMUM_DBH
 
@@ -219,6 +221,14 @@ const onConfirm = async () => {
 }
 
 const onCancel = async () => {
+  if (isDirty.value) {
+    const proceed = await alertDialogStore.openDialog(
+      MESSAGE.UNSAVED_CHANGES_DIALOG.TITLE,
+      MESSAGE.UNSAVED_CHANGES_DIALOG.MESSAGE,
+      { variant: 'warning' },
+    )
+    if (!proceed) return
+  }
   appStore.isSavingProjection = true
   try {
     await revertPanelToSaved(panelName)

--- a/frontend/src/components/projection/input/report-info/ReportConfigPanel.vue
+++ b/frontend/src/components/projection/input/report-info/ReportConfigPanel.vue
@@ -681,6 +681,14 @@ const onConfirm = async () => {
 }
 
 const onCancel = async () => {
+  if (isDirty.value) {
+    const proceed = await alertDialogStore.openDialog(
+      MESSAGE.UNSAVED_CHANGES_DIALOG.TITLE,
+      MESSAGE.UNSAVED_CHANGES_DIALOG.MESSAGE,
+      { variant: 'warning' },
+    )
+    if (!proceed) return
+  }
   suppressDirtyTracking = true
   appStore.isSavingProjection = true
   try {

--- a/frontend/src/components/projection/input/report-info/ReportDetailsPanel.vue
+++ b/frontend/src/components/projection/input/report-info/ReportDetailsPanel.vue
@@ -267,6 +267,14 @@ const onConfirm = async () => {
 }
 
 const onCancel = async () => {
+  if (isDirty.value) {
+    const proceed = await alertDialogStore.openDialog(
+      MESSAGE.UNSAVED_CHANGES_DIALOG.TITLE,
+      MESSAGE.UNSAVED_CHANGES_DIALOG.MESSAGE,
+      { variant: 'warning' },
+    )
+    if (!proceed) return
+  }
   suppressDirtyTracking = true
   appStore.isSavingProjection = true
   try {

--- a/frontend/src/components/projection/input/site-info/SiteInfoPanel.vue
+++ b/frontend/src/components/projection/input/site-info/SiteInfoPanel.vue
@@ -342,6 +342,7 @@ watch(ageType, markDirty)
 watch(spzAge, markDirty)
 watch(spzHeight, markDirty)
 watch(bha50SiteIndex, markDirty)
+watch(siteIndexRows, markDirty, { deep: true })
 
 const siteSpeciesOptions = computed(() =>
   speciesGroups.value.map((group: SpeciesGroup) => ({
@@ -685,6 +686,14 @@ const onHeaderEdit = async () => {
 }
 
 const onCancel = async () => {
+  if (isDirty.value) {
+    const proceed = await alertDialogStore.openDialog(
+      MESSAGE.UNSAVED_CHANGES_DIALOG.TITLE,
+      MESSAGE.UNSAVED_CHANGES_DIALOG.MESSAGE,
+      { variant: 'warning' },
+    )
+    if (!proceed) return
+  }
   suppressDirtyTracking = true
   appStore.isSavingProjection = true
   try {

--- a/frontend/src/components/projection/input/species-info/SpeciesInfoPanel.vue
+++ b/frontend/src/components/projection/input/species-info/SpeciesInfoPanel.vue
@@ -375,6 +375,14 @@ const onHeaderEdit = async () => {
 }
 
 const onCancel = async () => {
+  if (isDirty.value) {
+    const proceed = await alertDialogStore.openDialog(
+      MESSAGE.UNSAVED_CHANGES_DIALOG.TITLE,
+      MESSAGE.UNSAVED_CHANGES_DIALOG.MESSAGE,
+      { variant: 'warning' },
+    )
+    if (!proceed) return
+  }
   suppressDirtyTracking = true
   appStore.isSavingProjection = true
   try {

--- a/frontend/src/components/projection/input/stand-info/StandInfoPanel.vue
+++ b/frontend/src/components/projection/input/stand-info/StandInfoPanel.vue
@@ -569,6 +569,14 @@ const onHeaderEdit = async () => {
 }
 
 const onCancel = async () => {
+  if (isDirty.value) {
+    const proceed = await alertDialogStore.openDialog(
+      MESSAGE.UNSAVED_CHANGES_DIALOG.TITLE,
+      MESSAGE.UNSAVED_CHANGES_DIALOG.MESSAGE,
+      { variant: 'warning' },
+    )
+    if (!proceed) return
+  }
   suppressDirtyTracking = true
   appStore.isSavingProjection = true
   try {

--- a/frontend/src/views/ProjectionDetail.vue
+++ b/frontend/src/views/ProjectionDetail.vue
@@ -377,6 +377,14 @@ const isCancelDisabled = computed(() => {
 })
 
 const onRevertCancel = async () => {
+  if (reportSettingsPanelRef.value?.isDirty) {
+    const proceed = await alertDialogStore.openDialog(
+      MESSAGE.UNSAVED_CHANGES_DIALOG.TITLE,
+      MESSAGE.UNSAVED_CHANGES_DIALOG.MESSAGE,
+      { variant: 'warning' },
+    )
+    if (!proceed) return
+  }
   appStore.isSavingProjection = true
   try {
     await revertPanelToSaved(CONSTANTS.MANUAL_INPUT_PANEL.REPORT_SETTINGS as PanelName)


### PR DESCRIPTION
- When a user clicks the Cancel button on a projection parameter panel with unsaved changes, an "Unsaved Changes" warning dialog is now displayed before discarding edits

- Fixed 'SiteInfoPanel' not detecting changes to Site Indices table fields (Computed Value, Age Type, Age, Height in Meters, BHA Site Index) by adding a missing 'watch' on 'siteIndexRows'