### PR TITLE
VDYP-1226: Move job folder deletion to job execution listener.

### DIFF
--- a/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/configuration/BatchJobExecutionListener.java
+++ b/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/configuration/BatchJobExecutionListener.java
@@ -1,5 +1,14 @@
 package ca.bc.gov.nrs.vdyp.batch.configuration;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.batch.core.JobExecution;
@@ -8,11 +17,7 @@ import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Component;
 
 import ca.bc.gov.nrs.vdyp.batch.util.BatchConstants;
-
-import java.time.LocalDateTime;
-import java.time.Duration;
-import java.util.HashMap;
-import java.util.Map;
+import ca.bc.gov.nrs.vdyp.batch.util.BatchUtils;
 
 /**
  * Job execution listener for partitioned VDYP batch job.
@@ -50,6 +55,8 @@ public class BatchJobExecutionListener implements JobExecutionListener {
 	public void afterJob(@NonNull JobExecution jobExecution) {
 		Long jobExecutionId = jobExecution.getId();
 		String jobGuid = jobExecution.getJobParameters().getString(BatchConstants.Job.GUID);
+		String jobBaseDir = jobExecution.getJobParameters().getString(BatchConstants.Job.BASE_DIR);
+		Path jobBasePath = jobBaseDir != null ? Paths.get(jobBaseDir) : null;
 
 		// Use synchronization to ensure only one thread processes this job completion
 		synchronized (lock) {
@@ -61,6 +68,10 @@ public class BatchJobExecutionListener implements JobExecutionListener {
 						jobGuid, jobExecutionId
 				);
 				return;
+			}
+
+			if (jobBasePath != null) {
+				cleanupJobDirectory(jobGuid, jobBasePath);
 			}
 
 			// Mark this job as processed
@@ -89,6 +100,24 @@ public class BatchJobExecutionListener implements JobExecutionListener {
 			logger.info(separator);
 
 			cleanupOldJobTracker(jobExecutionId);
+		}
+	}
+
+	private void cleanupJobDirectory(String jobGuid, Path jobBasePath) {
+		try {
+			BatchUtils.deleteDirectoryRecursively(jobBasePath);
+			logger.debug("[GUID: {}] Deleted job directory after S3 upload: {}", jobGuid, jobBasePath);
+		} catch (IOException e) {
+			logger.warn("[GUID: {}] Failed to delete job directory {}: {}", jobGuid, jobBasePath, e.getMessage());
+		}
+
+		Path warningsFile = Paths.get(jobBasePath + BatchConstants.Partition.WARNING_FILE_NAME);
+		try {
+			if (Files.deleteIfExists(warningsFile)) {
+				logger.debug("[GUID: {}] Deleted warnings file: {}", jobGuid, warningsFile);
+			}
+		} catch (IOException e) {
+			logger.warn("[GUID: {}] Failed to delete warnings file {}: {}", jobGuid, warningsFile, e.getMessage());
 		}
 	}
 

--- a/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/service/ResultPersistenceTasklet.java
+++ b/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/service/ResultPersistenceTasklet.java
@@ -5,7 +5,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
-import java.util.UUID;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -18,7 +17,6 @@ import ca.bc.gov.nrs.vdyp.batch.client.vdyp.VdypClient;
 import ca.bc.gov.nrs.vdyp.batch.client.vdyp.VdypProjectionDetails;
 import ca.bc.gov.nrs.vdyp.batch.exception.BatchException;
 import ca.bc.gov.nrs.vdyp.batch.exception.BatchResultPersistenceException;
-import ca.bc.gov.nrs.vdyp.batch.util.BatchConstants;
 import ca.bc.gov.nrs.vdyp.batch.util.BatchUtils;
 
 @Component
@@ -53,50 +51,26 @@ public class ResultPersistenceTasklet extends VdypFileTasklet {
 				throw new IOException("Could not find expected result zip file at: " + finalZipPath);
 			}
 
-			String resultZipFileName = BatchUtils.buildResultZipFileName(projectionDetails.reportTitle());
-			String resultFileSetGUID = projectionDetails.resultFileSet().guid();
-			if (resultFiles.isEmpty()) {
-				// No result file yet: register a placeholder in Backend/COMS, upload directly, then confirm.
-				FileMappingDetails placeholder = vdypClient
-						.startFileSetFileUpload(projectionGUID, resultFileSetGUID, resultZipFileName);
-				comsFileService.updateStoredObject(
-						UUID.fromString(placeholder.comsObjectGuid()), finalZipPath, resultZipFileName
-				);
-				vdypClient.completeFileSetFileUpload(projectionGUID, resultFileSetGUID, placeholder.fileMappingGuid());
-			} else {
-				comsFileService.updateStoredObject(
-						UUID.fromString(resultFiles.get(0).comsObjectGuid()), finalZipPath, resultZipFileName
-				);
-			}
-
-			vdypClient.markComplete(
-					projectionGUID, true, BatchUtils.buildFinalProgress(jobGuid, stepExecution.getJobExecution())
-			);
-
-			logger.debug("Completed persistence of result zip file to COMS.");
-
-			cleanupJobFiles(jobBasePath);
+			throw new Exception("Fail on purpose");
+			/*
+			 * String resultZipFileName = BatchUtils.buildResultZipFileName(projectionDetails.reportTitle()); String
+			 * resultFileSetGUID = projectionDetails.resultFileSet().guid(); if (resultFiles.isEmpty()) { // No result
+			 * file yet: register a placeholder in Backend/COMS, upload directly, then confirm. FileMappingDetails
+			 * placeholder = vdypClient .startFileSetFileUpload(projectionGUID, resultFileSetGUID, resultZipFileName);
+			 * comsFileService.updateStoredObject( UUID.fromString(placeholder.comsObjectGuid()), finalZipPath,
+			 * resultZipFileName ); vdypClient.completeFileSetFileUpload(projectionGUID, resultFileSetGUID,
+			 * placeholder.fileMappingGuid()); } else { comsFileService.updateStoredObject(
+			 * UUID.fromString(resultFiles.get(0).comsObjectGuid()), finalZipPath, resultZipFileName ); }
+			 *
+			 * vdypClient.markComplete( projectionGUID, true, BatchUtils.buildFinalProgress(jobGuid,
+			 * stepExecution.getJobExecution()) );
+			 *
+			 * logger.debug("Completed persistence of result zip file to COMS.");
+			 *
+			 */
 		} catch (Exception e) {
 			throw BatchResultPersistenceException
 					.handleResultPersistenceFailure(e, "Failed to persist result zip to COMS.", jobGuid, jobId, logger);
-		}
-	}
-
-	private void cleanupJobFiles(Path jobBasePath) {
-		try {
-			BatchUtils.deleteDirectoryRecursively(jobBasePath);
-			logger.debug("[GUID: {}] Deleted job directory after S3 upload: {}", jobGuid, jobBasePath);
-		} catch (IOException e) {
-			logger.warn("[GUID: {}] Failed to delete job directory {}: {}", jobGuid, jobBasePath, e.getMessage());
-		}
-
-		Path warningsFile = Paths.get(jobBasePath + BatchConstants.Partition.WARNING_FILE_NAME);
-		try {
-			if (Files.deleteIfExists(warningsFile)) {
-				logger.debug("[GUID: {}] Deleted warnings file: {}", jobGuid, warningsFile);
-			}
-		} catch (IOException e) {
-			logger.warn("[GUID: {}] Failed to delete warnings file {}: {}", jobGuid, warningsFile, e.getMessage());
 		}
 	}
 

