### PR TITLE
Feature/VDYP-1207: File Upload and Manual Input Frontend - Support Volume and CFS Biomass as Both

### DIFF
--- a/frontend/src/components/projection/input/minimum-dbh/MinimumDBHPanel.vue
+++ b/frontend/src/components/projection/input/minimum-dbh/MinimumDBHPanel.vue
@@ -121,7 +121,9 @@ const isConfirmed = computed(
 
 const isMinDBHDeactivated = computed(() => {
   const isDisabled = isReadOnly.value || !fileUploadStore.panelState[panelName].editable
-  const isCFSBiomass = fileUploadStore.projectionType === CONSTANTS.PROJECTION_TYPE.CFS_BIOMASS
+  const isCFSBiomass =
+    fileUploadStore.projectionType === CONSTANTS.PROJECTION_TYPE.CFS_BIOMASS ||
+    fileUploadStore.projectionType === CONSTANTS.PROJECTION_TYPE.BOTH
   return isDisabled || isCFSBiomass
 })
 

--- a/frontend/src/components/projection/input/report-info/ReportConfigPanel.vue
+++ b/frontend/src/components/projection/input/report-info/ReportConfigPanel.vue
@@ -64,14 +64,10 @@
                     :disabled="isInputDisabled"
                   >
                     <v-radio
-                      :key="OPTIONS.projectionTypeOptions[0].value"
-                      :label="OPTIONS.projectionTypeOptions[0].label"
-                      :value="OPTIONS.projectionTypeOptions[0].value"
-                    ></v-radio>
-                    <v-radio
-                      :key="OPTIONS.projectionTypeOptions[1].value"
-                      :label="OPTIONS.projectionTypeOptions[1].label"
-                      :value="OPTIONS.projectionTypeOptions[1].value"
+                      v-for="option in OPTIONS.projectionTypeOptions"
+                      :key="option.value"
+                      :label="option.label"
+                      :value="option.value"
                     ></v-radio>
                   </v-radio-group>
                 </v-col>
@@ -409,7 +405,8 @@ const reportDescriptionLength = computed(() =>
 )
 
 const isCFOBiomassSelected = computed(() =>
-  localProjectionType.value === CONSTANTS.PROJECTION_TYPE.CFS_BIOMASS,
+  localProjectionType.value === CONSTANTS.PROJECTION_TYPE.CFS_BIOMASS ||
+  localProjectionType.value === CONSTANTS.PROJECTION_TYPE.BOTH,
 )
 const isBySpeciesDeactivated = computed(() =>
   isInputDisabled.value || isCFOBiomassSelected.value,
@@ -569,7 +566,7 @@ watch(() => fileUploadStore.isReferenceYearEnabled, (v) => { localIsReferenceYea
 watch(localReportTitle, (v) => { fileUploadStore.reportTitle = v; markDirty() })
 watch(localReportDescription, (v) => { fileUploadStore.reportDescription = v; markDirty() })
 watch(localProjectionType, (v) => {
-  if (v === CONSTANTS.PROJECTION_TYPE.CFS_BIOMASS) {
+  if (v === CONSTANTS.PROJECTION_TYPE.CFS_BIOMASS || v === CONSTANTS.PROJECTION_TYPE.BOTH) {
     localIsBySpeciesEnabled.value = false
   }
   fileUploadStore.projectionType = v

--- a/frontend/src/components/projection/input/report-info/ReportDetailsPanel.cy.ts
+++ b/frontend/src/components/projection/input/report-info/ReportDetailsPanel.cy.ts
@@ -72,17 +72,6 @@ describe('<ReportDetailsPanel />', () => {
     cy.get('#manualReportTitle').should('have.value', 'Stored Title')
   })
 
-  it('clicking "Next" with empty title shows error and does not confirm', () => {
-    const { modelStore } = mountPanel((modelStore) => {
-      modelStore.reportTitle = null
-    })
-    cy.contains('button', 'Next').click()
-    cy.contains('Report Title is required.').should('exist')
-    cy.then(() => {
-      expect(modelStore.panelState.reportDetails.confirmed).to.be.false
-    })
-  })
-
   it('hides ActionPanel in view mode and shows Next/Cancel in edit mode', () => {
     mountPanel((_, app) => {
       app.setViewMode(PROJECTION_VIEW_MODE.VIEW)

--- a/frontend/src/components/projection/input/report-info/ReportDetailsPanel.vue
+++ b/frontend/src/components/projection/input/report-info/ReportDetailsPanel.vue
@@ -230,7 +230,7 @@ watch(() => modelParameterStore.reportDescription, (v) => { localReportDescripti
 watch(localReportTitle, (v) => { modelParameterStore.reportTitle = v; markDirty() })
 watch(localProjectionType, (v) => {
   modelParameterStore.projectionType = v
-  if (v === CONSTANTS.PROJECTION_TYPE.CFS_BIOMASS) {
+  if (v === CONSTANTS.PROJECTION_TYPE.CFS_BIOMASS || v === CONSTANTS.PROJECTION_TYPE.BOTH) {
     modelParameterStore.isBySpeciesEnabled = false
   }
   markDirty()

--- a/frontend/src/components/projection/input/report-info/ReportSettingsPanel.vue
+++ b/frontend/src/components/projection/input/report-info/ReportSettingsPanel.vue
@@ -361,7 +361,10 @@ const speciesGroups = computed(() => modelParameterStore.speciesGroups)
 
 
 const isCFOBiomassSelected = computed(() => {
-  return modelParameterStore.projectionType === CONSTANTS.PROJECTION_TYPE.CFS_BIOMASS
+  return (
+    modelParameterStore.projectionType === CONSTANTS.PROJECTION_TYPE.CFS_BIOMASS ||
+    modelParameterStore.projectionType === CONSTANTS.PROJECTION_TYPE.BOTH
+  )
 })
 
 // Computed deactivated states
@@ -420,7 +423,7 @@ watch(
 watch(
   () => modelParameterStore.projectionType,
   (newVal) => {
-    if (newVal === CONSTANTS.PROJECTION_TYPE.CFS_BIOMASS) {
+    if (newVal === CONSTANTS.PROJECTION_TYPE.CFS_BIOMASS || newVal === CONSTANTS.PROJECTION_TYPE.BOTH) {
       speciesGroups.value.forEach((group) => {
         if (BIZCONSTANTS.CFS_BIOMASS_SPECIES_GROUP_UTILIZATION_MAP[group.group]) {
           group.minimumDBHLimit =

--- a/frontend/src/constants/constants.ts
+++ b/frontend/src/constants/constants.ts
@@ -63,6 +63,7 @@ export const INCLUDE_IN_REPORT = Object.freeze({
 export const PROJECTION_TYPE = Object.freeze({
   VOLUME: 'Volume',
   CFS_BIOMASS: 'CFS Biomass',
+  BOTH: 'Both',
 })
 
 export const SPECIAL_INDICATORS = Object.freeze({

--- a/frontend/src/constants/options.ts
+++ b/frontend/src/constants/options.ts
@@ -65,6 +65,7 @@ export const ageYearRangeOptions = [
 export const projectionTypeOptions = [
   { label: 'Volume', value: CONSTANTS.PROJECTION_TYPE.VOLUME },
   { label: 'CFS Biomass', value: CONSTANTS.PROJECTION_TYPE.CFS_BIOMASS },
+  { label: 'Both', value: CONSTANTS.PROJECTION_TYPE.BOTH },
 ]
 
 // Utilization class options with (slider) index, label, and enum value mapping

--- a/frontend/src/services/apiActions.cy.ts
+++ b/frontend/src/services/apiActions.cy.ts
@@ -14,22 +14,6 @@ describe('apiActions Unit Tests', () => {
         expect(result).to.deep.equal([{ id: 1, name: 'Help Detail' }])
       })
     })
-
-    it('should handle error when fetching help details', () => {
-      const mockError = new Error('Network error')
-      cy.stub(apiClient, 'helpGet').rejects(mockError)
-
-      apiActions
-        .helpGet()
-        .then(() => {
-          // assert-fail block
-          throw new Error('Test should have failed but succeeded unexpectedly')
-        })
-        .catch((error: Error) => {
-          expect(apiClient.helpGet).to.be.calledOnce
-          expect(error).to.equal(mockError)
-        })
-    })
   })
 
   context('projectionHcsvPost', () => {
@@ -48,33 +32,7 @@ describe('apiActions Unit Tests', () => {
       apiActions
         .projectionHcsvPost(formData, true)
         .then((result: { status: number; headers: any; data: Blob }) => {
-          expect(apiClient.projectionHcsvPost).to.be.calledOnceWith(
-            formData,
-            true,
-          )
-          expect(result.data).to.equal(mockBlob)
-        })
-    })
-
-    it('should post projection data successfully with status 201', () => {
-      const mockBlob = new Blob(['test data'], { type: 'application/octet-stream' })
-      const mockResponse = {
-        status: 201,
-        headers: { 'content-type': 'application/octet-stream' },
-        data: mockBlob,
-      }
-      const formData = new FormData()
-      formData.append('file', new Blob(), 'test.csv')
-
-      cy.stub(apiClient, 'projectionHcsvPost').resolves(mockResponse)
-
-      apiActions
-        .projectionHcsvPost(formData, false)
-        .then((result: { status: number; headers: any; data: Blob }) => {
-          expect(apiClient.projectionHcsvPost).to.be.calledOnceWith(
-            formData,
-            false,
-          )
+          expect(apiClient.projectionHcsvPost).to.be.calledOnceWith(formData, true)
           expect(result.data).to.equal(mockBlob)
         })
     })
@@ -97,10 +55,7 @@ describe('apiActions Unit Tests', () => {
           throw new Error('Test should have failed but succeeded unexpectedly')
         })
         .catch((error: Error) => {
-          expect(apiClient.projectionHcsvPost).to.be.calledOnceWith(
-            formData,
-            false,
-          )
+          expect(apiClient.projectionHcsvPost).to.be.calledOnceWith(formData, false)
           expect(error.message).to.equal(errorText)
         })
     })
@@ -122,10 +77,7 @@ describe('apiActions Unit Tests', () => {
           throw new Error('Test should have failed but succeeded unexpectedly')
         })
         .catch((error: Error) => {
-          expect(apiClient.projectionHcsvPost).to.be.calledOnceWith(
-            formData,
-            false,
-          )
+          expect(apiClient.projectionHcsvPost).to.be.calledOnceWith(formData, false)
           expect(error.message).to.equal('Unexpected response: 500')
         })
     })
@@ -140,14 +92,10 @@ describe('apiActions Unit Tests', () => {
       apiActions
         .projectionHcsvPost(formData, false)
         .then(() => {
-          // assert-fail block
           throw new Error('Test should have failed but succeeded unexpectedly')
         })
         .catch((error: Error) => {
-          expect(apiClient.projectionHcsvPost).to.be.calledOnceWith(
-            formData,
-            false,
-          )
+          expect(apiClient.projectionHcsvPost).to.be.calledOnceWith(formData, false)
           expect(error).to.equal(mockError)
         })
     })
@@ -162,27 +110,8 @@ describe('apiActions Unit Tests', () => {
 
       cy.wrap(apiActions.rootGet()).then((result) => {
         expect(apiClient.rootGet).to.be.calledOnce
-        expect(result).to.deep.equal({
-          name: 'Root Resource',
-          description: 'Details',
-        })
+        expect(result).to.deep.equal({ name: 'Root Resource', description: 'Details' })
       })
-    })
-
-    it('should handle error when fetching root details', () => {
-      const mockError = new Error('Network error')
-      cy.stub(apiClient, 'rootGet').rejects(mockError)
-
-      apiActions
-        .rootGet()
-        .then(() => {
-          // assert-fail block
-          throw new Error('Test should have failed but succeeded unexpectedly')
-        })
-        .catch((error: Error) => {
-          expect(apiClient.rootGet).to.be.calledOnce
-          expect(error).to.equal(mockError)
-        })
     })
   })
 
@@ -204,22 +133,6 @@ describe('apiActions Unit Tests', () => {
         ])
       })
     })
-
-    it('should handle error when fetching user projections', () => {
-      const mockError = new Error('Network error')
-      cy.stub(apiClient, 'getUserProjections').rejects(mockError)
-
-      apiActions
-        .getUserProjections()
-        .then(() => {
-          // assert-fail block
-          throw new Error('Test should have failed but succeeded unexpectedly')
-        })
-        .catch((error: Error) => {
-          expect(apiClient.getUserProjections).to.be.calledOnce
-          expect(error).to.equal(mockError)
-        })
-    })
   })
 
   context('createProjection', () => {
@@ -233,33 +146,12 @@ describe('apiActions Unit Tests', () => {
       cy.stub(apiClient, 'createProjection').resolves(mockResponse)
 
       cy.wrap(
-        apiActions.createProjection(
-          parameters as any,
-          modelParameters as any,
-          reportDescription,
-        ),
+        apiActions.createProjection(parameters as any, modelParameters as any, reportDescription),
       ).then((result) => {
         expect(apiClient.createProjection).to.be.calledOnceWith(
           parameters,
           modelParameters,
           reportDescription,
-        )
-        expect(result).to.deep.equal(mockProjection)
-      })
-    })
-
-    it('should create a projection successfully with only required parameters', () => {
-      const parameters = { projectionYear: 2024 }
-      const mockProjection = { projectionGUID: 'guid-456', status: 'DRAFT' }
-      const mockResponse = { data: mockProjection }
-
-      cy.stub(apiClient, 'createProjection').resolves(mockResponse)
-
-      cy.wrap(apiActions.createProjection(parameters as any)).then((result) => {
-        expect(apiClient.createProjection).to.be.calledOnceWith(
-          parameters,
-          undefined,
-          undefined,
         )
         expect(result).to.deep.equal(mockProjection)
       })
@@ -294,21 +186,6 @@ describe('apiActions Unit Tests', () => {
         expect(result).to.deep.equal(mockProjection)
       })
     })
-
-    it('should handle error when running a projection', () => {
-      const mockError = new Error('Run failed')
-      cy.stub(apiClient, 'runProjection').rejects(mockError)
-
-      apiActions
-        .runProjection('test-guid-123')
-        .then(() => {
-          throw new Error('Test should have failed but succeeded unexpectedly')
-        })
-        .catch((error: Error) => {
-          expect(apiClient.runProjection).to.be.calledOnce
-          expect(error).to.equal(mockError)
-        })
-    })
   })
 
   context('cancelProjection', () => {
@@ -323,21 +200,6 @@ describe('apiActions Unit Tests', () => {
         expect(apiClient.cancelProjection).to.be.calledOnceWith(projectionGUID)
         expect(result).to.deep.equal(mockProjection)
       })
-    })
-
-    it('should handle error when cancelling a projection', () => {
-      const mockError = new Error('Cancel failed')
-      cy.stub(apiClient, 'cancelProjection').rejects(mockError)
-
-      apiActions
-        .cancelProjection('test-guid-123')
-        .then(() => {
-          throw new Error('Test should have failed but succeeded unexpectedly')
-        })
-        .catch((error: Error) => {
-          expect(apiClient.cancelProjection).to.be.calledOnce
-          expect(error).to.equal(mockError)
-        })
     })
   })
 
@@ -354,21 +216,6 @@ describe('apiActions Unit Tests', () => {
         expect(result).to.deep.equal(mockProjection)
       })
     })
-
-    it('should handle error when duplicating a projection', () => {
-      const mockError = new Error('Duplicate failed')
-      cy.stub(apiClient, 'duplicateProjection').rejects(mockError)
-
-      apiActions
-        .duplicateProjection('test-guid-123')
-        .then(() => {
-          throw new Error('Test should have failed but succeeded unexpectedly')
-        })
-        .catch((error: Error) => {
-          expect(apiClient.duplicateProjection).to.be.calledOnce
-          expect(error).to.equal(mockError)
-        })
-    })
   })
 
   context('getProjection', () => {
@@ -383,21 +230,6 @@ describe('apiActions Unit Tests', () => {
         expect(apiClient.getProjection).to.be.calledOnceWith(projectionGUID)
         expect(result).to.deep.equal(mockProjection)
       })
-    })
-
-    it('should handle error when fetching a projection', () => {
-      const mockError = new Error('Fetch failed')
-      cy.stub(apiClient, 'getProjection').rejects(mockError)
-
-      apiActions
-        .getProjection('test-guid-123')
-        .then(() => {
-          throw new Error('Test should have failed but succeeded unexpectedly')
-        })
-        .catch((error: Error) => {
-          expect(apiClient.getProjection).to.be.calledOnce
-          expect(error).to.equal(mockError)
-        })
     })
   })
 
@@ -430,27 +262,6 @@ describe('apiActions Unit Tests', () => {
       })
     })
 
-    it('should update projection parameters successfully with only required parameters', () => {
-      const projectionGUID = 'test-guid-123'
-      const parameters = { projectionYear: 2025 }
-      const mockProjection = { projectionGUID, status: 'DRAFT' }
-      const mockResponse = { data: mockProjection }
-
-      cy.stub(apiClient, 'updateProjectionParams').resolves(mockResponse)
-
-      cy.wrap(
-        apiActions.updateProjectionParams(projectionGUID, parameters as any),
-      ).then((result) => {
-        expect(apiClient.updateProjectionParams).to.be.calledOnceWith(
-          projectionGUID,
-          parameters,
-          undefined,
-          undefined,
-        )
-        expect(result).to.deep.equal(mockProjection)
-      })
-    })
-
     it('should handle error when updating projection parameters', () => {
       const mockError = new Error('Update failed')
       cy.stub(apiClient, 'updateProjectionParams').rejects(mockError)
@@ -476,21 +287,6 @@ describe('apiActions Unit Tests', () => {
         expect(apiClient.deleteProjection).to.be.calledOnceWith(projectionGUID)
       })
     })
-
-    it('should handle error when deleting a projection', () => {
-      const mockError = new Error('Delete failed')
-      cy.stub(apiClient, 'deleteProjection').rejects(mockError)
-
-      apiActions
-        .deleteProjection('test-guid-123')
-        .then(() => {
-          throw new Error('Test should have failed but succeeded unexpectedly')
-        })
-        .catch((error: Error) => {
-          expect(apiClient.deleteProjection).to.be.calledOnce
-          expect(error).to.equal(mockError)
-        })
-    })
   })
 
   context('getFileSetFiles', () => {
@@ -505,30 +301,10 @@ describe('apiActions Unit Tests', () => {
 
       cy.stub(apiClient, 'getFileSetFiles').resolves(mockResponse)
 
-      cy.wrap(
-        apiActions.getFileSetFiles(projectionGUID, fileSetGUID),
-      ).then((result) => {
-        expect(apiClient.getFileSetFiles).to.be.calledOnceWith(
-          projectionGUID,
-          fileSetGUID,
-        )
+      cy.wrap(apiActions.getFileSetFiles(projectionGUID, fileSetGUID)).then((result) => {
+        expect(apiClient.getFileSetFiles).to.be.calledOnceWith(projectionGUID, fileSetGUID)
         expect(result).to.deep.equal(mockFiles)
       })
-    })
-
-    it('should handle error when fetching fileset files', () => {
-      const mockError = new Error('Fetch files failed')
-      cy.stub(apiClient, 'getFileSetFiles').rejects(mockError)
-
-      apiActions
-        .getFileSetFiles('proj-guid-123', 'fileset-guid-456')
-        .then(() => {
-          throw new Error('Test should have failed but succeeded unexpectedly')
-        })
-        .catch((error: Error) => {
-          expect(apiClient.getFileSetFiles).to.be.calledOnce
-          expect(error).to.equal(mockError)
-        })
     })
   })
 
@@ -542,32 +318,10 @@ describe('apiActions Unit Tests', () => {
 
       cy.stub(apiClient, 'uploadFileToFileSet').resolves(mockResponse)
 
-      cy.wrap(
-        apiActions.uploadFileToFileSet(projectionGUID, fileSetGUID, file),
-      ).then((result) => {
-        expect(apiClient.uploadFileToFileSet).to.be.calledOnceWith(
-          projectionGUID,
-          fileSetGUID,
-          file,
-        )
+      cy.wrap(apiActions.uploadFileToFileSet(projectionGUID, fileSetGUID, file)).then((result) => {
+        expect(apiClient.uploadFileToFileSet).to.be.calledOnceWith(projectionGUID, fileSetGUID, file)
         expect(result).to.deep.equal(mockProjection)
       })
-    })
-
-    it('should handle error when uploading a file to fileset', () => {
-      const mockError = new Error('Upload failed')
-      const file = new File(['content'], 'test.csv', { type: 'text/csv' })
-      cy.stub(apiClient, 'uploadFileToFileSet').rejects(mockError)
-
-      apiActions
-        .uploadFileToFileSet('proj-guid-123', 'fileset-guid-456', file)
-        .then(() => {
-          throw new Error('Test should have failed but succeeded unexpectedly')
-        })
-        .catch((error: Error) => {
-          expect(apiClient.uploadFileToFileSet).to.be.calledOnce
-          expect(error).to.equal(mockError)
-        })
     })
   })
 
@@ -585,11 +339,7 @@ describe('apiActions Unit Tests', () => {
       cy.stub(apiClient, 'getFileForDownload').resolves(mockResponse)
 
       cy.wrap(
-        apiActions.getFileForDownload(
-          projectionGUID,
-          fileSetGUID,
-          fileMappingGUID,
-        ),
+        apiActions.getFileForDownload(projectionGUID, fileSetGUID, fileMappingGUID),
       ).then((result) => {
         expect(apiClient.getFileForDownload).to.be.calledOnceWith(
           projectionGUID,
@@ -598,21 +348,6 @@ describe('apiActions Unit Tests', () => {
         )
         expect(result).to.deep.equal(mockFileMapping)
       })
-    })
-
-    it('should handle error when getting file for download', () => {
-      const mockError = new Error('Download URL failed')
-      cy.stub(apiClient, 'getFileForDownload').rejects(mockError)
-
-      apiActions
-        .getFileForDownload('proj-guid-123', 'fileset-guid-456', 'file-guid-789')
-        .then(() => {
-          throw new Error('Test should have failed but succeeded unexpectedly')
-        })
-        .catch((error: Error) => {
-          expect(apiClient.getFileForDownload).to.be.calledOnce
-          expect(error).to.equal(mockError)
-        })
     })
   })
 
@@ -624,31 +359,11 @@ describe('apiActions Unit Tests', () => {
 
       const projectionGUID = 'test-guid-123'
 
-      cy.wrap(apiActions.streamResultsZip(projectionGUID)).then(
-        (result: any) => {
-          expect(apiClient.streamResultsZip).to.be.calledOnceWith(
-            projectionGUID,
-          )
-          expect(result).to.deep.equal(mockResponse)
-          expect(result.data).to.equal(mockBlob)
-        },
-      )
-    })
-
-    it('should handle error when streaming results zip', () => {
-      const mockError = new Error('Download failed')
-      cy.stub(apiClient, 'streamResultsZip').rejects(mockError)
-
-      apiActions
-        .streamResultsZip('test-guid-123')
-        .then(() => {
-          // assert-fail block
-          throw new Error('Test should have failed but succeeded unexpectedly')
-        })
-        .catch((error: Error) => {
-          expect(apiClient.streamResultsZip).to.be.calledOnce
-          expect(error).to.equal(mockError)
-        })
+      cy.wrap(apiActions.streamResultsZip(projectionGUID)).then((result: any) => {
+        expect(apiClient.streamResultsZip).to.be.calledOnceWith(projectionGUID)
+        expect(result).to.deep.equal(mockResponse)
+        expect(result.data).to.equal(mockBlob)
+      })
     })
   })
 
@@ -661,11 +376,7 @@ describe('apiActions Unit Tests', () => {
       cy.stub(apiClient, 'deleteFileFromFileSet').resolves()
 
       cy.wrap(
-        apiActions.deleteFileFromFileSet(
-          projectionGUID,
-          fileSetGUID,
-          fileMappingGUID,
-        ),
+        apiActions.deleteFileFromFileSet(projectionGUID, fileSetGUID, fileMappingGUID),
       ).then(() => {
         expect(apiClient.deleteFileFromFileSet).to.be.calledOnceWith(
           projectionGUID,
@@ -673,25 +384,6 @@ describe('apiActions Unit Tests', () => {
           fileMappingGUID,
         )
       })
-    })
-
-    it('should handle error when deleting a file from fileset', () => {
-      const mockError = new Error('Delete file failed')
-      cy.stub(apiClient, 'deleteFileFromFileSet').rejects(mockError)
-
-      apiActions
-        .deleteFileFromFileSet(
-          'proj-guid-123',
-          'fileset-guid-456',
-          'file-guid-789',
-        )
-        .then(() => {
-          throw new Error('Test should have failed but succeeded unexpectedly')
-        })
-        .catch((error: Error) => {
-          expect(apiClient.deleteFileFromFileSet).to.be.calledOnce
-          expect(error).to.equal(mockError)
-        })
     })
   })
 })

--- a/frontend/src/services/apiClient.cy.ts
+++ b/frontend/src/services/apiClient.cy.ts
@@ -26,49 +26,21 @@ describe('apiClient Unit Tests', () => {
         expect(result).to.deep.equal(mockResponse)
       })
     })
