### PR TITLE
Feature/VDYP-1196: Delete downloaded input files immediately after partitioning

### DIFF
--- a/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/service/DownloadAndPartitionTasklet.java
+++ b/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/service/DownloadAndPartitionTasklet.java
@@ -1,6 +1,7 @@
 package ca.bc.gov.nrs.vdyp.batch.service;
 
 import java.io.BufferedReader;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -94,6 +95,8 @@ public class DownloadAndPartitionTasklet extends VdypFileTasklet {
 			partitionedCount = inputPartitioner
 					.partitionCsvFiles(polygonPath, layerPath, computedPartitions, jobBaseDir, jobGuid);
 
+			deleteOriginalInputDirectory(inputDir);
+
 			stepExecution.getJobExecution().getExecutionContext()
 					.putInt(BatchConstants.Job.TOTAL_POLYGONS, partitionedCount);
 			stepExecution.getJobExecution().getExecutionContext()
@@ -107,6 +110,17 @@ public class DownloadAndPartitionTasklet extends VdypFileTasklet {
 		pushInitialProgress(partitionedCount);
 
 		logger.debug("Completed download and partitioning of input files.");
+	}
+
+	private void deleteOriginalInputDirectory(Path inputDir) {
+		try {
+			BatchUtils.deleteDirectoryRecursively(inputDir);
+			logger.debug("[GUID: {}] Deleted original input directory after partitioning: {}", jobGuid, inputDir);
+		} catch (IOException e) {
+			logger.warn(
+					"[GUID: {}] Failed to delete original input directory {}: {}", jobGuid, inputDir, e.getMessage()
+			);
+		}
 	}
 
 	private void pushInitialProgress(int totalPolygons) {

--- a/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/service/DownloadAndPartitionTasklet.java
+++ b/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/service/DownloadAndPartitionTasklet.java
@@ -112,15 +112,19 @@ public class DownloadAndPartitionTasklet extends VdypFileTasklet {
 		logger.debug("Completed download and partitioning of input files.");
 	}
 
-	private void deleteOriginalInputDirectory(Path inputDir) {
+	void deleteOriginalInputDirectory(Path inputDir) {
 		try {
-			BatchUtils.deleteDirectoryRecursively(inputDir);
+			deleteDirectory(inputDir);
 			logger.debug("[GUID: {}] Deleted original input directory after partitioning: {}", jobGuid, inputDir);
 		} catch (IOException e) {
 			logger.warn(
 					"[GUID: {}] Failed to delete original input directory {}: {}", jobGuid, inputDir, e.getMessage()
 			);
 		}
+	}
+
+	protected void deleteDirectory(Path dir) throws IOException {
+		BatchUtils.deleteDirectoryRecursively(dir);
 	}
 
 	private void pushInitialProgress(int totalPolygons) {

--- a/batch/src/test/java/ca/bc/gov/nrs/vdyp/batch/service/DownloadAndPartitionTaskletTest.java
+++ b/batch/src/test/java/ca/bc/gov/nrs/vdyp/batch/service/DownloadAndPartitionTaskletTest.java
@@ -1,5 +1,6 @@
 package ca.bc.gov.nrs.vdyp.batch.service;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -8,9 +9,11 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.matches;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -82,9 +85,9 @@ class DownloadAndPartitionTaskletTest {
 	void setup() {
 		tasklet = new DownloadAndPartitionTasklet(comsFileService, inputPartitioner, vdypClient, batchProperties);
 
-		when(chunkContext.getStepContext()).thenReturn(stepContext);
-		when(stepContext.getStepExecution()).thenReturn(stepExecution);
-		when(stepExecution.getJobExecution()).thenReturn(jobExecution);
+		lenient().when(chunkContext.getStepContext()).thenReturn(stepContext);
+		lenient().when(stepContext.getStepExecution()).thenReturn(stepExecution);
+		lenient().when(stepExecution.getJobExecution()).thenReturn(jobExecution);
 	}
 
 	@Test
@@ -196,6 +199,20 @@ class DownloadAndPartitionTaskletTest {
 		assertFalse(Files.exists(inputDir.resolve("polygon.csv")), "polygon.csv should be deleted after partitioning");
 		assertFalse(Files.exists(inputDir.resolve("layer.csv")), "layer.csv should be deleted after partitioning");
 		assertFalse(Files.exists(inputDir), "input directory should be deleted after partitioning");
+	}
+
+	@Test
+	void testDeleteOriginalInputDirectory_ioExceptionIsSwallowedAsWarning() {
+		DownloadAndPartitionTasklet testTasklet = new DownloadAndPartitionTasklet(
+				comsFileService, inputPartitioner, vdypClient, batchProperties
+		) {
+			@Override
+			protected void deleteDirectory(Path dir) throws IOException {
+				throw new IOException("simulated disk error");
+			}
+		};
+
+		assertDoesNotThrow(() -> testTasklet.deleteOriginalInputDirectory(tempDir));
 	}
 
 	@Test

--- a/batch/src/test/java/ca/bc/gov/nrs/vdyp/batch/service/DownloadAndPartitionTaskletTest.java
+++ b/batch/src/test/java/ca/bc/gov/nrs/vdyp/batch/service/DownloadAndPartitionTaskletTest.java
@@ -1,6 +1,7 @@
 package ca.bc.gov.nrs.vdyp.batch.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -190,6 +191,53 @@ class DownloadAndPartitionTaskletTest {
 				eq("job-123")
 		);
 		verify(vdypClient).pushProgress(eq(projectionGuid.toString()), any());
+
+		// Verify original input files are deleted after partitioning
+		assertFalse(Files.exists(inputDir.resolve("polygon.csv")), "polygon.csv should be deleted after partitioning");
+		assertFalse(Files.exists(inputDir.resolve("layer.csv")), "layer.csv should be deleted after partitioning");
+		assertFalse(Files.exists(inputDir), "input directory should be deleted after partitioning");
+	}
+
+	@Test
+	void testExecute_inputFilesDeletedEvenWhenPartitionerReturnsZero() throws Exception {
+		UUID polygonFileSetGuid = UUID.randomUUID();
+		UUID layerFileSetGuid = UUID.randomUUID();
+		polygonComsObjectGuid = UUID.randomUUID();
+		layerComsObjectGuid = UUID.randomUUID();
+
+		jobParameters = new JobParametersBuilder().addString(BatchConstants.Job.GUID, "job-456")
+				.addString(BatchConstants.Job.BASE_DIR, tempDir.toString()).addLong(BatchConstants.Partition.NUMBER, 2L)
+				.addString(BatchConstants.GuidInput.PROJECTION_GUID, projectionGuid.toString()).toJobParameters();
+		ExecutionContext executionContext = new ExecutionContext();
+		when(vdypClient.getProjectionDetails(any())).thenReturn(details);
+		when(details.polygonFileSet())
+				.thenReturn(new VdypProjectionDetails.VdypProjectionFileSet(polygonFileSetGuid.toString()));
+		when(details.layerFileSet())
+				.thenReturn(new VdypProjectionDetails.VdypProjectionFileSet(layerFileSetGuid.toString()));
+		when(jobExecution.getJobParameters()).thenReturn(jobParameters);
+		when(jobExecution.getExecutionContext()).thenReturn(executionContext);
+		when(vdypClient.getFileSetFiles(any(), matches(polygonFileSetGuid.toString()))).thenReturn(
+				List.of(new FileMappingDetails(polygonFileSetGuid.toString(), polygonComsObjectGuid.toString()))
+		);
+		when(vdypClient.getFileSetFiles(any(), matches(layerFileSetGuid.toString()))).thenReturn(
+				List.of(new FileMappingDetails(layerFileSetGuid.toString(), layerComsObjectGuid.toString()))
+		);
+
+		when(batchProperties.getReader()).thenReturn(readerProperties);
+		when(readerProperties.getDefaultChunkSize()).thenReturn(150);
+		when(batchProperties.getThreadPool()).thenReturn(threadPoolProperties);
+		when(threadPoolProperties.getMaxJobThreads()).thenReturn(4);
+
+		Path inputDir = tempDir.resolve("input");
+		Files.createDirectories(inputDir);
+		Files.writeString(inputDir.resolve("polygon.csv"), "FEATURE_ID\n12345\n");
+		Files.writeString(inputDir.resolve("layer.csv"), "LAYER_ID\n");
+		doNothing().when(comsFileService).fetchObjectToFile(any(UUID.class), any(Path.class));
+
+		RepeatStatus status = tasklet.execute(stepContribution, chunkContext);
+
+		assertEquals(RepeatStatus.FINISHED, status);
+		assertFalse(Files.exists(inputDir), "input directory should be cleaned up after partitioning");
 	}
 
 }


### PR DESCRIPTION
- Deletes the original 'input/' directory immediately after partitioning is complete, as these files are no longer needed once partitioned and were unnecessarily occupying PVC storage.