--- a/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/service/ResultPersistenceTasklet.java
+++ b/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/service/ResultPersistenceTasklet.java
@@ -5,6 +5,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
+import java.util.UUID;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,23 +52,28 @@ public class ResultPersistenceTasklet extends VdypFileTasklet {
 				throw new IOException("Could not find expected result zip file at: " + finalZipPath);
 			}
 
-			throw new Exception("Fail on purpose");
-			/*
-			 * String resultZipFileName = BatchUtils.buildResultZipFileName(projectionDetails.reportTitle()); String
-			 * resultFileSetGUID = projectionDetails.resultFileSet().guid(); if (resultFiles.isEmpty()) { // No result
-			 * file yet: register a placeholder in Backend/COMS, upload directly, then confirm. FileMappingDetails
-			 * placeholder = vdypClient .startFileSetFileUpload(projectionGUID, resultFileSetGUID, resultZipFileName);
-			 * comsFileService.updateStoredObject( UUID.fromString(placeholder.comsObjectGuid()), finalZipPath,
-			 * resultZipFileName ); vdypClient.completeFileSetFileUpload(projectionGUID, resultFileSetGUID,
-			 * placeholder.fileMappingGuid()); } else { comsFileService.updateStoredObject(
-			 * UUID.fromString(resultFiles.get(0).comsObjectGuid()), finalZipPath, resultZipFileName ); }
-			 *
-			 * vdypClient.markComplete( projectionGUID, true, BatchUtils.buildFinalProgress(jobGuid,
-			 * stepExecution.getJobExecution()) );
-			 *
-			 * logger.debug("Completed persistence of result zip file to COMS.");
-			 *
-			 */
+			String resultZipFileName = BatchUtils.buildResultZipFileName(projectionDetails.reportTitle());
+			String resultFileSetGUID = projectionDetails.resultFileSet().guid();
+			if (resultFiles.isEmpty()) {
+				// No result file yet: register a placeholder in Backend/COMS, upload directly, then confirm.
+				FileMappingDetails placeholder = vdypClient
+						.startFileSetFileUpload(projectionGUID, resultFileSetGUID, resultZipFileName);
+				comsFileService.updateStoredObject(
+						UUID.fromString(placeholder.comsObjectGuid()), finalZipPath, resultZipFileName
+				);
+				vdypClient.completeFileSetFileUpload(projectionGUID, resultFileSetGUID, placeholder.fileMappingGuid());
+			} else {
+				comsFileService.updateStoredObject(
+						UUID.fromString(resultFiles.get(0).comsObjectGuid()), finalZipPath, resultZipFileName
+				);
+			}
+
+			vdypClient.markComplete(
+					projectionGUID, true, BatchUtils.buildFinalProgress(jobGuid, stepExecution.getJobExecution())
+			);
+
+			logger.debug("Completed persistence of result zip file to COMS.");
+
 		} catch (Exception e) {
 			throw BatchResultPersistenceException
 					.handleResultPersistenceFailure(e, "Failed to persist result zip to COMS.", jobGuid, jobId, logger);

--- a/batch/src/test/java/ca/bc/gov/nrs/vdyp/batch/configuration/BatchJobExecutionListenerTest.java
+++ b/batch/src/test/java/ca/bc/gov/nrs/vdyp/batch/configuration/BatchJobExecutionListenerTest.java
@@ -1,9 +1,25 @@
 package ca.bc.gov.nrs.vdyp.batch.configuration;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
@@ -14,11 +30,7 @@ import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.JobParametersBuilder;
 
 import ca.bc.gov.nrs.vdyp.batch.util.BatchConstants;
-
-import java.time.LocalDateTime;
-
-import static org.mockito.Mockito.*;
-import static org.junit.jupiter.api.Assertions.*;
+import ca.bc.gov.nrs.vdyp.batch.util.BatchUtils;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -165,5 +177,63 @@ class BatchJobExecutionListenerTest {
 
 			listener.beforeJob(finalJob);
 		});
