### PR TITLE
Feature/VDYP-1152: Configure batch to write to a persistent volume claim

### DIFF
--- a/charts/app/templates/batch/templates/deployment.yaml
+++ b/charts/app/templates/batch/templates/deployment.yaml
@@ -107,6 +107,10 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.batch.env.BATCH_DB_SECRET_NAME }}
                   key: dbname
+            {{- if .Values.batch.pvc.enabled }}
+            - name: BATCH_ROOT_DIRECTORY
+              value: {{ .Values.batch.pvc.mountPath | quote }}
+            {{- end }}
 
           ports:
             - name: http
@@ -138,6 +142,17 @@ spec:
             requests:
               cpu: 50m
               memory: 256Mi
+          {{- if .Values.batch.pvc.enabled }}
+          volumeMounts:
+            - name: batch-data
+              mountPath: {{ .Values.batch.pvc.mountPath | quote }}
+          {{- end }}
+      {{- if .Values.batch.pvc.enabled }}
+      volumes:
+        - name: batch-data
+          persistentVolumeClaim:
+            claimName: {{ include "batch.fullname" . }}
+      {{- end }}
       {{- with .Values.batch.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/app/templates/batch/templates/pvc.yaml
+++ b/charts/app/templates/batch/templates/pvc.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.batch.enabled .Values.batch.pvc.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "batch.fullname" . }}
+  labels:
+    {{- include "batch.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.batch.pvc.accessModes }}
+  resources:
+    requests:
+      storage: {{ .Values.batch.pvc.size }}
+  storageClassName: {{ .Values.batch.pvc.storageClassName }}
+{{- end }}

--- a/charts/app/values-dev.yaml
+++ b/charts/app/values-dev.yaml
@@ -263,6 +263,12 @@ batch:
   #-- route configuration for external access (dev only for debugging)
   route:
     enabled: true
+  pvc:
+    enabled: true
+    size: 2Gi
+    storageClassName: netapp-file-standard
+    accessModes: ReadWriteMany
+    mountPath: /opt/vdyp-batch/data
   env:
     SPRING_PROFILES_ACTIVE: "dev"
     BATCH_DB_SECRET_NAME: crunchy-postgres-dev-pguser-batch

--- a/charts/app/values-prod.yaml
+++ b/charts/app/values-prod.yaml
@@ -263,6 +263,12 @@ batch:
   #-- route configuration for external access (dev only for debugging)
   route:
     enabled: true
+  pvc:
+    enabled: true
+    size: 2Gi
+    storageClassName: netapp-file-standard
+    accessModes: ReadWriteMany
+    mountPath: /opt/vdyp-batch/data
   env:
     SPRING_PROFILES_ACTIVE: "prod"
     BATCH_DB_SECRET_NAME: crunchy-postgres-prod-pguser-batch

--- a/charts/app/values-test.yaml
+++ b/charts/app/values-test.yaml
@@ -263,6 +263,12 @@ batch:
   #-- route configuration for external access (dev only for debugging)
   route:
     enabled: true
+  pvc:
+    enabled: true
+    size: 2Gi
+    storageClassName: netapp-file-standard
+    accessModes: ReadWriteMany
+    mountPath: /opt/vdyp-batch/data
   env:
     SPRING_PROFILES_ACTIVE: "test"
     BATCH_DB_SECRET_NAME: crunchy-postgres-test-pguser-batch


### PR DESCRIPTION
- Add PVC template for batch storage ('charts/app/templates/batch/templates/pvc.yaml')
- Mount PVC at '/opt/vdyp-batch/data' in batch deployment and inject 'BATCH_ROOT_DIRECTORY' env var pointing to the mount path
- Enable PVC config ('2Gi', 'netapp-file-standard', 'ReadWriteMany') across dev, test, and prod values files
  - 'ReadWriteMany' is set to support future remote partitioning and multi-pod scaling