### PR TITLE
VDYP-1165: Display VDYP version number in the UI and update project version to 1.2.0

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>ca.bc.gov.nrs.vdyp</groupId>
     <artifactId>vdyp-root</artifactId>
-    <version>8.0.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
   <artifactId>vdyp-backend</artifactId>
   <name>Variable Density Yield Project - Backend</name>

--- a/batch/pom.xml
+++ b/batch/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>ca.bc.gov.nrs.vdyp</groupId>
         <artifactId>vdyp-root</artifactId>
-        <version>8.0.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
     <artifactId>vdyp-batch</artifactId>
     <name>Variable Density Yield Project - Batch</name>

--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>ca.bc.gov.nrs.vdyp</groupId>
 		<artifactId>vdyp-root</artifactId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/charts/app/values-dev.yaml
+++ b/charts/app/values-dev.yaml
@@ -270,7 +270,7 @@ batch:
     enabled: true
   pvc:
     enabled: true
-    size: 2Gi
+    size: 5Gi
     storageClassName: netapp-file-standard
     accessModes: ReadWriteMany
     mountPath: /opt/vdyp-batch/data

--- a/frontend/src/layouts/DefaultLayout.vue
+++ b/frontend/src/layouts/DefaultLayout.vue
@@ -34,7 +34,7 @@ if (APP_VERSION) {
   color: #2D2D2D;
   font-family: var(--typography-font-families-bc-sans);
   font-size: 14px;
-  padding: 16px 24px 8px;
+  padding: 4px 16px 8px 16px;
   text-align: left;
 }
 </style>

--- a/frontend/src/layouts/DefaultLayout.vue
+++ b/frontend/src/layouts/DefaultLayout.vue
@@ -1,27 +1,22 @@
 <template>
-   <div
-    class="main-layout-container"
-  >
+  <div class="main-layout-container">
     <slot />
+    <div
+      v-if="appVersion"
+      class="vdyp-version-info"
+    >
+      VDYP Version: {{ appVersion }}
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
 import { APP_VERSION } from '@/constants/appVersion'
-import { BUILD_NUMBER } from '@/constants/buildNumber'
 
 let appVersion = ''
 if (APP_VERSION) {
-  const baseVersion = APP_VERSION.replace(
-    /(-snapshot|-SNAPSHOT|-Snapshot)/i,
-    '',
-  )
-  appVersion = `${baseVersion}.${BUILD_NUMBER || ''}`
+  appVersion = APP_VERSION.replace(/(-snapshot|-SNAPSHOT|-Snapshot)/i, '')
 }
-
-console.log(`App Version: ${appVersion}`)
-console.log(`Build Numer: ${BUILD_NUMBER}`)
-
 </script>
 
 <style scoped>
@@ -33,5 +28,13 @@ console.log(`Build Numer: ${BUILD_NUMBER}`)
   min-width: 0;
   width: 100%;
   overflow-x: hidden;
+}
+
+.vdyp-version-info {
+  color: #2D2D2D;
+  font-family: var(--typography-font-families-bc-sans);
+  font-size: 14px;
+  padding: 16px 24px 8px;
+  text-align: left;
 }
 </style>

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>ca.bc.gov.nrs.vdyp</groupId>
 		<artifactId>vdyp-root</artifactId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/lib/vdyp-back/pom.xml
+++ b/lib/vdyp-back/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>ca.bc.gov.nrs.vdyp</groupId>
 		<artifactId>vdyp-lib</artifactId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/lib/vdyp-common/pom.xml
+++ b/lib/vdyp-common/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>ca.bc.gov.nrs.vdyp</groupId>
 		<artifactId>vdyp-lib</artifactId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/lib/vdyp-extended-core/pom.xml
+++ b/lib/vdyp-extended-core/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>ca.bc.gov.nrs.vdyp</groupId>
 		<artifactId>vdyp-lib</artifactId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/lib/vdyp-fip/pom.xml
+++ b/lib/vdyp-fip/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>ca.bc.gov.nrs.vdyp</groupId>
 		<artifactId>vdyp-lib</artifactId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/lib/vdyp-forward/pom.xml
+++ b/lib/vdyp-forward/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>ca.bc.gov.nrs.vdyp</groupId>
 		<artifactId>vdyp-lib</artifactId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/lib/vdyp-integration-tests/pom.xml
+++ b/lib/vdyp-integration-tests/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>ca.bc.gov.nrs.vdyp</groupId>
 		<artifactId>vdyp-lib</artifactId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/lib/vdyp-si32/pom.xml
+++ b/lib/vdyp-si32/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>ca.bc.gov.nrs.vdyp</groupId>
 		<artifactId>vdyp-lib</artifactId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 	</parent>
 
 	<build>

--- a/lib/vdyp-sindex/pom.xml
+++ b/lib/vdyp-sindex/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>ca.bc.gov.nrs.vdyp</groupId>
 		<artifactId>vdyp-lib</artifactId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 	</parent>
 
 	<build>

--- a/lib/vdyp-vri/pom.xml
+++ b/lib/vdyp-vri/pom.xml
@@ -12,14 +12,14 @@
 	<parent>
 		<groupId>ca.bc.gov.nrs.vdyp</groupId>
 		<artifactId>vdyp-lib</artifactId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>
 		<dependency>
 			<groupId>ca.bc.gov.nrs.vdyp</groupId>
 			<artifactId>vdyp-common</artifactId>
-			<version>8.0.0-SNAPSHOT</version>
+			<version>1.2.0-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>ca.bc.gov.nrs.vdyp</groupId>
 	<artifactId>vdyp-root</artifactId>
-	<version>8.0.0-SNAPSHOT</version>
+	<version>1.2.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Variable Density Yield Project - Parent</name>

--- a/report-aggregate/pom.xml
+++ b/report-aggregate/pom.xml
@@ -3,7 +3,7 @@
 
 	<groupId>ca.bc.gov.nrs.vdyp</groupId>
   <artifactId>report-aggregate</artifactId>
-	<version>8.0.0-SNAPSHOT</version>
+	<version>1.2.0-SNAPSHOT</version>
   <name>Variable Density Yield Project - Report Aggregation</name>
   <description>Aggregate Coverage Report</description>
 

--- a/vdyp-test-oracle/pom.xml
+++ b/vdyp-test-oracle/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>ca.bc.gov.nrs.vdyp</groupId>
 		<artifactId>vdyp-root</artifactId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>


### PR DESCRIPTION
- Shows VDYP version (e.g. VDYP Version: 1.2.0)
- Updates all pom.xml versions from 8.0.0-SNAPSHOT to 1.2.0-SNAPSHOT