+	}
+
+	@Test
+	void testAfterJob_JobBasePathDeleteThrowsIOException(@TempDir Path tempDir) throws IOException {
+		Long jobId = 6L;
+		String jobGuid = "guid-006";
+		Path jobBaseDir = Files.createDirectory(tempDir.resolve("job-dir"));
+
+		JobParameters jobParameters = new JobParametersBuilder().addString(BatchConstants.Job.GUID, jobGuid)
+				.addString(BatchConstants.Job.BASE_DIR, jobBaseDir.toString()).toJobParameters();
+
+		when(jobExecution.getId()).thenReturn(jobId);
+		when(jobExecution.getJobParameters()).thenReturn(jobParameters);
+		when(jobExecution.getStatus()).thenReturn(BatchStatus.COMPLETED);
+		when(jobExecution.getStartTime()).thenReturn(LocalDateTime.now().minusMinutes(1));
+		when(jobExecution.getEndTime()).thenReturn(LocalDateTime.now());
+
+		listener.beforeJob(jobExecution);
+
+		try (MockedStatic<BatchUtils> batchUtilsMock = mockStatic(BatchUtils.class)) {
+			batchUtilsMock.when(() -> BatchUtils.deleteDirectoryRecursively(jobBaseDir))
+					.thenThrow(new IOException("simulated delete failure"));
+
+			assertDoesNotThrow(() -> listener.afterJob(jobExecution));
+		}
+
+		assertTrue(Files.exists(jobBaseDir));
+	}
+
+	@Test
+	void testAfterJob_WarningsDeleteThrowsIOException(@TempDir Path tempDir) throws IOException {
+		Long jobId = 7L;
+		String jobGuid = "guid-007";
+		Path jobBaseDir = Files.createDirectory(tempDir.resolve("job-dir"));
+		Path warningsPath = Path.of(jobBaseDir + BatchConstants.Partition.WARNING_FILE_NAME);
+		Files.createDirectories(warningsPath);
+		Files.createFile(warningsPath.resolve("nested.txt"));
+
+		JobParameters jobParameters = new JobParametersBuilder().addString(BatchConstants.Job.GUID, jobGuid)
+				.addString(BatchConstants.Job.BASE_DIR, jobBaseDir.toString()).toJobParameters();
+
+		when(jobExecution.getId()).thenReturn(jobId);
+		when(jobExecution.getJobParameters()).thenReturn(jobParameters);
+		when(jobExecution.getStatus()).thenReturn(BatchStatus.COMPLETED);
+		when(jobExecution.getStartTime()).thenReturn(LocalDateTime.now().minusMinutes(1));
+		when(jobExecution.getEndTime()).thenReturn(LocalDateTime.now());
+
+		listener.beforeJob(jobExecution);
+
+		try (MockedStatic<BatchUtils> batchUtilsMock = mockStatic(BatchUtils.class)) {
+			batchUtilsMock.when(() -> BatchUtils.deleteDirectoryRecursively(any(Path.class)))
+					.thenAnswer(invocation -> null);
+
+			assertDoesNotThrow(() -> listener.afterJob(jobExecution));
+		}
+
+		assertTrue(Files.exists(warningsPath));
+		assertTrue(Files.exists(warningsPath.resolve("nested.txt")));
 	}
 }

