### PR TITLE
Feature/VDYP-1197: Delete job files from PVC after S3 upload

### DIFF
--- a/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/service/BatchResultAggregationService.java
+++ b/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/service/BatchResultAggregationService.java
@@ -833,24 +833,8 @@ public class BatchResultAggregationService {
 		}
 	}
 
-	/**
-	 * Recursively deletes a directory and all its contents.
-	 */
 	private void deleteDirectoryRecursively(Path directory) throws IOException {
-		if (!Files.exists(directory)) {
-			return;
-		}
-
-		try (Stream<Path> walk = Files.walk(directory)) {
-			walk.sorted(Comparator.reverseOrder()).forEach(path -> {
-				try {
-					Files.delete(path);
-					logger.trace("Deleted: {}", path);
-				} catch (IOException e) {
-					logger.warn("Failed to delete: {} - {}", path, e.getMessage());
-				}
-			});
-		}
+		BatchUtils.deleteDirectoryRecursively(directory);
 	}
 
 	/**

--- a/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/service/ResultPersistenceTasklet.java
+++ b/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/service/ResultPersistenceTasklet.java
@@ -18,6 +18,7 @@ import ca.bc.gov.nrs.vdyp.batch.client.vdyp.VdypClient;
 import ca.bc.gov.nrs.vdyp.batch.client.vdyp.VdypProjectionDetails;
 import ca.bc.gov.nrs.vdyp.batch.exception.BatchException;
 import ca.bc.gov.nrs.vdyp.batch.exception.BatchResultPersistenceException;
+import ca.bc.gov.nrs.vdyp.batch.util.BatchConstants;
 import ca.bc.gov.nrs.vdyp.batch.util.BatchUtils;
 
 @Component
@@ -73,9 +74,29 @@ public class ResultPersistenceTasklet extends VdypFileTasklet {
 			);
 
 			logger.debug("Completed persistence of result zip file to COMS.");
+
+			cleanupJobFiles(jobBasePath);
 		} catch (Exception e) {
 			throw BatchResultPersistenceException
 					.handleResultPersistenceFailure(e, "Failed to persist result zip to COMS.", jobGuid, jobId, logger);
+		}
+	}
+
+	private void cleanupJobFiles(Path jobBasePath) {
+		try {
+			BatchUtils.deleteDirectoryRecursively(jobBasePath);
+			logger.debug("[GUID: {}] Deleted job directory after S3 upload: {}", jobGuid, jobBasePath);
+		} catch (IOException e) {
+			logger.warn("[GUID: {}] Failed to delete job directory {}: {}", jobGuid, jobBasePath, e.getMessage());
+		}
+
+		Path warningsFile = Paths.get(jobBasePath + BatchConstants.Partition.WARNING_FILE_NAME);
+		try {
+			if (Files.deleteIfExists(warningsFile)) {
+				logger.debug("[GUID: {}] Deleted warnings file: {}", jobGuid, warningsFile);
+			}
+		} catch (IOException e) {
+			logger.warn("[GUID: {}] Failed to delete warnings file {}: {}", jobGuid, warningsFile, e.getMessage());
 		}
 	}
 

--- a/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/util/BatchUtils.java
+++ b/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/util/BatchUtils.java
@@ -2,14 +2,15 @@ package ca.bc.gov.nrs.vdyp.batch.util;
 
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.Comparator;
 import java.util.UUID;
-import java.util.stream.Stream;
 
 import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.JobExecution;
@@ -267,18 +268,25 @@ public final class BatchUtils {
 	 * @throws IOException if deletion fails for any entry
 	 */
 	public static void deleteDirectoryRecursively(Path directory) throws IOException {
-		if (!Files.exists(directory)) {
+		if (Files.notExists(directory)) {
 			return;
 		}
-		try (Stream<Path> walk = Files.walk(directory)) {
-			walk.sorted(Comparator.reverseOrder()).forEach(path -> {
-				try {
-					Files.delete(path);
-				} catch (IOException e) {
-					// Individual delete failures are logged by callers; continue to attempt remaining entries
+		Files.walkFileTree(directory, new SimpleFileVisitor<>() {
+			@Override
+			public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+				Files.delete(file);
+				return FileVisitResult.CONTINUE;
+			}
+
+			@Override
+			public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+				if (exc != null) {
+					throw exc;
 				}
-			});
-		}
+				Files.delete(dir);
+				return FileVisitResult.CONTINUE;
+			}
+		});
 	}
 
 	public static void confirmDirectoryExists(Path dirPath) throws IOException {

--- a/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/util/BatchUtils.java
+++ b/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/util/BatchUtils.java
@@ -7,7 +7,9 @@ import java.nio.file.Path;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Comparator;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.JobExecution;
@@ -256,6 +258,27 @@ public final class BatchUtils {
 		return new VDYPProjectionProgressUpdate(
 				jobGuid, totalPolygons, polygonsProcessed, errorCount, polygonsSkipped, 0
 		);
+	}
+
+	/**
+	 * Recursively deletes a directory and all its contents. Silently succeeds if the directory does not exist.
+	 *
+	 * @param directory The directory to delete
+	 * @throws IOException if deletion fails for any entry
+	 */
+	public static void deleteDirectoryRecursively(Path directory) throws IOException {
+		if (!Files.exists(directory)) {
+			return;
+		}
+		try (Stream<Path> walk = Files.walk(directory)) {
+			walk.sorted(Comparator.reverseOrder()).forEach(path -> {
+				try {
+					Files.delete(path);
+				} catch (IOException e) {
+					// Individual delete failures are logged by callers; continue to attempt remaining entries
+				}
+			});
+		}
 	}
 
 	public static void confirmDirectoryExists(Path dirPath) throws IOException {

--- a/batch/src/test/java/ca/bc/gov/nrs/vdyp/batch/service/ResultPersistenceTaskletTest.java
+++ b/batch/src/test/java/ca/bc/gov/nrs/vdyp/batch/service/ResultPersistenceTaskletTest.java
@@ -242,4 +242,44 @@ class ResultPersistenceTaskletTest {
 				projectionGuid.toString(), resultFileSetGuid.toString(), placeholderFileMappingGuid.toString()
 		);
 	}
+
+	@Test
+	void testCleanupJobFiles_warningsPathIsNonEmptyDir_logsWarnAndContinues() throws Exception {
+		UUID resultFileSetGuid = UUID.randomUUID();
+		UUID resultFileComsObjectGuid = UUID.randomUUID();
+
+		jobParameters = new JobParametersBuilder().addString(BatchConstants.Job.GUID, "job-123")
+				.addString(BatchConstants.Job.BASE_DIR, tempDir.toString()) //
+				.addString(BatchConstants.Job.TIMESTAMP, BatchUtils.createJobTimestamp()) //
+				.addLong(BatchConstants.Partition.NUMBER, 4L) //
+				.addString(BatchConstants.GuidInput.PROJECTION_GUID, projectionGuid.toString()) //
+				.toJobParameters();
+		when(jobExecution.getJobParameters()).thenReturn(jobParameters);
+		when(jobExecution.getExecutionContext()).thenReturn(new ExecutionContext());
+		when(jobExecution.getStepExecutions()).thenReturn(Collections.emptyList());
+		when(vdypClient.getProjectionDetails(any())).thenReturn(details);
+		when(details.resultFileSet())
+				.thenReturn(new VdypProjectionDetails.VdypProjectionFileSet(resultFileSetGuid.toString()));
+		when(vdypClient.getFileSetFiles(any(), matches(resultFileSetGuid.toString()))).thenReturn(
+				List.of(new FileMappingDetails(UUID.randomUUID().toString(), resultFileComsObjectGuid.toString()))
+		);
+		when(details.reportTitle()).thenReturn("Test Report");
+		doNothing().when(comsFileService).updateStoredObject(any(UUID.class), any(Path.class), any(String.class));
+
+		Path finalZipPath = BatchUtils.getFinalZipName(tempDir, jobParameters.getString(BatchConstants.Job.TIMESTAMP));
+		Files.createFile(finalZipPath);
+
+		Path warningsAsDir = tempDir.getParent()
+				.resolve(tempDir.getFileName() + BatchConstants.Partition.WARNING_FILE_NAME);
+		Files.createDirectory(warningsAsDir);
+		Files.createFile(warningsAsDir.resolve("nested.txt"));
+
+		try {
+			RepeatStatus status = tasklet.execute(stepContribution, chunkContext);
+			assertEquals(RepeatStatus.FINISHED, status);
+		} finally {
+			Files.deleteIfExists(warningsAsDir.resolve("nested.txt"));
+			Files.deleteIfExists(warningsAsDir);
+		}
+	}
 }

