### PR TITLE
Feature/VDYP-1163: Support e-notation values in FEATURE_ID field

### DIFF
--- a/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/util/BatchUtils.java
+++ b/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/util/BatchUtils.java
@@ -2,6 +2,7 @@ package ca.bc.gov.nrs.vdyp.batch.util;
 
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
@@ -151,7 +152,7 @@ public final class BatchUtils {
 			return null;
 		}
 		try {
-			return Long.valueOf(field);
+			return new BigDecimal(field).longValue();
 		} catch (NumberFormatException e) {
 			return null;
 		}

--- a/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/util/BatchUtils.java
+++ b/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/util/BatchUtils.java
@@ -152,10 +152,17 @@ public final class BatchUtils {
 			return null;
 		}
 		try {
-			return new BigDecimal(field).longValue();
+			return toLong(field);
 		} catch (NumberFormatException e) {
 			return null;
 		}
+	}
+
+	public static long toLong(String s) {
+		if (s.indexOf('.') >= 0 || s.indexOf('e') >= 0 || s.indexOf('E') >= 0) {
+			return new BigDecimal(s).longValue();
+		}
+		return Long.parseLong(s);
 	}
 
 	/**

--- a/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/util/BatchUtils.java
+++ b/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/util/BatchUtils.java
@@ -2,7 +2,6 @@ package ca.bc.gov.nrs.vdyp.batch.util;
 
 import java.io.BufferedReader;
 import java.io.IOException;
-import java.math.BigDecimal;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
@@ -16,6 +15,7 @@ import org.springframework.batch.core.StepExecution;
 import org.springframework.batch.item.ExecutionContext;
 
 import ca.bc.gov.nrs.vdyp.batch.model.VDYPProjectionProgressUpdate;
+import ca.bc.gov.nrs.vdyp.ecore.utils.CsvRecordBeanHelper;
 
 public final class BatchUtils {
 
@@ -152,17 +152,10 @@ public final class BatchUtils {
 			return null;
 		}
 		try {
-			return toLong(field);
+			return CsvRecordBeanHelper.parseLongAcceptNull(field);
 		} catch (NumberFormatException e) {
 			return null;
 		}
-	}
-
-	public static long toLong(String s) {
-		if (s.indexOf('.') >= 0 || s.indexOf('e') >= 0 || s.indexOf('E') >= 0) {
-			return new BigDecimal(s).longValue();
-		}
-		return Long.parseLong(s);
 	}
 
 	/**

--- a/batch/src/test/java/ca/bc/gov/nrs/vdyp/batch/util/BatchUtilsTest.java
+++ b/batch/src/test/java/ca/bc/gov/nrs/vdyp/batch/util/BatchUtilsTest.java
@@ -144,6 +144,41 @@ class BatchUtilsTest {
 	}
 
 	@Test
+	void toLong_standardInteger_parsesCorrectly() {
+		assertEquals(23000000L, BatchUtils.toLong("23000000"));
+	}
+
+	@Test
+	void toLong_eNotationLowerCase_parsesCorrectly() {
+		assertEquals(23000000L, BatchUtils.toLong("2.3e+07"));
+	}
+
+	@Test
+	void toLong_eNotationUpperCase_parsesCorrectly() {
+		assertEquals(23000000L, BatchUtils.toLong("2.3E+07"));
+	}
+
+	@Test
+	void toLong_invalidValue_throwsNumberFormatException() {
+		assertThrows(NumberFormatException.class, () -> BatchUtils.toLong("abc"));
+	}
+
+	@Test
+	void extractFeatureIdLong_eNotation_returnsLong() {
+		assertEquals(23000000L, BatchUtils.extractFeatureIdLong("2.3e+07,092O096,42344045"));
+	}
+
+	@Test
+	void extractFeatureIdLong_standardInteger_returnsLong() {
+		assertEquals(23000000L, BatchUtils.extractFeatureIdLong("23000000,092O096,42344045"));
+	}
+
+	@Test
+	void extractFeatureIdLong_invalidValue_returnsNull() {
+		assertNull(BatchUtils.extractFeatureIdLong("abc,092O096,42344045"));
+	}
+
+	@Test
 	void buildFinalProgress_nonWorkerStepIgnored() {
 		JobExecution jobExecution = mock(JobExecution.class);
 		when(jobExecution.getExecutionContext()).thenReturn(new ExecutionContext());

--- a/batch/src/test/java/ca/bc/gov/nrs/vdyp/batch/util/BatchUtilsTest.java
+++ b/batch/src/test/java/ca/bc/gov/nrs/vdyp/batch/util/BatchUtilsTest.java
@@ -15,6 +15,7 @@ import org.springframework.batch.core.StepExecution;
 import org.springframework.batch.item.ExecutionContext;
 
 import ca.bc.gov.nrs.vdyp.batch.model.VDYPProjectionProgressUpdate;
+import ca.bc.gov.nrs.vdyp.ecore.utils.CsvRecordBeanHelper;
 
 class BatchUtilsTest {
 	@Test
@@ -145,22 +146,22 @@ class BatchUtilsTest {
 
 	@Test
 	void toLong_standardInteger_parsesCorrectly() {
-		assertEquals(23000000L, BatchUtils.toLong("23000000"));
+		assertEquals(23000000L, CsvRecordBeanHelper.toLong("23000000"));
 	}
 
 	@Test
 	void toLong_eNotationLowerCase_parsesCorrectly() {
-		assertEquals(23000000L, BatchUtils.toLong("2.3e+07"));
+		assertEquals(23000000L, CsvRecordBeanHelper.toLong("2.3e+07"));
 	}
 
 	@Test
 	void toLong_eNotationUpperCase_parsesCorrectly() {
-		assertEquals(23000000L, BatchUtils.toLong("2.3E+07"));
+		assertEquals(23000000L, CsvRecordBeanHelper.toLong("2.3E+07"));
 	}
 
 	@Test
 	void toLong_invalidValue_throwsNumberFormatException() {
-		assertThrows(NumberFormatException.class, () -> BatchUtils.toLong("abc"));
+		assertThrows(NumberFormatException.class, () -> CsvRecordBeanHelper.toLong("abc"));
 	}
 
 	@Test

--- a/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/input/HcsvLayerRecordBean.java
+++ b/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/input/HcsvLayerRecordBean.java
@@ -3,7 +3,6 @@ package ca.bc.gov.nrs.vdyp.ecore.projection.input;
 import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -655,7 +654,7 @@ public class HcsvLayerRecordBean {
 					"Target VDYP7 Layer Code"
 			);
 
-			bvh.validateNumber(bean.featureId, n -> new BigDecimal(n).longValue(), "Feature Id");
+			bvh.validateNumber(bean.featureId, CsvRecordBeanHelper::parseLongAcceptNull, "Feature Id");
 			bvh.validateNumber(bean.polygonNumber, n -> Long.parseLong(n), "Polygon Number");
 
 			// TREE_COVER_ID is not transferred from the CSV to the layer snapshot in VDYP7

--- a/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/input/HcsvLayerRecordBean.java
+++ b/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/input/HcsvLayerRecordBean.java
@@ -3,6 +3,7 @@ package ca.bc.gov.nrs.vdyp.ecore.projection.input;
 import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -654,7 +655,7 @@ public class HcsvLayerRecordBean {
 					"Target VDYP7 Layer Code"
 			);
 
-			bvh.validateNumber(bean.featureId, n -> Long.parseLong(n), "Feature Id");
+			bvh.validateNumber(bean.featureId, n -> new BigDecimal(n).longValue(), "Feature Id");
 			bvh.validateNumber(bean.polygonNumber, n -> Long.parseLong(n), "Polygon Number");
 
 			// TREE_COVER_ID is not transferred from the CSV to the layer snapshot in VDYP7

--- a/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/input/HcsvPolygonRecordBean.java
+++ b/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/input/HcsvPolygonRecordBean.java
@@ -3,7 +3,6 @@ package ca.bc.gov.nrs.vdyp.ecore.projection.input;
 import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -561,7 +560,7 @@ public class HcsvPolygonRecordBean {
 
 			BeanValidatorHelper bvh = new BeanValidatorHelper(bean.polyFeatureId);
 
-			bvh.validateNumber(bean.polyFeatureId, n -> new BigDecimal(n).longValue(), "Feature ID");
+			bvh.validateNumber(bean.polyFeatureId, CsvRecordBeanHelper::parseLongAcceptNull, "Feature ID");
 
 			// lcl_CopyPolygonDataIntoSnapshot: 3156
 			bean.mapId = bvh.truncateString(bean.mapId, Vdyp7Constants.MAX_LEN_MAPSHEET);

--- a/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/input/HcsvPolygonRecordBean.java
+++ b/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/input/HcsvPolygonRecordBean.java
@@ -3,6 +3,7 @@ package ca.bc.gov.nrs.vdyp.ecore.projection.input;
 import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -319,7 +320,7 @@ public class HcsvPolygonRecordBean {
 	// ACCESSORS
 
 	public Long getFeatureId() {
-		return Long.valueOf(polyFeatureId);
+		return CsvRecordBeanHelper.parseLongAcceptNull(polyFeatureId);
 	}
 
 	public String getMapId() {
@@ -560,7 +561,7 @@ public class HcsvPolygonRecordBean {
 
 			BeanValidatorHelper bvh = new BeanValidatorHelper(bean.polyFeatureId);
 
-			bvh.validateNumber(bean.polyFeatureId, n -> Long.parseLong(n), "Feature ID");
+			bvh.validateNumber(bean.polyFeatureId, n -> new BigDecimal(n).longValue(), "Feature ID");
 
 			// lcl_CopyPolygonDataIntoSnapshot: 3156
 			bean.mapId = bvh.truncateString(bean.mapId, Vdyp7Constants.MAX_LEN_MAPSHEET);

--- a/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/utils/CsvRecordBeanHelper.java
+++ b/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/utils/CsvRecordBeanHelper.java
@@ -12,13 +12,14 @@ public class CsvRecordBeanHelper {
 	}
 
 	public static Long parseLongAcceptNull(String longText) {
-		if (longText == null) {
-			return null;
+		return longText == null ? null : toLong(longText);
+	}
+
+	public static long toLong(String s) {
+		if (s.indexOf('.') >= 0 || s.indexOf('e') >= 0 || s.indexOf('E') >= 0) {
+			return new BigDecimal(s).longValue();
 		}
-		if (longText.indexOf('.') >= 0 || longText.indexOf('e') >= 0 || longText.indexOf('E') >= 0) {
-			return new BigDecimal(longText).longValue();
-		}
-		return Long.parseLong(longText);
+		return Long.parseLong(s);
 	}
 
 	public static Short parseShortAcceptNull(String shortText) {

--- a/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/utils/CsvRecordBeanHelper.java
+++ b/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/utils/CsvRecordBeanHelper.java
@@ -1,5 +1,7 @@
 package ca.bc.gov.nrs.vdyp.ecore.utils;
 
+import java.math.BigDecimal;
+
 public class CsvRecordBeanHelper {
 
 	public static Double parseDoubleAcceptNull(String doubleText) {
@@ -7,7 +9,7 @@ public class CsvRecordBeanHelper {
 	}
 
 	public static Long parseLongAcceptNull(String longText) {
-		return longText == null ? null : Long.parseLong(longText);
+		return longText == null ? null : new BigDecimal(longText).longValue();
 	}
 
 	public static Short parseShortAcceptNull(String shortText) {

--- a/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/utils/CsvRecordBeanHelper.java
+++ b/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/utils/CsvRecordBeanHelper.java
@@ -4,12 +4,21 @@ import java.math.BigDecimal;
 
 public class CsvRecordBeanHelper {
 
+	private CsvRecordBeanHelper() {
+	}
+
 	public static Double parseDoubleAcceptNull(String doubleText) {
 		return doubleText == null ? null : Double.parseDouble(doubleText);
 	}
 
 	public static Long parseLongAcceptNull(String longText) {
-		return longText == null ? null : new BigDecimal(longText).longValue();
+		if (longText == null) {
+			return null;
+		}
+		if (longText.indexOf('.') >= 0 || longText.indexOf('e') >= 0 || longText.indexOf('E') >= 0) {
+			return new BigDecimal(longText).longValue();
+		}
+		return Long.parseLong(longText);
 	}
 
 	public static Short parseShortAcceptNull(String shortText) {

--- a/lib/vdyp-extended-core/src/test/java/ca/bc/gov/nrs/vdyp/ecore/utils/CsvRecordBeanHelperTest.java
+++ b/lib/vdyp-extended-core/src/test/java/ca/bc/gov/nrs/vdyp/ecore/utils/CsvRecordBeanHelperTest.java
@@ -1,0 +1,35 @@
+package ca.bc.gov.nrs.vdyp.ecore.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class CsvRecordBeanHelperTest {
+
+	@Test
+	void parseLongAcceptNull_nullValue_returnsNull() {
+		assertNull(CsvRecordBeanHelper.parseLongAcceptNull(null));
+	}
+
+	@Test
+	void parseLongAcceptNull_standardInteger_returnsLong() {
+		assertEquals(23000000L, CsvRecordBeanHelper.parseLongAcceptNull("23000000"));
+	}
+
+	@Test
+	void parseLongAcceptNull_eNotationLowerCase_returnsLong() {
+		assertEquals(23000000L, CsvRecordBeanHelper.parseLongAcceptNull("2.3e+07"));
+	}
+
+	@Test
+	void parseLongAcceptNull_eNotationUpperCase_returnsLong() {
+		assertEquals(23000000L, CsvRecordBeanHelper.parseLongAcceptNull("2.3E+07"));
+	}
+
+	@Test
+	void parseLongAcceptNull_invalidValue_throwsNumberFormatException() {
+		assertThrows(NumberFormatException.class, () -> CsvRecordBeanHelper.parseLongAcceptNull("abc"));
+	}
+}

--- a/lib/vdyp-extended-core/src/test/java/ca/bc/gov/nrs/vdyp/ecore/utils/CsvRecordBeanHelperTest.java
+++ b/lib/vdyp-extended-core/src/test/java/ca/bc/gov/nrs/vdyp/ecore/utils/CsvRecordBeanHelperTest.java
@@ -32,4 +32,24 @@ public class CsvRecordBeanHelperTest {
 	void parseLongAcceptNull_invalidValue_throwsNumberFormatException() {
 		assertThrows(NumberFormatException.class, () -> CsvRecordBeanHelper.parseLongAcceptNull("abc"));
 	}
+
+	@Test
+	void toLong_standardInteger_parsesCorrectly() {
+		assertEquals(23000000L, CsvRecordBeanHelper.toLong("23000000"));
+	}
+
+	@Test
+	void toLong_eNotationLowerCase_parsesCorrectly() {
+		assertEquals(23000000L, CsvRecordBeanHelper.toLong("2.3e+07"));
+	}
+
+	@Test
+	void toLong_eNotationUpperCase_parsesCorrectly() {
+		assertEquals(23000000L, CsvRecordBeanHelper.toLong("2.3E+07"));
+	}
+
+	@Test
+	void toLong_invalidValue_throwsNumberFormatException() {
+		assertThrows(NumberFormatException.class, () -> CsvRecordBeanHelper.toLong("abc"));
+	}
 }


### PR DESCRIPTION
- FEATURE_ID values in e-notation format caused projections to fail immediately
- Fixed by replacing 'Long.parseLong()' with 'new BigDecimal(s).longValue()' in 'CsvRecordBeanHelper', 'HcsvPolygonRecordBean', 'HcsvLayerRecordBean', and 'BatchUtils'.