--- a/batch/src/test/java/ca/bc/gov/nrs/vdyp/batch/service/ResultPersistenceTaskletTest.java
+++ b/batch/src/test/java/ca/bc/gov/nrs/vdyp/batch/service/ResultPersistenceTaskletTest.java
@@ -158,39 +158,6 @@ class ResultPersistenceTaskletTest {
 	}
 
 	@Test
-	void testExecute_filesExist_warningsFileDeletedAfterUpload() throws Exception {
-		UUID resultFileSetGuid = UUID.randomUUID();
-		UUID resultFileComsObjectGuid = UUID.randomUUID();
-
-		jobParameters = new JobParametersBuilder().addString(BatchConstants.Job.GUID, "job-123")
-				.addString(BatchConstants.Job.BASE_DIR, tempDir.toString()) //
-				.addString(BatchConstants.Job.TIMESTAMP, BatchUtils.createJobTimestamp()) //
-				.addLong(BatchConstants.Partition.NUMBER, 4L) //
-				.addString(BatchConstants.GuidInput.PROJECTION_GUID, projectionGuid.toString()) //
-				.toJobParameters();
-		when(jobExecution.getJobParameters()).thenReturn(jobParameters);
-		when(jobExecution.getExecutionContext()).thenReturn(new ExecutionContext());
-		when(jobExecution.getStepExecutions()).thenReturn(Collections.emptyList());
-		when(vdypClient.getProjectionDetails(any())).thenReturn(details);
-		when(details.resultFileSet())
-				.thenReturn(new VdypProjectionDetails.VdypProjectionFileSet(resultFileSetGuid.toString()));
-		when(vdypClient.getFileSetFiles(any(), matches(resultFileSetGuid.toString()))).thenReturn(
-				List.of(new FileMappingDetails(UUID.randomUUID().toString(), resultFileComsObjectGuid.toString()))
-		);
-		when(details.reportTitle()).thenReturn("Test Report");
-		doNothing().when(comsFileService).updateStoredObject(any(UUID.class), any(Path.class), any(String.class));
-
-		Path finalZipPath = BatchUtils.getFinalZipName(tempDir, jobParameters.getString(BatchConstants.Job.TIMESTAMP));
-		Files.createFile(finalZipPath);
-
-		Path warningsFile = tempDir.getParent()
-				.resolve(tempDir.getFileName() + BatchConstants.Partition.WARNING_FILE_NAME);
-		Files.createFile(warningsFile);
-
-		tasklet.execute(stepContribution, chunkContext);
-	}
-
-	@Test
 	void testExecute_filesExist_emptyFileSetCallsVDYPClient() throws Exception {
 		UUID resultFileSetGuid = UUID.randomUUID();
 		UUID placeholderComsObjectGuid = UUID.randomUUID();

--- a/batch/src/test/java/ca/bc/gov/nrs/vdyp/batch/service/ResultPersistenceTaskletTest.java
+++ b/batch/src/test/java/ca/bc/gov/nrs/vdyp/batch/service/ResultPersistenceTaskletTest.java
@@ -1,7 +1,6 @@
 package ca.bc.gov.nrs.vdyp.batch.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -156,7 +155,6 @@ class ResultPersistenceTaskletTest {
 		// Assert
 		assertEquals(RepeatStatus.FINISHED, status);
 		verify(comsFileService).updateStoredObject(eq(resultFileComsObjectGuid), any(Path.class), any(String.class));
-		assertFalse(Files.exists(tempDir), "Job directory should be deleted after successful S3 upload");
 	}
 
 	@Test
@@ -190,8 +188,6 @@ class ResultPersistenceTaskletTest {
 		Files.createFile(warningsFile);
 
 		tasklet.execute(stepContribution, chunkContext);
-
-		assertFalse(Files.exists(warningsFile), "Warnings file should be deleted after successful S3 upload");
 	}
 
 	@Test


### PR DESCRIPTION
Done in an effort to delete files in the event of any job failure