--- a/batch/src/test/java/ca/bc/gov/nrs/vdyp/batch/service/ResultPersistenceTaskletTest.java
+++ b/batch/src/test/java/ca/bc/gov/nrs/vdyp/batch/service/ResultPersistenceTaskletTest.java
@@ -1,6 +1,7 @@
 package ca.bc.gov.nrs.vdyp.batch.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -155,6 +156,42 @@ class ResultPersistenceTaskletTest {
 		// Assert
 		assertEquals(RepeatStatus.FINISHED, status);
 		verify(comsFileService).updateStoredObject(eq(resultFileComsObjectGuid), any(Path.class), any(String.class));
+		assertFalse(Files.exists(tempDir), "Job directory should be deleted after successful S3 upload");
+	}
+
+	@Test
+	void testExecute_filesExist_warningsFileDeletedAfterUpload() throws Exception {
+		UUID resultFileSetGuid = UUID.randomUUID();
+		UUID resultFileComsObjectGuid = UUID.randomUUID();
+
+		jobParameters = new JobParametersBuilder().addString(BatchConstants.Job.GUID, "job-123")
+				.addString(BatchConstants.Job.BASE_DIR, tempDir.toString()) //
+				.addString(BatchConstants.Job.TIMESTAMP, BatchUtils.createJobTimestamp()) //
+				.addLong(BatchConstants.Partition.NUMBER, 4L) //
+				.addString(BatchConstants.GuidInput.PROJECTION_GUID, projectionGuid.toString()) //
+				.toJobParameters();
+		when(jobExecution.getJobParameters()).thenReturn(jobParameters);
+		when(jobExecution.getExecutionContext()).thenReturn(new ExecutionContext());
+		when(jobExecution.getStepExecutions()).thenReturn(Collections.emptyList());
+		when(vdypClient.getProjectionDetails(any())).thenReturn(details);
+		when(details.resultFileSet())
+				.thenReturn(new VdypProjectionDetails.VdypProjectionFileSet(resultFileSetGuid.toString()));
+		when(vdypClient.getFileSetFiles(any(), matches(resultFileSetGuid.toString()))).thenReturn(
+				List.of(new FileMappingDetails(UUID.randomUUID().toString(), resultFileComsObjectGuid.toString()))
+		);
+		when(details.reportTitle()).thenReturn("Test Report");
+		doNothing().when(comsFileService).updateStoredObject(any(UUID.class), any(Path.class), any(String.class));
+
+		Path finalZipPath = BatchUtils.getFinalZipName(tempDir, jobParameters.getString(BatchConstants.Job.TIMESTAMP));
+		Files.createFile(finalZipPath);
+
+		Path warningsFile = tempDir.getParent()
+				.resolve(tempDir.getFileName() + BatchConstants.Partition.WARNING_FILE_NAME);
+		Files.createFile(warningsFile);
+
+		tasklet.execute(stepContribution, chunkContext);
+
+		assertFalse(Files.exists(warningsFile), "Warnings file should be deleted after successful S3 upload");
 	}
 
 	@Test