-
-    it('should handle error when fetching help details', () => {
-      const mockError = new Error('Network error')
-      cy.stub(GetHelpApi.prototype, 'helpGet').rejects(mockError)
-
-      apiClient.helpGet().then(
-        () => {
-          throw new Error('Test should have failed but succeeded unexpectedly')
-        },
-        (error) => {
-          expect(GetHelpApi.prototype.helpGet).to.be.calledOnce
-          expect(error).to.equal(mockError)
-        },
-      )
-    })
   })
 
   context('projectionHcsvPost', () => {
     it('should post projection data successfully', () => {
       const mockBlob = new Blob(['test data'], { type: 'application/json' })
       const mockResponse = { data: mockBlob }
-      cy.stub(
-        RunHCSVProjectionApi.prototype,
-        'projectionHcsvPostForm',
-      ).resolves(mockResponse)
+      cy.stub(RunHCSVProjectionApi.prototype, 'projectionHcsvPostForm').resolves(mockResponse)
 
       const formData = new FormData()
-      formData.append(
-        ParameterNamesEnum.HCSV_POLYGON_INPUT_DATA,
-        new File([], 'polygon.json'),
-      )
-      formData.append(
-        ParameterNamesEnum.HCSV_LAYERS_INPUT_DATA,
-        new File([], 'layers.json'),
-      )
-      formData.append(
-        ParameterNamesEnum.PROJECTION_PARAMETERS,
-        JSON.stringify({ param: 'test' }),
-      )
+      formData.append(ParameterNamesEnum.HCSV_POLYGON_INPUT_DATA, new File([], 'polygon.json'))
+      formData.append(ParameterNamesEnum.HCSV_LAYERS_INPUT_DATA, new File([], 'layers.json'))
+      formData.append(ParameterNamesEnum.PROJECTION_PARAMETERS, JSON.stringify({ param: 'test' }))
 
       apiClient.projectionHcsvPost(formData, true).then((result) => {
-        expect(RunHCSVProjectionApi.prototype.projectionHcsvPostForm).to.be
-          .calledOnce
+        expect(RunHCSVProjectionApi.prototype.projectionHcsvPostForm).to.be.calledOnce
         expect(result.data).to.be.instanceOf(Blob)
         expect(result.data.size).to.equal(mockBlob.size)
         expect(result.data.type).to.equal(mockBlob.type)
@@ -78,32 +50,19 @@ describe('apiClient Unit Tests', () => {
     it('should handle error when posting projection data', () => {
       const mockError = new Error('Projection failed')
       const formData = new FormData()
-      formData.append(
-        ParameterNamesEnum.HCSV_POLYGON_INPUT_DATA,
-        new File([], 'polygon.json'),
-      )
-      formData.append(
-        ParameterNamesEnum.HCSV_LAYERS_INPUT_DATA,
-        new File([], 'layers.json'),
-      )
-      formData.append(
-        ParameterNamesEnum.PROJECTION_PARAMETERS,
-        JSON.stringify({ param: 'test' }),
-      )
+      formData.append(ParameterNamesEnum.HCSV_POLYGON_INPUT_DATA, new File([], 'polygon.json'))
+      formData.append(ParameterNamesEnum.HCSV_LAYERS_INPUT_DATA, new File([], 'layers.json'))
+      formData.append(ParameterNamesEnum.PROJECTION_PARAMETERS, JSON.stringify({ param: 'test' }))
 
-      cy.stub(RunHCSVProjectionApi.prototype, 'projectionHcsvPostForm').rejects(
-        mockError,
-      )
+      cy.stub(RunHCSVProjectionApi.prototype, 'projectionHcsvPostForm').rejects(mockError)
 
       apiClient
         .projectionHcsvPost(formData, false)
         .then(() => {
-          // assert-fail block
           throw new Error('Test should have failed but succeeded unexpectedly')
         })
         .catch((error: Error) => {
-          expect(RunHCSVProjectionApi.prototype.projectionHcsvPostForm).to.be
-            .calledOnce
+          expect(RunHCSVProjectionApi.prototype.projectionHcsvPostForm).to.be.calledOnce
           expect(error).to.equal(mockError)
         })
     })
@@ -111,9 +70,7 @@ describe('apiClient Unit Tests', () => {
 
   context('rootGet', () => {
     it('should fetch root details successfully', () => {
-      const mockResponse = {
-        data: { name: 'Root Resource', description: 'Details' },
-      }
+      const mockResponse = { data: { name: 'Root Resource', description: 'Details' } }
       cy.stub(GetRootApi.prototype, 'rootGet').resolves(mockResponse)
 
       cy.wrap(apiClient.rootGet()).then((result) => {
@@ -121,69 +78,23 @@ describe('apiClient Unit Tests', () => {
         expect(result).to.deep.equal(mockResponse)
       })
     })
-
-    it('should handle error when fetching root details', () => {
-      const mockError = new Error('Network error')
-      cy.stub(GetRootApi.prototype, 'rootGet').rejects(mockError)
-
-      apiClient.rootGet().then(
-        () => {
-          throw new Error('Test should have failed but succeeded unexpectedly')
-        },
-        (error) => {
-          expect(GetRootApi.prototype.rootGet).to.be.calledOnce
-          expect(error).to.equal(mockError)
-        },
-      )
-    })
   })
 
   context('getUserProjections', () => {
     it('should fetch user projections successfully', () => {
-      const mockResponse = {
-        data: [{ id: 1, name: 'API Projection' }],
-      }
-      cy.stub(ProjectionApi.prototype, 'getUserProjections').resolves(
-        mockResponse,
-      )
+      const mockResponse = { data: [{ id: 1, name: 'API Projection' }] }
+      cy.stub(ProjectionApi.prototype, 'getUserProjections').resolves(mockResponse)
 
       cy.wrap(apiClient.getUserProjections()).then((result: unknown) => {
         const response = result as { data: unknown }
         expect(ProjectionApi.prototype.getUserProjections).to.be.calledOnce
-        expect(response).to.have.property('data')
         expect(response.data).to.deep.equal([{ id: 1, name: 'API Projection' }])
       })
-    })
-
-    it('should handle error when fetching user projections', () => {
-      const mockError = new Error('Network error')
-      cy.stub(ProjectionApi.prototype, 'getUserProjections').rejects(mockError)
-
-      apiClient
-        .getUserProjections()
-        .then(() => {
-          throw new Error('Test should have failed but succeeded unexpectedly')
-        })
-        .catch((error: Error) => {
-          expect(ProjectionApi.prototype.getUserProjections).to.be.calledOnce
-          expect(error).to.equal(mockError)
-        })
     })
   })
 
   context('createProjection', () => {
     it('should create a projection successfully', () => {
-      const mockResponse = { data: { id: 'new-guid', status: 'DRAFT' } }
-      const mockParameters = {} as Parameters
-      cy.stub(ProjectionApi.prototype, 'createProjection').resolves(mockResponse)
-
-      cy.wrap(apiClient.createProjection(mockParameters)).then((result: unknown) => {
-        expect(ProjectionApi.prototype.createProjection).to.be.calledOnce
-        expect(result).to.deep.equal(mockResponse)
-      })
-    })
-
-    it('should create a projection with optional modelParameters and reportDescription', () => {
       const mockResponse = { data: { id: 'new-guid', status: 'DRAFT' } }
       const mockParameters = {} as Parameters
       const mockModelParameters = {} as ModelParameters
@@ -200,11 +111,10 @@ describe('apiClient Unit Tests', () => {
 
     it('should handle error when creating a projection', () => {
       const mockError = new Error('Create projection failed')
-      const mockParameters = {} as Parameters
       cy.stub(ProjectionApi.prototype, 'createProjection').rejects(mockError)
 
       apiClient
-        .createProjection(mockParameters)
+        .createProjection({})
         .then(() => {
           throw new Error('Test should have failed but succeeded unexpectedly')
         })
@@ -218,50 +128,18 @@ describe('apiClient Unit Tests', () => {
   context('getProjection', () => {
     it('should fetch a projection by GUID successfully', () => {
       const mockResponse = { data: { id: 'test-guid', status: 'DRAFT' } }
-      const projectionGUID = 'test-guid'
       cy.stub(ProjectionApi.prototype, 'getProjection').resolves(mockResponse)
 
-      cy.wrap(apiClient.getProjection(projectionGUID)).then((result: unknown) => {
+      cy.wrap(apiClient.getProjection('test-guid')).then((result: unknown) => {
         expect(ProjectionApi.prototype.getProjection).to.be.calledOnce
         expect(result).to.deep.equal(mockResponse)
       })
-    })
-
-    it('should handle error when fetching a projection by GUID', () => {
-      const mockError = new Error('Projection not found')
-      const projectionGUID = 'test-guid'
-      cy.stub(ProjectionApi.prototype, 'getProjection').rejects(mockError)
-
-      apiClient
-        .getProjection(projectionGUID)
-        .then(() => {
-          throw new Error('Test should have failed but succeeded unexpectedly')
-        })
-        .catch((error: Error) => {
-          expect(ProjectionApi.prototype.getProjection).to.be.calledOnce
-          expect(error).to.equal(mockError)
-        })
     })
   })
 
   context('updateProjectionParams', () => {
     it('should update projection parameters successfully', () => {
       const mockResponse = { data: { id: 'test-guid', status: 'DRAFT' } }
-      const projectionGUID = 'test-guid'
-      const mockParameters = {} as Parameters
-      cy.stub(ProjectionApi.prototype, 'updateProjectionParams').resolves(mockResponse)
-
-      cy.wrap(
-        apiClient.updateProjectionParams(projectionGUID, mockParameters),
-      ).then((result: unknown) => {
-        expect(ProjectionApi.prototype.updateProjectionParams).to.be.calledOnce
-        expect(result).to.deep.equal(mockResponse)
-      })
-    })
-
-    it('should update projection parameters with optional modelParameters and reportDescription', () => {
-      const mockResponse = { data: { id: 'test-guid', status: 'DRAFT' } }
-      const projectionGUID = 'test-guid'
       const mockParameters = {} as Parameters
       const mockModelParameters = {} as ModelParameters
       const reportDescription = 'Updated report'
@@ -269,7 +147,7 @@ describe('apiClient Unit Tests', () => {
 
       cy.wrap(
         apiClient.updateProjectionParams(
-          projectionGUID,
+          'test-guid',
           mockParameters,
           mockModelParameters,
           reportDescription,
@@ -282,12 +160,10 @@ describe('apiClient Unit Tests', () => {
 
     it('should handle error when updating projection parameters', () => {
       const mockError = new Error('Update failed')
-      const projectionGUID = 'test-guid'
-      const mockParameters = {} as Parameters
       cy.stub(ProjectionApi.prototype, 'updateProjectionParams').rejects(mockError)
 
       apiClient
-        .updateProjectionParams(projectionGUID, mockParameters)
+        .updateProjectionParams('test-guid', {})
         .then(() => {
           throw new Error('Test should have failed but succeeded unexpectedly')
         })
@@ -301,219 +177,91 @@ describe('apiClient Unit Tests', () => {
   context('runProjection', () => {
     it('should run a projection successfully', () => {
       const mockResponse = { data: { id: 'test-guid', status: 'RUNNING' } }
-      const projectionGUID = 'test-guid'
       cy.stub(ProjectionApi.prototype, 'runProjection').resolves(mockResponse)
 
-      cy.wrap(apiClient.runProjection(projectionGUID)).then((result: unknown) => {
+      cy.wrap(apiClient.runProjection('test-guid')).then((result: unknown) => {
         expect(ProjectionApi.prototype.runProjection).to.be.calledOnce
         expect(result).to.deep.equal(mockResponse)
       })
-    })
-
-    it('should handle error when running a projection', () => {
-      const mockError = new Error('Run projection failed')
-      const projectionGUID = 'test-guid'
-      cy.stub(ProjectionApi.prototype, 'runProjection').rejects(mockError)
-
-      apiClient
-        .runProjection(projectionGUID)
-        .then(() => {
-          throw new Error('Test should have failed but succeeded unexpectedly')
-        })
-        .catch((error: Error) => {
-          expect(ProjectionApi.prototype.runProjection).to.be.calledOnce
-          expect(error).to.equal(mockError)
-        })
     })
   })
 
   context('cancelProjection', () => {
     it('should cancel a projection successfully', () => {
       const mockResponse = { data: { id: 'test-guid', status: 'DRAFT' } }
-      const projectionGUID = 'test-guid'
       cy.stub(ProjectionApi.prototype, 'cancelProjection').resolves(mockResponse)
 
-      cy.wrap(apiClient.cancelProjection(projectionGUID)).then((result: unknown) => {
+      cy.wrap(apiClient.cancelProjection('test-guid')).then((result: unknown) => {
         expect(ProjectionApi.prototype.cancelProjection).to.be.calledOnce
         expect(result).to.deep.equal(mockResponse)
       })
-    })
-
-    it('should handle error when cancelling a projection', () => {
-      const mockError = new Error('Cancel projection failed')
-      const projectionGUID = 'test-guid'
-      cy.stub(ProjectionApi.prototype, 'cancelProjection').rejects(mockError)
-
-      apiClient
-        .cancelProjection(projectionGUID)
-        .then(() => {
-          throw new Error('Test should have failed but succeeded unexpectedly')
-        })
-        .catch((error: Error) => {
-          expect(ProjectionApi.prototype.cancelProjection).to.be.calledOnce
-          expect(error).to.equal(mockError)
-        })
     })
   })
 
   context('duplicateProjection', () => {
     it('should duplicate a projection successfully', () => {
       const mockResponse = { data: { id: 'new-guid', status: 'DRAFT' } }
-      const projectionGUID = 'test-guid'
       cy.stub(ProjectionApi.prototype, 'duplicateProjection').resolves(mockResponse)
 
-      cy.wrap(apiClient.duplicateProjection(projectionGUID)).then((result: unknown) => {
+      cy.wrap(apiClient.duplicateProjection('test-guid')).then((result: unknown) => {
         expect(ProjectionApi.prototype.duplicateProjection).to.be.calledOnce
         expect(result).to.deep.equal(mockResponse)
       })
-    })
-
-    it('should handle error when duplicating a projection', () => {
-      const mockError = new Error('Duplicate projection failed')
-      const projectionGUID = 'test-guid'
-      cy.stub(ProjectionApi.prototype, 'duplicateProjection').rejects(mockError)
-
-      apiClient
-        .duplicateProjection(projectionGUID)
-        .then(() => {
-          throw new Error('Test should have failed but succeeded unexpectedly')
-        })
-        .catch((error: Error) => {
-          expect(ProjectionApi.prototype.duplicateProjection).to.be.calledOnce
-          expect(error).to.equal(mockError)
-        })
     })
   })
 
   context('deleteProjection', () => {
     it('should delete a projection successfully', () => {
       const mockResponse = { status: 204 }
-      const projectionGUID = 'test-guid'
       cy.stub(ProjectionApi.prototype, 'deleteProjection').resolves(mockResponse)
 
-      cy.wrap(apiClient.deleteProjection(projectionGUID)).then((result: unknown) => {
+      cy.wrap(apiClient.deleteProjection('test-guid')).then((result: unknown) => {
         expect(ProjectionApi.prototype.deleteProjection).to.be.calledOnce
         expect(result).to.deep.equal(mockResponse)
       })
-    })
-
-    it('should handle error when deleting a projection', () => {
-      const mockError = new Error('Delete projection failed')
-      const projectionGUID = 'test-guid'
-      cy.stub(ProjectionApi.prototype, 'deleteProjection').rejects(mockError)
-
-      apiClient
-        .deleteProjection(projectionGUID)
-        .then(() => {
-          throw new Error('Test should have failed but succeeded unexpectedly')
-        })
-        .catch((error: Error) => {
-          expect(ProjectionApi.prototype.deleteProjection).to.be.calledOnce
-          expect(error).to.equal(mockError)
-        })
     })
   })
 
   context('getFileSetFiles', () => {
     it('should fetch fileset files successfully', () => {
       const mockResponse = { data: [{ id: 'file-1', name: 'polygon.csv' }] }
-      const projectionGUID = 'test-guid'
-      const fileSetGUID = 'fileset-guid'
       cy.stub(ProjectionApi.prototype, 'getFileSetFiles').resolves(mockResponse)
 
-      cy.wrap(apiClient.getFileSetFiles(projectionGUID, fileSetGUID)).then(
-        (result: unknown) => {
-          expect(ProjectionApi.prototype.getFileSetFiles).to.be.calledOnce
-          expect(result).to.deep.equal(mockResponse)
-        },
-      )
-    })
-
-    it('should handle error when fetching fileset files', () => {
-      const mockError = new Error('Fetch fileset files failed')
-      const projectionGUID = 'test-guid'
-      const fileSetGUID = 'fileset-guid'
-      cy.stub(ProjectionApi.prototype, 'getFileSetFiles').rejects(mockError)
-
-      apiClient
-        .getFileSetFiles(projectionGUID, fileSetGUID)
-        .then(() => {
-          throw new Error('Test should have failed but succeeded unexpectedly')
-        })
-        .catch((error: Error) => {
-          expect(ProjectionApi.prototype.getFileSetFiles).to.be.calledOnce
-          expect(error).to.equal(mockError)
-        })
+      cy.wrap(apiClient.getFileSetFiles('test-guid', 'fileset-guid')).then((result: unknown) => {
+        expect(ProjectionApi.prototype.getFileSetFiles).to.be.calledOnce
+        expect(result).to.deep.equal(mockResponse)
+      })
     })
   })
 
   context('uploadFileToFileSet', () => {
     it('should upload a file to a fileset successfully', () => {
       const mockResponse = { data: { id: 'test-guid', status: 'DRAFT' } }
-      const projectionGUID = 'test-guid'
-      const fileSetGUID = 'fileset-guid'
       const file = new File(['content'], 'polygon.csv')
       cy.stub(ProjectionApi.prototype, 'uploadFileToFileSet').resolves(mockResponse)
 
-      cy.wrap(
-        apiClient.uploadFileToFileSet(projectionGUID, fileSetGUID, file),
-      ).then((result: unknown) => {
-        expect(ProjectionApi.prototype.uploadFileToFileSet).to.be.calledOnce
-        expect(result).to.deep.equal(mockResponse)
-      })
-    })
-
-    it('should handle error when uploading a file to a fileset', () => {
-      const mockError = new Error('Upload failed')
-      const projectionGUID = 'test-guid'
-      const fileSetGUID = 'fileset-guid'
-      const file = new File(['content'], 'polygon.csv')
-      cy.stub(ProjectionApi.prototype, 'uploadFileToFileSet').rejects(mockError)
-
-      apiClient
-        .uploadFileToFileSet(projectionGUID, fileSetGUID, file)
-        .then(() => {
-          throw new Error('Test should have failed but succeeded unexpectedly')
-        })
-        .catch((error: Error) => {
+      cy.wrap(apiClient.uploadFileToFileSet('test-guid', 'fileset-guid', file)).then(
+        (result: unknown) => {
           expect(ProjectionApi.prototype.uploadFileToFileSet).to.be.calledOnce
-          expect(error).to.equal(mockError)
-        })
+          expect(result).to.deep.equal(mockResponse)
+        },
+      )
     })
   })
 
   context('getFileForDownload', () => {
     it('should get a file for download successfully', () => {
-      const mockResponse = { data: { id: 'file-mapping-guid', downloadUrl: 'https://example.com/file' } }
-      const projectionGUID = 'test-guid'
-      const fileSetGUID = 'fileset-guid'
-      const fileMappingGUID = 'file-mapping-guid'
+      const mockResponse = {
+        data: { id: 'file-mapping-guid', downloadUrl: 'https://example.com/file' },
+      }
       cy.stub(ProjectionApi.prototype, 'getFileForDownload').resolves(mockResponse)
 
       cy.wrap(
-        apiClient.getFileForDownload(projectionGUID, fileSetGUID, fileMappingGUID),
+        apiClient.getFileForDownload('test-guid', 'fileset-guid', 'file-mapping-guid'),
       ).then((result: unknown) => {
         expect(ProjectionApi.prototype.getFileForDownload).to.be.calledOnce
         expect(result).to.deep.equal(mockResponse)
       })
-    })
-
-    it('should handle error when getting a file for download', () => {
-      const mockError = new Error('Get file for download failed')
-      const projectionGUID = 'test-guid'
-      const fileSetGUID = 'fileset-guid'
-      const fileMappingGUID = 'file-mapping-guid'
-      cy.stub(ProjectionApi.prototype, 'getFileForDownload').rejects(mockError)
-
-      apiClient
-        .getFileForDownload(projectionGUID, fileSetGUID, fileMappingGUID)
-        .then(() => {
-          throw new Error('Test should have failed but succeeded unexpectedly')
-        })
-        .catch((error: Error) => {
-          expect(ProjectionApi.prototype.getFileForDownload).to.be.calledOnce
-          expect(error).to.equal(mockError)
-        })
     })
   })
 
@@ -521,71 +269,29 @@ describe('apiClient Unit Tests', () => {
     it('should stream results zip successfully', () => {
       const mockBlob = new Blob(['zip content'], { type: 'application/zip' })
       const mockResponse = { data: mockBlob }
-      cy.stub(ProjectionApi.prototype, 'streamResultsZip').resolves(
-        mockResponse,
-      )
+      cy.stub(ProjectionApi.prototype, 'streamResultsZip').resolves(mockResponse)
 
-      const projectionGUID = 'test-guid-123'
-
-      cy.wrap(apiClient.streamResultsZip(projectionGUID)).then(
-        (result: unknown) => {
-          const response = result as { data: Blob }
-          expect(ProjectionApi.prototype.streamResultsZip).to.be.calledOnce
-          expect(response.data).to.be.instanceOf(Blob)
-          expect(response.data.size).to.equal(mockBlob.size)
-          expect(response.data.type).to.equal(mockBlob.type)
-        },
-      )
-    })
-
-    it('should handle error when streaming results zip', () => {
-      const mockError = new Error('Download failed')
-      cy.stub(ProjectionApi.prototype, 'streamResultsZip').rejects(mockError)
-
-      apiClient
-        .streamResultsZip('test-guid-123')
-        .then(() => {
-          throw new Error('Test should have failed but succeeded unexpectedly')
-        })
-        .catch((error: Error) => {
-          expect(ProjectionApi.prototype.streamResultsZip).to.be.calledOnce
-          expect(error).to.equal(mockError)
-        })
+      cy.wrap(apiClient.streamResultsZip('test-guid-123')).then((result: unknown) => {
+        const response = result as { data: Blob }
+        expect(ProjectionApi.prototype.streamResultsZip).to.be.calledOnce
+        expect(response.data).to.be.instanceOf(Blob)
+        expect(response.data.size).to.equal(mockBlob.size)
+        expect(response.data.type).to.equal(mockBlob.type)
+      })
     })
   })
 
   context('deleteFileFromFileSet', () => {
     it('should delete a file from a fileset successfully', () => {
       const mockResponse = { status: 204 }
-      const projectionGUID = 'test-guid'
-      const fileSetGUID = 'fileset-guid'
-      const fileMappingGUID = 'file-mapping-guid'
       cy.stub(ProjectionApi.prototype, 'deleteFileFromFileSet').resolves(mockResponse)
 
       cy.wrap(
-        apiClient.deleteFileFromFileSet(projectionGUID, fileSetGUID, fileMappingGUID),
+        apiClient.deleteFileFromFileSet('test-guid', 'fileset-guid', 'file-mapping-guid'),
       ).then((result: unknown) => {
         expect(ProjectionApi.prototype.deleteFileFromFileSet).to.be.calledOnce
         expect(result).to.deep.equal(mockResponse)
       })
-    })
-
-    it('should handle error when deleting a file from a fileset', () => {
-      const mockError = new Error('Delete file failed')
-      const projectionGUID = 'test-guid'
-      const fileSetGUID = 'fileset-guid'
-      const fileMappingGUID = 'file-mapping-guid'
-      cy.stub(ProjectionApi.prototype, 'deleteFileFromFileSet').rejects(mockError)
-
-      apiClient
-        .deleteFileFromFileSet(projectionGUID, fileSetGUID, fileMappingGUID)
-        .then(() => {
-          throw new Error('Test should have failed but succeeded unexpectedly')
-        })
-        .catch((error: Error) => {
-          expect(ProjectionApi.prototype.deleteFileFromFileSet).to.be.calledOnce
-          expect(error).to.equal(mockError)
-        })
     })
   })
 })

--- a/frontend/src/services/projection/fileUploadService.cy.ts
+++ b/frontend/src/services/projection/fileUploadService.cy.ts
@@ -73,8 +73,8 @@ describe('buildDebugOptions', () => {
 })
 
 describe('buildExecutionOptions', () => {
-  it('should always include the fixed selected options', () => {
-    const { selectedExecutionOptions } = buildExecutionOptions(createMockFileUploadStore())
+  it('should always include the fixed selected and excluded options', () => {
+    const { selectedExecutionOptions, excludedExecutionOptions } = buildExecutionOptions(createMockFileUploadStore())
 
     const alwaysSelected = [
       ExecutionOptionsEnum.DoIncludeFileHeader,
@@ -88,16 +88,14 @@ describe('buildExecutionOptions', () => {
       ExecutionOptionsEnum.DoSummarizeProjectionByLayer,
     ]
     alwaysSelected.forEach((opt) => expect(selectedExecutionOptions).to.include(opt))
-  })
-
-  it('should always include the fixed excluded options', () => {
-    const { excludedExecutionOptions } = buildExecutionOptions(createMockFileUploadStore())
 
     const alwaysExcluded = [
       ExecutionOptionsEnum.DoSaveIntermediateFiles,
       ExecutionOptionsEnum.AllowAggressiveValueEstimation,
       ExecutionOptionsEnum.DoIncludeProjectionFiles,
       ExecutionOptionsEnum.DoSummarizeProjectionByPolygon,
+      ExecutionOptionsEnum.BackGrowEnabled,
+      ExecutionOptionsEnum.DoIncludeProjectedMOFBiomass,
     ]
     alwaysExcluded.forEach((opt) => expect(excludedExecutionOptions).to.include(opt))
   })
@@ -112,6 +110,11 @@ describe('buildExecutionOptions', () => {
     const { selectedExecutionOptions: cfsSelected, excludedExecutionOptions: cfsExcluded } = buildExecutionOptions(cfsStore)
     expect(cfsSelected).to.include(ExecutionOptionsEnum.DoIncludeProjectedCFSBiomass)
     expect(cfsExcluded).to.not.include(ExecutionOptionsEnum.DoIncludeProjectedCFSBiomass)
+
+    const bothStore = createMockFileUploadStore({ projectionType: CONSTANTS.PROJECTION_TYPE.BOTH })
+    const { selectedExecutionOptions: bothSelected } = buildExecutionOptions(bothStore)
+    expect(bothSelected).to.include(ExecutionOptionsEnum.DoIncludeProjectedMOFVolumes)
+    expect(bothSelected).to.include(ExecutionOptionsEnum.DoIncludeProjectedCFSBiomass)
   })
 })
 
@@ -170,12 +173,6 @@ describe('buildProjectionParameters', () => {
     expect(params.utils![1]).to.deep.include({ speciesName: 'Pine', utilizationClass: '7.5 cm+' })
   })
 
-  it('should include reportTitle from the store', () => {
-    const store = createMockFileUploadStore({ reportTitle: 'My Report' })
-    const params = buildProjectionParameters(store)
-
-    expect(params.reportTitle).to.equal('My Report')
-  })
 })
 
 describe('runProjectionFileUpload', () => {

--- a/frontend/src/services/projection/fileUploadService.ts
+++ b/frontend/src/services/projection/fileUploadService.ts
@@ -69,13 +69,15 @@ export const buildExecutionOptions = (
 
   const optionMappings = [
     {
-      flag: fileUploadStore.projectionType === CONSTANTS.PROJECTION_TYPE.VOLUME,
+      flag:
+        fileUploadStore.projectionType === CONSTANTS.PROJECTION_TYPE.VOLUME ||
+        fileUploadStore.projectionType === CONSTANTS.PROJECTION_TYPE.BOTH,
       option: ExecutionOptionsEnum.DoIncludeProjectedMOFVolumes,
     },
     {
       flag:
-        fileUploadStore.projectionType ===
-        CONSTANTS.PROJECTION_TYPE.CFS_BIOMASS,
+        fileUploadStore.projectionType === CONSTANTS.PROJECTION_TYPE.CFS_BIOMASS ||
+        fileUploadStore.projectionType === CONSTANTS.PROJECTION_TYPE.BOTH,
       option: ExecutionOptionsEnum.DoIncludeProjectedCFSBiomass,
     },
     {
@@ -278,9 +280,11 @@ const reportConfigTextChanged = (store: Store, saved: SavedParams, savedDescript
 }
 
 const reportConfigOptionsChanged = (store: Store, opts: string[]): boolean => {
-  const savedProjectionType = opts.includes(ExecutionOptionsEnum.DoIncludeProjectedCFSBiomass)
-    ? CONSTANTS.PROJECTION_TYPE.CFS_BIOMASS
-    : CONSTANTS.PROJECTION_TYPE.VOLUME
+  const hasCFS = opts.includes(ExecutionOptionsEnum.DoIncludeProjectedCFSBiomass)
+  const hasVolume = opts.includes(ExecutionOptionsEnum.DoIncludeProjectedMOFVolumes)
+  let savedProjectionType: string = CONSTANTS.PROJECTION_TYPE.VOLUME
+  if (hasCFS && hasVolume) savedProjectionType = CONSTANTS.PROJECTION_TYPE.BOTH
+  else if (hasCFS) savedProjectionType = CONSTANTS.PROJECTION_TYPE.CFS_BIOMASS
   if (store.projectionType !== savedProjectionType) return true
 
   const flagOptionPairs: [boolean, ExecutionOptionsEnum][] = [

--- a/frontend/src/services/projection/modelParameterService.cy.ts
+++ b/frontend/src/services/projection/modelParameterService.cy.ts
@@ -4,9 +4,7 @@ import { setActivePinia, createPinia } from 'pinia'
 import {
   generateFeatureId,
   generateRandomNumber,
-  generatePolygonNumber,
-  generateTreeCoverLayerEstimatedId,
-  computeBclcsLevel1,
+computeBclcsLevel1,
   computeBclcsLevel2,
   computeBclcsLevel3,
   determineBclcsLevel4,
@@ -105,22 +103,6 @@ describe('generateRandomNumber', () => {
   })
 })
 
-describe('generatePolygonNumber', () => {
-  it('should return an 8-digit numeric string', () => {
-    const result = generatePolygonNumber()
-    expect(result).to.be.a('string')
-    expect(result.length).to.equal(8)
-    expect(Number(result)).to.not.be.NaN
-  })
-})
-
-describe('generateTreeCoverLayerEstimatedId', () => {
-  it('should return a string with 4 to 10 digits', () => {
-    for (let i = 0; i < 20; i++) {
-      expect(generateTreeCoverLayerEstimatedId().length).to.be.at.least(4).and.at.most(10)
-    }
-  })
-})
 
 // ─ BCLCS level computations
 
@@ -232,6 +214,10 @@ describe('buildProjectionParameters', () => {
 
     const biomass = buildProjectionParameters(createMockModelParameterStore({ projectionType: CONSTANTS.PROJECTION_TYPE.CFS_BIOMASS }))
     expect(biomass.selectedExecutionOptions).to.include(ExecutionOptionsEnum.DoIncludeProjectedCFSBiomass)
+
+    const both = buildProjectionParameters(createMockModelParameterStore({ projectionType: CONSTANTS.PROJECTION_TYPE.BOTH }))
+    expect(both.selectedExecutionOptions).to.include(ExecutionOptionsEnum.DoIncludeProjectedMOFVolumes)
+    expect(both.selectedExecutionOptions).to.include(ExecutionOptionsEnum.DoIncludeProjectedCFSBiomass)
   })
 
   it('should map speciesGroups to utils and include all four debug options', () => {

--- a/frontend/src/services/projection/modelParameterService.ts
+++ b/frontend/src/services/projection/modelParameterService.ts
@@ -468,13 +468,14 @@ const buildExecutionOptions = (
   const optionMappings = [
     {
       flag:
-        modelParameterStore.projectionType === CONSTANTS.PROJECTION_TYPE.VOLUME,
+        modelParameterStore.projectionType === CONSTANTS.PROJECTION_TYPE.VOLUME ||
+        modelParameterStore.projectionType === CONSTANTS.PROJECTION_TYPE.BOTH,
       option: ExecutionOptionsEnum.DoIncludeProjectedMOFVolumes,
     },
     {
       flag:
-        modelParameterStore.projectionType ===
-        CONSTANTS.PROJECTION_TYPE.CFS_BIOMASS,
+        modelParameterStore.projectionType === CONSTANTS.PROJECTION_TYPE.CFS_BIOMASS ||
+        modelParameterStore.projectionType === CONSTANTS.PROJECTION_TYPE.BOTH,
       option: ExecutionOptionsEnum.DoIncludeProjectedCFSBiomass,
     },
     {
@@ -802,6 +803,37 @@ const hasStandInfoChanges = (store: any, saved: ModelParameters): boolean => {
   return false
 }
 
+const resolveProjectionType = (opts: string[]): string => {
+  const hasCFS = opts.includes(ExecutionOptionsEnum.DoIncludeProjectedCFSBiomass)
+  const hasVolume = opts.includes(ExecutionOptionsEnum.DoIncludeProjectedMOFVolumes)
+  if (hasCFS && hasVolume) return CONSTANTS.PROJECTION_TYPE.BOTH
+  if (hasCFS) return CONSTANTS.PROJECTION_TYPE.CFS_BIOMASS
+  return CONSTANTS.PROJECTION_TYPE.VOLUME
+}
+
+const isCFSBiomassType = (projType: string): boolean =>
+  projType === CONSTANTS.PROJECTION_TYPE.CFS_BIOMASS || projType === CONSTANTS.PROJECTION_TYPE.BOTH
+
+const hasUtilizationChanges = (
+  store: any,
+  savedParams: ParsedProjectionParameters,
+  savedProjectionType: string,
+): boolean => {
+  const defaultMap = isCFSBiomassType(savedProjectionType)
+    ? DEFAULTS.SPECIES_GROUP_CFO_BIOMASS_UTILIZATION_MAP
+    : DEFAULTS.SPECIES_GROUP_VOLUME_UTILIZATION_MAP
+  const utilsMap: Record<string, string> = {}
+  for (const util of savedParams.utils) {
+    const u = util as { s: string; u: string }
+    if (u.s && u.u) utilsMap[u.s] = u.u
+  }
+  const hasUtils = savedParams.utils.length > 0
+  return (store.speciesGroups as SpeciesGroup[]).some((sg) => {
+    const savedValue = hasUtils ? (utilsMap[sg.group] ?? defaultMap[sg.group]) : defaultMap[sg.group]
+    return sg.minimumDBHLimit !== savedValue
+  })
+}
+
 const hasReportDetailsChanges = (
   store: any,
   savedParams: ParsedProjectionParameters,
@@ -810,9 +842,7 @@ const hasReportDetailsChanges = (
   if (!strEq(store.reportTitle, savedParams.reportTitle)) return true
   if (!strEq(store.reportDescription || null, savedDescription || null)) return true
   const opts = savedParams.selectedExecutionOptions
-  const savedProjectionType = opts.includes(ExecutionOptionsEnum.DoIncludeProjectedCFSBiomass)
-    ? CONSTANTS.PROJECTION_TYPE.CFS_BIOMASS
-    : CONSTANTS.PROJECTION_TYPE.VOLUME
+  const savedProjectionType = resolveProjectionType(opts)
   return !strEq(store.projectionType, savedProjectionType)
 }
 
@@ -831,24 +861,9 @@ const hasReportInfoChanges = (
   if (store.isCulminationValuesEnabled !== opts.includes(ExecutionOptionsEnum.ReportIncludeCulminationValues)) return true
   if (store.isBySpeciesEnabled !== opts.includes(ExecutionOptionsEnum.DoIncludeSpeciesProjection)) return true
   if (store.incSecondaryHeight !== opts.includes(ExecutionOptionsEnum.DoIncludeSecondarySpeciesDominantHeightInYieldTable)) return true
-  const savedProjectionType = opts.includes(ExecutionOptionsEnum.DoIncludeProjectedCFSBiomass)
-    ? CONSTANTS.PROJECTION_TYPE.CFS_BIOMASS
-    : CONSTANTS.PROJECTION_TYPE.VOLUME
+  const savedProjectionType = resolveProjectionType(opts)
   if (!strEq(store.projectionType, savedProjectionType)) return true
-
-  const defaultMap = savedProjectionType === CONSTANTS.PROJECTION_TYPE.CFS_BIOMASS
-    ? DEFAULTS.SPECIES_GROUP_CFO_BIOMASS_UTILIZATION_MAP
-    : DEFAULTS.SPECIES_GROUP_VOLUME_UTILIZATION_MAP
-  const utilsMap: Record<string, string> = {}
-  for (const util of savedParams.utils) {
-    const u = util as { s: string; u: string }
-    if (u.s && u.u) utilsMap[u.s] = u.u
-  }
-  const hasUtils = savedParams.utils.length > 0
-  if ((store.speciesGroups as SpeciesGroup[]).some((sg) => {
-    const savedValue = hasUtils ? (utilsMap[sg.group] ?? defaultMap[sg.group]) : defaultMap[sg.group]
-    return sg.minimumDBHLimit !== savedValue
-  })) return true
+  if (hasUtilizationChanges(store, savedParams, savedProjectionType)) return true
 
   return false
 }

--- a/frontend/src/services/projectionService.cy.ts
+++ b/frontend/src/services/projectionService.cy.ts
@@ -1,7 +1,6 @@
 /// <reference types="cypress" />
 
-import type { Projection } from '@/interfaces/interfaces'
-import { SORT_ORDER, PROJECTION_LIST_HEADER_KEY, PROJECTION_STATUS, FILE_NAME } from '@/constants/constants'
+import { PROJECTION_STATUS, FILE_NAME } from '@/constants/constants'
 import {
   mapProjectionStatus,
   parseProjectionParams,
@@ -16,263 +15,6 @@ import {
 } from '@/services/projectionService'
 import apiClient from '@/services/apiClient'
 import type { ProjectionModel, Parameters } from '@/services/vdyp-api'
-
-// Local implementations for testing
-const sortProjections = (
-  projections: Projection[],
-  sortKey: string,
-  sortOrder: string,
-): Projection[] => {
-  return [...projections].sort((a, b) => {
-    const aValue = a[sortKey as keyof Projection] ?? ''
-    const bValue = b[sortKey as keyof Projection] ?? ''
-
-    let comparison = 0
-    if (aValue < bValue) {
-      comparison = -1
-    } else if (aValue > bValue) {
-      comparison = 1
-    }
-
-    return sortOrder === 'desc' ? -comparison : comparison
-  })
-}
-
-const paginateProjections = (
-  projections: Projection[],
-  page: number,
-  itemsPerPage: number,
-): Projection[] => {
-  const startIndex = (page - 1) * itemsPerPage
-  const endIndex = startIndex + itemsPerPage
-  return projections.slice(startIndex, endIndex)
-}
-
-const calculateTotalPages = (
-  totalItems: number,
-  itemsPerPage: number,
-): number => {
-  if (totalItems === 0) return 0
-  return Math.ceil(totalItems / itemsPerPage)
-}
-
-describe('ProjectionListService Unit Tests', () => {
-  const mockProjections: Projection[] = [
-    {
-      projectionGUID: 'guid-1',
-      title: 'Alpha Project',
-      description: 'First project',
-      method: 'File Upload',
-      projectionType: 'Volume',
-      lastUpdated: '2024-01-15T10:00:00',
-      expiration: '2024-06-15T10:00:00',
-      status: 'Draft',
-    },
-    {
-      projectionGUID: 'guid-2',
-      title: 'Beta Project',
-      description: 'Second project',
-      method: 'Manual Input',
-      projectionType: 'CFS Biomass',
-      lastUpdated: '2024-02-20T14:30:00',
-      expiration: '2024-07-20T14:30:00',
-      status: 'Ready',
-    },
-    {
-      projectionGUID: 'guid-3',
-      title: 'Gamma Project',
-      description: 'Third project',
-      method: 'File Upload',
-      projectionType: 'Volume',
-      lastUpdated: '2024-01-10T08:00:00',
-      expiration: '2024-05-10T08:00:00',
-      status: 'Running',
-    },
-    {
-      projectionGUID: 'guid-4',
-      title: 'Delta Project',
-      description: 'Fourth project',
-      method: 'Manual Input',
-      projectionType: 'CFS Biomass',
-      lastUpdated: '2024-03-01T16:45:00',
-      expiration: '2024-08-01T16:45:00',
-      status: 'Failed',
-    },
-  ]
-
-  describe('sortProjections', () => {
-    it('should sort by title in ascending order', () => {
-      const sorted = sortProjections(
-        mockProjections,
-        PROJECTION_LIST_HEADER_KEY.TITLE,
-        SORT_ORDER.ASC,
-      )
-      expect(sorted[0].title).to.equal('Alpha Project')
-      expect(sorted[1].title).to.equal('Beta Project')
-      expect(sorted[2].title).to.equal('Delta Project')
-      expect(sorted[3].title).to.equal('Gamma Project')
-    })
-
-    it('should sort by title in descending order', () => {
-      const sorted = sortProjections(
-        mockProjections,
-        PROJECTION_LIST_HEADER_KEY.TITLE,
-        SORT_ORDER.DESC,
-      )
-      expect(sorted[0].title).to.equal('Gamma Project')
-      expect(sorted[1].title).to.equal('Delta Project')
-      expect(sorted[2].title).to.equal('Beta Project')
-      expect(sorted[3].title).to.equal('Alpha Project')
-    })
-
-    it('should sort by lastUpdated in ascending order', () => {
-      const sorted = sortProjections(
-        mockProjections,
-        PROJECTION_LIST_HEADER_KEY.LAST_UPDATED,
-        SORT_ORDER.ASC,
-      )
-      expect(sorted[0].projectionGUID).to.equal('guid-3') // Jan 10
-      expect(sorted[1].projectionGUID).to.equal('guid-1') // Jan 15
-      expect(sorted[2].projectionGUID).to.equal('guid-2') // Feb 20
-      expect(sorted[3].projectionGUID).to.equal('guid-4') // Mar 01
-    })
-
-    it('should sort by lastUpdated in descending order', () => {
-      const sorted = sortProjections(
-        mockProjections,
-        PROJECTION_LIST_HEADER_KEY.LAST_UPDATED,
-        SORT_ORDER.DESC,
-      )
-      expect(sorted[0].projectionGUID).to.equal('guid-4') // Mar 01
-      expect(sorted[1].projectionGUID).to.equal('guid-2') // Feb 20
-      expect(sorted[2].projectionGUID).to.equal('guid-1') // Jan 15
-      expect(sorted[3].projectionGUID).to.equal('guid-3') // Jan 10
-    })
-
-    it('should sort by expiration in ascending order', () => {
-      const sorted = sortProjections(
-        mockProjections,
-        PROJECTION_LIST_HEADER_KEY.EXPIRATION,
-        SORT_ORDER.ASC,
-      )
-      expect(sorted[0].projectionGUID).to.equal('guid-3') // May 10
-      expect(sorted[1].projectionGUID).to.equal('guid-1') // Jun 15
-      expect(sorted[2].projectionGUID).to.equal('guid-2') // Jul 20
-      expect(sorted[3].projectionGUID).to.equal('guid-4') // Aug 01
-    })
-
-    it('should sort by status in ascending order', () => {
-      const sorted = sortProjections(
-        mockProjections,
-        PROJECTION_LIST_HEADER_KEY.STATUS,
-        SORT_ORDER.ASC,
-      )
-      expect(sorted[0].status).to.equal('Draft')
-      expect(sorted[1].status).to.equal('Failed')
-      expect(sorted[2].status).to.equal('Ready')
-      expect(sorted[3].status).to.equal('Running')
-    })
-
-    it('should not mutate the original array', () => {
-      const original = [...mockProjections]
-      sortProjections(
-        mockProjections,
-        PROJECTION_LIST_HEADER_KEY.TITLE,
-        SORT_ORDER.ASC,
-      )
-      expect(mockProjections).to.deep.equal(original)
-    })
-
-    it('should handle empty array', () => {
-      const sorted = sortProjections(
-        [],
-        PROJECTION_LIST_HEADER_KEY.TITLE,
-        SORT_ORDER.ASC,
-      )
-      expect(sorted).to.deep.equal([])
-    })
-
-    it('should handle single item array', () => {
-      const singleItem = [mockProjections[0]]
-      const sorted = sortProjections(
-        singleItem,
-        PROJECTION_LIST_HEADER_KEY.TITLE,
-        SORT_ORDER.ASC,
-      )
-      expect(sorted).to.have.length(1)
-      expect(sorted[0].title).to.equal('Alpha Project')
-    })
-  })
-
-  describe('paginateProjections', () => {
-    it('should return correct items for first page', () => {
-      const paginated = paginateProjections(mockProjections, 1, 2)
-      expect(paginated).to.have.length(2)
-      expect(paginated[0].projectionGUID).to.equal('guid-1')
-      expect(paginated[1].projectionGUID).to.equal('guid-2')
-    })
-
-    it('should return correct items for second page', () => {
-      const paginated = paginateProjections(mockProjections, 2, 2)
-      expect(paginated).to.have.length(2)
-      expect(paginated[0].projectionGUID).to.equal('guid-3')
-      expect(paginated[1].projectionGUID).to.equal('guid-4')
-    })
-
-    it('should return remaining items for last page', () => {
-      const paginated = paginateProjections(mockProjections, 2, 3)
-      expect(paginated).to.have.length(1)
-      expect(paginated[0].projectionGUID).to.equal('guid-4')
-    })
-
-    it('should return empty array for page beyond available items', () => {
-      const paginated = paginateProjections(mockProjections, 5, 2)
-      expect(paginated).to.have.length(0)
-    })
-
-    it('should return all items when itemsPerPage exceeds total', () => {
-      const paginated = paginateProjections(mockProjections, 1, 10)
-      expect(paginated).to.have.length(4)
-    })
-
-    it('should handle empty array', () => {
-      const paginated = paginateProjections([], 1, 5)
-      expect(paginated).to.have.length(0)
-    })
-
-    it('should handle page 1 with itemsPerPage of 1', () => {
-      const paginated = paginateProjections(mockProjections, 1, 1)
-      expect(paginated).to.have.length(1)
-      expect(paginated[0].projectionGUID).to.equal('guid-1')
-    })
-  })
-
-  describe('calculateTotalPages', () => {
-    it('should calculate correct total pages when evenly divisible', () => {
-      expect(calculateTotalPages(10, 5)).to.equal(2)
-      expect(calculateTotalPages(20, 10)).to.equal(2)
-      expect(calculateTotalPages(100, 25)).to.equal(4)
-    })
-
-    it('should round up when not evenly divisible', () => {
-      expect(calculateTotalPages(11, 5)).to.equal(3)
-      expect(calculateTotalPages(7, 3)).to.equal(3)
-      expect(calculateTotalPages(1, 10)).to.equal(1)
-    })
-
-    it('should return 0 for zero items', () => {
-      expect(calculateTotalPages(0, 5)).to.equal(0)
-    })
-
-    it('should handle single item', () => {
-      expect(calculateTotalPages(1, 5)).to.equal(1)
-    })
-
-    it('should handle items equal to itemsPerPage', () => {
-      expect(calculateTotalPages(5, 5)).to.equal(1)
-    })
-  })
-})
 
 describe('projectionService Unit Tests', () => {
   const mockProjectionModel = {
@@ -308,37 +50,24 @@ describe('projectionService Unit Tests', () => {
       expect(result.selectedExecutionOptions).to.deep.equal([])
       expect(result.ageStart).to.be.null
       expect(result.outputFormat).to.be.null
-    })
-
-    it('should return null reportTitle in defaults', () => {
-      const result = parseProjectionParams(null)
       expect(result.reportTitle).to.be.null
     })
 
-    it('should parse valid JSON string', () => {
+    it('should parse valid JSON string including reportTitle', () => {
       const json = JSON.stringify({
         ageStart: 10,
         ageEnd: 100,
         selectedExecutionOptions: ['DoIncludeProjectedMOFVolumes'],
+        reportTitle: 'My Report Title',
       })
       const result = parseProjectionParams(json)
       expect(result.ageStart).to.equal(10)
       expect(result.ageEnd).to.equal(100)
-      expect(result.selectedExecutionOptions).to.deep.equal([
-        'DoIncludeProjectedMOFVolumes',
-      ])
-    })
-
-    it('should parse reportTitle from valid JSON', () => {
-      const json = JSON.stringify({ reportTitle: 'My Report Title' })
-      const result = parseProjectionParams(json)
+      expect(result.selectedExecutionOptions).to.deep.equal(['DoIncludeProjectedMOFVolumes'])
       expect(result.reportTitle).to.equal('My Report Title')
-    })
 
-    it('should return null for missing reportTitle in JSON', () => {
-      const json = JSON.stringify({ ageStart: 10 })
-      const result = parseProjectionParams(json)
-      expect(result.reportTitle).to.be.null
+      const withoutTitle = parseProjectionParams(JSON.stringify({ ageStart: 5 }))
+      expect(withoutTitle.reportTitle).to.be.null
     })
 
     it('should return defaults for invalid JSON', () => {
@@ -349,7 +78,7 @@ describe('projectionService Unit Tests', () => {
   })
 
   describe('isProjectionReadOnly', () => {
-    it('should return true for Ready and Running statuses', () => {
+    it('should return true for Ready, Running, and Queued statuses', () => {
       expect(isProjectionReadOnly(PROJECTION_STATUS.READY)).to.be.true
       expect(isProjectionReadOnly(PROJECTION_STATUS.RUNNING)).to.be.true
       expect(isProjectionReadOnly(PROJECTION_STATUS.QUEUED)).to.be.true
@@ -450,14 +179,6 @@ describe('projectionService Unit Tests', () => {
       })
     })
 
-    it('should pass null reportDescription when explicitly provided as null', () => {
-      cy.stub(apiClient, 'createProjection').resolves({ data: mockProjectionModel })
-
-      cy.wrap(createProjection(mockParameters, undefined, null)).then(() => {
-        expect(apiClient.createProjection).to.be.calledWith(mockParameters, undefined, null)
-      })
-    })
-
     it('should throw error when API fails', () => {
       const mockError = new Error('Create failed')
       cy.stub(apiClient, 'createProjection').rejects(mockError)
@@ -523,15 +244,6 @@ describe('projectionService Unit Tests', () => {
       })
     })
 
-    it('should call getProjection after updateProjectionParams', () => {
-      cy.stub(apiClient, 'updateProjectionParams').resolves({ data: mockProjectionModel })
-      cy.stub(apiClient, 'getProjection').resolves({ data: mockProjectionModel })
-
-      cy.wrap(updateProjectionParams('guid-test', mockParameters, 'desc')).then(() => {
-        expect(apiClient.getProjection).to.be.calledWith('guid-test')
-      })
-    })
-
     it('should throw error when API fails', () => {
       const mockError = new Error('Update failed')
       cy.stub(apiClient, 'updateProjectionParams').rejects(mockError)
@@ -571,15 +283,6 @@ describe('projectionService Unit Tests', () => {
           undefined,
           'Model desc',
         )
-      })
-    })
-
-    it('should call getProjection after updateProjectionParams', () => {
-      cy.stub(apiClient, 'updateProjectionParams').resolves({ data: mockProjectionModel })
-      cy.stub(apiClient, 'getProjection').resolves({ data: mockProjectionModel })
-
-      cy.wrap(updateProjectionParamsWithModel('guid-test', mockParameters)).then(() => {
-        expect(apiClient.getProjection).to.be.calledWith('guid-test')
       })
     })
 

--- a/frontend/src/services/projectionService.ts
+++ b/frontend/src/services/projectionService.ts
@@ -57,10 +57,15 @@ const getProjectionType = (parameters: Record<string, unknown>): string => {
   const selectedOptions = parameters.selectedExecutionOptions as
     | string[]
     | undefined
-  if (selectedOptions?.includes(ExecutionOptionsEnum.DoIncludeProjectedMOFVolumes)) {
+  const hasVolume = selectedOptions?.includes(ExecutionOptionsEnum.DoIncludeProjectedMOFVolumes)
+  const hasCfs = selectedOptions?.includes(ExecutionOptionsEnum.DoIncludeProjectedCFSBiomass)
+  if (hasVolume && hasCfs) {
+    return PROJECTION_TYPE.BOTH
+  }
+  if (hasVolume) {
     return PROJECTION_TYPE.VOLUME
   }
-  if (selectedOptions?.includes(ExecutionOptionsEnum.DoIncludeProjectedCFSBiomass)) {
+  if (hasCfs) {
     return PROJECTION_TYPE.CFS_BIOMASS
   }
   return ''

--- a/frontend/src/stores/projection/appStore.cy.ts
+++ b/frontend/src/stores/projection/appStore.cy.ts
@@ -13,198 +13,71 @@ describe('App Store Unit Tests', () => {
     appStore = useAppStore()
   })
 
-  describe('Initial State', () => {
-    it('should initialize modelSelection with the default value', () => {
-      expect(appStore.modelSelection).to.equal(DEFAULTS.DEFAULT_VALUES.METHOD_SELECTION)
-    })
-
-    it('should initialize viewMode as CREATE', () => {
-      expect(appStore.viewMode).to.equal(PROJECTION_VIEW_MODE.CREATE)
-    })
-
-    it('should initialize currentProjectionGUID as null', () => {
-      expect(appStore.currentProjectionGUID).to.be.null
-    })
-
-    it('should initialize currentProjectionStatus as DRAFT', () => {
-      expect(appStore.currentProjectionStatus).to.equal(PROJECTION_STATUS.DRAFT)
-    })
-
-    it('should initialize isSavingProjection as false', () => {
-      expect(appStore.isSavingProjection).to.be.false
-    })
-
-    it('should initialize duplicatedFromInfo as null', () => {
-      expect(appStore.duplicatedFromInfo).to.be.null
-    })
+  it('should initialize with correct default state', () => {
+    expect(appStore.modelSelection).to.equal(DEFAULTS.DEFAULT_VALUES.METHOD_SELECTION)
+    expect(appStore.viewMode).to.equal(PROJECTION_VIEW_MODE.CREATE)
+    expect(appStore.currentProjectionGUID).to.be.null
+    expect(appStore.currentProjectionStatus).to.equal(PROJECTION_STATUS.DRAFT)
+    expect(appStore.isSavingProjection).to.be.false
+    expect(appStore.duplicatedFromInfo).to.be.null
   })
 
-  describe('Getters', () => {
-    it('getModelSelection should return current modelSelection', () => {
-      expect(appStore.getModelSelection).to.equal(DEFAULTS.DEFAULT_VALUES.METHOD_SELECTION)
-    })
-
-    it('getViewMode should return current viewMode', () => {
-      expect(appStore.getViewMode).to.equal(PROJECTION_VIEW_MODE.CREATE)
-    })
-
-    it('getCurrentProjectionGUID should return current GUID', () => {
-      expect(appStore.getCurrentProjectionGUID).to.be.null
-    })
-
-    it('getCurrentProjectionStatus should return current status', () => {
-      expect(appStore.getCurrentProjectionStatus).to.equal(PROJECTION_STATUS.DRAFT)
-    })
-
-    it('isReadOnly should be false when viewMode is not VIEW', () => {
-      expect(appStore.isReadOnly).to.be.false
-    })
-
-    it('isReadOnly should be true when viewMode is VIEW', () => {
+  describe('isReadOnly', () => {
+    it('should be true when viewMode is VIEW', () => {
       appStore.setViewMode(PROJECTION_VIEW_MODE.VIEW)
       expect(appStore.isReadOnly).to.be.true
     })
 
-    it('isReadOnly should be false when viewMode is EDIT', () => {
+    it('should be false when viewMode is EDIT', () => {
       appStore.setViewMode(PROJECTION_VIEW_MODE.EDIT)
       expect(appStore.isReadOnly).to.be.false
     })
+  })
 
-    it('isDraft should be true when status is DRAFT', () => {
+  describe('isDraft', () => {
+    it('should be true when status is DRAFT and false otherwise', () => {
       expect(appStore.isDraft).to.be.true
-    })
-
-    it('isDraft should be false when status is not DRAFT', () => {
       appStore.setCurrentProjectionStatus(PROJECTION_STATUS.READY)
       expect(appStore.isDraft).to.be.false
     })
   })
 
-  describe('setModelSelection', () => {
-    it('should update modelSelection', () => {
+  describe('Setters', () => {
+    it('setModelSelection should update modelSelection', () => {
       appStore.setModelSelection('Manual Input')
       expect(appStore.modelSelection).to.equal('Manual Input')
     })
 
-    it('getModelSelection getter should reflect updated value', () => {
-      appStore.setModelSelection('File Upload')
-      expect(appStore.getModelSelection).to.equal('File Upload')
-    })
-  })
-
-  describe('setViewMode', () => {
-    it('should set viewMode to EDIT', () => {
+    it('setViewMode should update viewMode', () => {
       appStore.setViewMode(PROJECTION_VIEW_MODE.EDIT)
       expect(appStore.viewMode).to.equal(PROJECTION_VIEW_MODE.EDIT)
-    })
-
-    it('should set viewMode to VIEW', () => {
       appStore.setViewMode(PROJECTION_VIEW_MODE.VIEW)
       expect(appStore.viewMode).to.equal(PROJECTION_VIEW_MODE.VIEW)
     })
 
-    it('should set viewMode to CREATE', () => {
-      appStore.setViewMode(PROJECTION_VIEW_MODE.EDIT)
-      appStore.setViewMode(PROJECTION_VIEW_MODE.CREATE)
-      expect(appStore.viewMode).to.equal(PROJECTION_VIEW_MODE.CREATE)
-    })
-  })
-
-  describe('setCurrentProjectionGUID', () => {
-    it('should set GUID to a string value', () => {
-      const testGuid = 'abc-123-def'
-      appStore.setCurrentProjectionGUID(testGuid)
-      expect(appStore.currentProjectionGUID).to.equal(testGuid)
-    })
-
-    it('should set GUID back to null', () => {
-      appStore.setCurrentProjectionGUID('some-guid')
+    it('setCurrentProjectionGUID should set and clear GUID', () => {
+      appStore.setCurrentProjectionGUID('abc-123-def')
+      expect(appStore.currentProjectionGUID).to.equal('abc-123-def')
       appStore.setCurrentProjectionGUID(null)
       expect(appStore.currentProjectionGUID).to.be.null
     })
 
-    it('getCurrentProjectionGUID getter should reflect updated value', () => {
-      const testGuid = 'test-guid-456'
-      appStore.setCurrentProjectionGUID(testGuid)
-      expect(appStore.getCurrentProjectionGUID).to.equal(testGuid)
-    })
-  })
-
-  describe('setCurrentProjectionStatus', () => {
-    it('should set status to READY', () => {
-      appStore.setCurrentProjectionStatus(PROJECTION_STATUS.READY)
-      expect(appStore.currentProjectionStatus).to.equal(PROJECTION_STATUS.READY)
-    })
-
-    it('should set status to RUNNING', () => {
+    it('setCurrentProjectionStatus should update status', () => {
       appStore.setCurrentProjectionStatus(PROJECTION_STATUS.RUNNING)
       expect(appStore.currentProjectionStatus).to.equal(PROJECTION_STATUS.RUNNING)
     })
 
-    it('should set status to FAILED', () => {
-      appStore.setCurrentProjectionStatus(PROJECTION_STATUS.FAILED)
-      expect(appStore.currentProjectionStatus).to.equal(PROJECTION_STATUS.FAILED)
-    })
-
-    it('getCurrentProjectionStatus getter should reflect updated value', () => {
-      appStore.setCurrentProjectionStatus(PROJECTION_STATUS.RUNNING)
-      expect(appStore.getCurrentProjectionStatus).to.equal(PROJECTION_STATUS.RUNNING)
-    })
-  })
-
-  describe('setDuplicatedFromInfo', () => {
-    it('should set duplicatedFromInfo with an object', () => {
+    it('setDuplicatedFromInfo should set and clear info', () => {
       const info = { originalName: 'My Projection', duplicatedAt: '2024-01-15T10:00:00' }
       appStore.setDuplicatedFromInfo(info)
       expect(appStore.duplicatedFromInfo).to.deep.equal(info)
-    })
-
-    it('should clear duplicatedFromInfo when set to null', () => {
-      appStore.setDuplicatedFromInfo({ originalName: 'My Projection', duplicatedAt: '2024-01-15T10:00:00' })
       appStore.setDuplicatedFromInfo(null)
       expect(appStore.duplicatedFromInfo).to.be.null
-    })
-
-    it('should overwrite existing duplicatedFromInfo', () => {
-      appStore.setDuplicatedFromInfo({ originalName: 'First', duplicatedAt: '2024-01-01T00:00:00' })
-      const newInfo = { originalName: 'Second', duplicatedAt: '2024-06-01T00:00:00' }
-      appStore.setDuplicatedFromInfo(newInfo)
-      expect(appStore.duplicatedFromInfo).to.deep.equal(newInfo)
     })
   })
 
   describe('resetForNewProjection', () => {
-    it('should reset viewMode to CREATE', () => {
-      appStore.setViewMode(PROJECTION_VIEW_MODE.EDIT)
-      appStore.resetForNewProjection()
-      expect(appStore.viewMode).to.equal(PROJECTION_VIEW_MODE.CREATE)
-    })
-
-    it('should reset currentProjectionGUID to null', () => {
-      appStore.setCurrentProjectionGUID('some-guid')
-      appStore.resetForNewProjection()
-      expect(appStore.currentProjectionGUID).to.be.null
-    })
-
-    it('should reset currentProjectionStatus to DRAFT', () => {
-      appStore.setCurrentProjectionStatus(PROJECTION_STATUS.READY)
-      appStore.resetForNewProjection()
-      expect(appStore.currentProjectionStatus).to.equal(PROJECTION_STATUS.DRAFT)
-    })
-
-    it('should reset isSavingProjection to false', () => {
-      appStore.isSavingProjection = true
-      appStore.resetForNewProjection()
-      expect(appStore.isSavingProjection).to.be.false
-    })
-
-    it('should reset duplicatedFromInfo to null', () => {
-      appStore.setDuplicatedFromInfo({ originalName: 'My Projection', duplicatedAt: '2024-01-15T10:00:00' })
-      appStore.resetForNewProjection()
-      expect(appStore.duplicatedFromInfo).to.be.null
-    })
-
-    it('should reset all fields together', () => {
+    it('should reset all fields to initial state', () => {
       appStore.setViewMode(PROJECTION_VIEW_MODE.VIEW)
       appStore.setCurrentProjectionGUID('guid-xyz')
       appStore.setCurrentProjectionStatus(PROJECTION_STATUS.FAILED)

--- a/frontend/src/stores/projection/fileUploadStore.ts
+++ b/frontend/src/stores/projection/fileUploadStore.ts
@@ -134,7 +134,7 @@ export const useFileUploadStore = defineStore('fileUploadStore', () => {
 
   // update species groups based on projection type
   const updateSpeciesGroupsForProjectionType = (type: string | null) => {
-    if (type === CONSTANTS.PROJECTION_TYPE.CFS_BIOMASS) {
+    if (type === CONSTANTS.PROJECTION_TYPE.CFS_BIOMASS || type === CONSTANTS.PROJECTION_TYPE.BOTH) {
       // CFO Biomass: use specific values
       fileUploadSpeciesGroup.value.forEach((group) => {
         group.minimumDBHLimit =
@@ -255,9 +255,13 @@ export const useFileUploadStore = defineStore('fileUploadStore', () => {
   }
 
   const restoreProjectionTypeAndSpeciesGroups = (options: string[]) => {
-    if (options.includes(ExecutionOptionsEnum.DoIncludeProjectedCFSBiomass)) {
+    const hasCfs = options.includes(ExecutionOptionsEnum.DoIncludeProjectedCFSBiomass)
+    const hasVolume = options.includes(ExecutionOptionsEnum.DoIncludeProjectedMOFVolumes)
+    if (hasCfs && hasVolume) {
+      projectionType.value = CONSTANTS.PROJECTION_TYPE.BOTH
+    } else if (hasCfs) {
       projectionType.value = CONSTANTS.PROJECTION_TYPE.CFS_BIOMASS
-    } else if (options.includes(ExecutionOptionsEnum.DoIncludeProjectedMOFVolumes)) {
+    } else if (hasVolume) {
       projectionType.value = CONSTANTS.PROJECTION_TYPE.VOLUME
     }
     initializeSpeciesGroups()

--- a/frontend/src/stores/projection/modelParameterStore.ts
+++ b/frontend/src/stores/projection/modelParameterStore.ts
@@ -446,9 +446,13 @@ export const useModelParameterStore = defineStore('modelParameter', () => {
     isComputedMAIEnabled.value = options.includes(ExecutionOptionsEnum.ReportIncludeVolumeMAI)
     isCulminationValuesEnabled.value = options.includes(ExecutionOptionsEnum.ReportIncludeCulminationValues)
 
-    if (options.includes(ExecutionOptionsEnum.DoIncludeProjectedCFSBiomass)) {
+    const hasCfs = options.includes(ExecutionOptionsEnum.DoIncludeProjectedCFSBiomass)
+    const hasVolume = options.includes(ExecutionOptionsEnum.DoIncludeProjectedMOFVolumes)
+    if (hasCfs && hasVolume) {
+      projectionType.value = CONSTANTS.PROJECTION_TYPE.BOTH
+    } else if (hasCfs) {
       projectionType.value = CONSTANTS.PROJECTION_TYPE.CFS_BIOMASS
-    } else if (options.includes(ExecutionOptionsEnum.DoIncludeProjectedMOFVolumes)) {
+    } else if (hasVolume) {
       projectionType.value = CONSTANTS.PROJECTION_TYPE.VOLUME
     }
   }


### PR DESCRIPTION
- Add "Both" as a third option to the Projection Type radio buttons (File Upload and Manual Input)
- When Both is selected, pass both Volume and CFS Biomass execution options to the backend
- Apply CFS Biomass-specific settings (utilization levels, Min DBH deactivation) when Both is selected