### PR TITLE
Feature/VDYP-1195: Truncate yield table rows beyond reference age + 400 years

### DIFF
--- a/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/model/Vdyp7Constants.java
+++ b/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/model/Vdyp7Constants.java
@@ -31,6 +31,7 @@ public class Vdyp7Constants {
 
 	public static final double MIN_SPECIES_AGE = 0.0;
 	public static final double MAX_SPECIES_AGE = 2000.0;
+	public static final int MAX_YEARS_BEYOND_REFERENCE_AGE = 400;
 
 	public static final int MAX_NUM_LAYERS_PER_POLYGON = 9;
 	public static final int MAX_NUM_SPECIES_PER_LAYER = 6;

--- a/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/output/yieldtable/YieldTableRowContext.java
+++ b/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/output/yieldtable/YieldTableRowContext.java
@@ -15,6 +15,7 @@ import ca.bc.gov.nrs.vdyp.ecore.projection.ValidatedParameters;
 import ca.bc.gov.nrs.vdyp.ecore.projection.model.Layer;
 import ca.bc.gov.nrs.vdyp.ecore.projection.model.LayerReportingInfo;
 import ca.bc.gov.nrs.vdyp.ecore.projection.model.Polygon;
+import ca.bc.gov.nrs.vdyp.ecore.projection.model.Vdyp7Constants;
 import ca.bc.gov.nrs.vdyp.ecore.projection.model.enumerations.ProjectionTypeCode;
 
 class YieldTableRowContext {
@@ -542,6 +543,33 @@ class YieldTableRowContext {
 		}
 		if (yearAtGapEnd != null) {
 			ageAtGapEnd = yearAtGapEnd - yearToAgeDifference;
+		}
+
+		if (yearAtDeath == null && ageAtEndYear != null) {
+			int maxAllowedAge = referenceAge + Vdyp7Constants.MAX_YEARS_BEYOND_REFERENCE_AGE;
+			if (ageAtEndYear > maxAllowedAge) {
+				ageAtEndYear = maxAllowedAge;
+				yearAtEndAge = ageAtEndYear + yearToAgeDifference;
+				if (ageAtGapStart != null && ageAtGapStart >= ageAtEndYear) {
+					ageAtGapStart = null;
+					yearAtGapStart = null;
+					ageAtGapEnd = null;
+					yearAtGapEnd = null;
+				} else if (ageAtGapEnd != null && ageAtGapEnd > ageAtEndYear) {
+					ageAtGapEnd = ageAtEndYear;
+					yearAtGapEnd = yearAtEndAge;
+				}
+				if (ageAtStartYear != null && ageAtStartYear > ageAtEndYear) {
+					yearAtStartAge = null;
+					yearAtEndAge = null;
+					ageAtStartYear = null;
+					ageAtEndYear = null;
+					yearAtGapStart = null;
+					yearAtGapEnd = null;
+					ageAtGapStart = null;
+					ageAtGapEnd = null;
+				}
+			}
 		}
 	}
 

--- a/lib/vdyp-extended-core/src/test/java/ca/bc/gov/nrs/vdyp/ecore/projection/output/yieldtable/YieldTableRowContextTest.java
+++ b/lib/vdyp-extended-core/src/test/java/ca/bc/gov/nrs/vdyp/ecore/projection/output/yieldtable/YieldTableRowContextTest.java
@@ -123,6 +123,20 @@ public class YieldTableRowContextTest {
 						AgeYearCombo.of(Parameters.AgeYearRangeCombinationKind.DIFFERENCE, 0, 50, 1975, 2000), // Disjoint
 						// Difference
 						AgeYearComboResults.of(0, 24, null, null)
+				),
+
+				Arguments.of(AgeYearCombo.of(null, 0, 500, null, null), AgeYearComboResults.of(0, 400, null, null)),
+				Arguments.of(AgeYearCombo.of(null, 0, 400, null, null), AgeYearComboResults.of(0, 400, null, null)),
+				Arguments.of(
+						AgeYearCombo.of(null, 401, 500, null, null), AgeYearComboResults.of(null, null, null, null)
+				),
+				Arguments.of(
+						AgeYearCombo.of(Parameters.AgeYearRangeCombinationKind.DIFFERENCE, 0, 500, 2360, 2500),
+						AgeYearComboResults.of(0, 400, null, null)
+				),
+				Arguments.of(
+						AgeYearCombo.of(Parameters.AgeYearRangeCombinationKind.DIFFERENCE, 0, 500, 2349, 2500),
+						AgeYearComboResults.of(0, 400, 398, 400)
 				)
 		);
 	}


### PR DESCRIPTION
- Yield table rows are now truncated for any period more than 400 years beyond a polygon's reference age (EST_AGE_SPP1)