--- a/batch/src/test/java/ca/bc/gov/nrs/vdyp/batch/util/BatchUtilsTest.java
+++ b/batch/src/test/java/ca/bc/gov/nrs/vdyp/batch/util/BatchUtilsTest.java
@@ -4,12 +4,16 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.StepExecution;
 import org.springframework.batch.item.ExecutionContext;
@@ -177,6 +181,23 @@ class BatchUtilsTest {
 	@Test
 	void extractFeatureIdLong_invalidValue_returnsNull() {
 		assertNull(BatchUtils.extractFeatureIdLong("abc,092O096,42344045"));
+	}
+
+	@Test
+	void deleteDirectoryRecursively_nonExistentDir_doesNothing(@TempDir Path tempDir) {
+		Path nonExistent = tempDir.resolve("does-not-exist");
+		assertDoesNotThrow(() -> BatchUtils.deleteDirectoryRecursively(nonExistent));
+		assertFalse(Files.exists(nonExistent));
+	}
+
+	@Test
+	void deleteDirectoryRecursively_existingDirWithFiles_deletesAll(@TempDir Path tempDir) throws IOException {
+		Path subDir = Files.createDirectory(tempDir.resolve("job-dir"));
+		Files.createFile(subDir.resolve("output.zip"));
+
+		BatchUtils.deleteDirectoryRecursively(subDir);
+
+		assertFalse(Files.exists(subDir));
 	}
 
 	@Test


### PR DESCRIPTION
- Delete job directory (zip + partition data) and warnings file from PVC after successful S3 upload
- Extract 'deleteDirectoryRecursively' into 'BatchUtils' to remove duplicate logic