### PR TITLE
VDYP-1233: Delete input partition dirs at start of result aggregation

### DIFF
--- a/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/configuration/BatchConfiguration.java
+++ b/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/configuration/BatchConfiguration.java
@@ -358,6 +358,24 @@ public class BatchConfiguration {
 			Duration duration = Duration
 					.between(now, startTime == null ? now : startTime.atZone(ZoneId.systemDefault()));
 
+			boolean cleanupEnabled = batchProperties.getPartition().getInterimDirsCleanupEnabled();
+
+			// Delete input partition directories first: they are no longer needed once the worker
+			// steps have finished, so there is no reason to wait until the output ZIP is built and
+			// validated before reclaiming that storage.
+			if (cleanupEnabled) {
+				Path jobBasePath = Paths.get(jobBaseDir);
+				resultAggregationService.cleanupInputPartitionDirectories(jobBasePath);
+				logger.info(
+						"[GUID: {}] Input partition directories cleanup completed for job: {}", jobGuid, jobExecutionId
+				);
+			} else {
+				logger.info(
+						"[GUID: {}] Cleanup is disabled. Skipping cleanup of input partition directories for job: {}",
+						jobGuid, jobExecutionId
+				);
+			}
+
 			VDYPProjectionProgressUpdate finalProgress = BatchUtils.buildFinalProgress(jobGuid, jobExecution);
 			// Execute aggregation
 			Path consolidatedZip = resultAggregationService.aggregateResultsFromJobDir(
@@ -371,15 +389,15 @@ public class BatchConfiguration {
 					jobGuid, jobExecutionId, consolidatedZip
 			);
 
-			// Clean up interim partition directories after successful zip creation and validation
-			if (batchProperties.getPartition().getInterimDirsCleanupEnabled()) {
+			// Clean up output partition directories after successful zip creation and validation
+			if (cleanupEnabled) {
 				if (resultAggregationService.validateConsolidatedZip(consolidatedZip)) {
 
 					Path jobBasePath = Paths.get(jobBaseDir);
-					resultAggregationService.cleanupPartitionDirectories(jobBasePath);
+					resultAggregationService.cleanupOutputPartitionDirectories(jobBasePath);
 
 					logger.info(
-							"[GUID: {}] Interim partition directories cleanup completed for job: {}", jobGuid,
+							"[GUID: {}] Output partition directories cleanup completed for job: {}", jobGuid,
 							jobExecutionId
 					);
 				} else {
@@ -390,7 +408,7 @@ public class BatchConfiguration {
 				}
 			} else {
 				logger.info(
-						"[GUID: {}] Cleanup is disabled. Skipping cleanup of interim partition directories for job: {}",
+						"[GUID: {}] Cleanup is disabled. Skipping cleanup of output partition directories for job: {}",
 						jobGuid, jobExecutionId
 				);
 			}

--- a/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/configuration/VDYPJobMetricListener.java
+++ b/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/configuration/VDYPJobMetricListener.java
@@ -80,7 +80,8 @@ public class VDYPJobMetricListener implements JobExecutionListener {
 				String jobBaseDir = jobExecution.getJobParameters().getString(BatchConstants.Job.BASE_DIR);
 				if (jobBaseDir != null) {
 					Path jobBasePath = Paths.get(jobBaseDir);
-					resultAggregationService.cleanupPartitionDirectories(jobBasePath);
+					resultAggregationService.cleanupInputPartitionDirectories(jobBasePath);
+					resultAggregationService.cleanupOutputPartitionDirectories(jobBasePath);
 					logger.info(
 							"[GUID: {}] Job execution ID: {} was stopped. Interim partition directories cleanup completed",
 							jobGuid, jobExecution.getId()

--- a/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/service/BatchResultAggregationService.java
+++ b/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/service/BatchResultAggregationService.java
@@ -755,11 +755,29 @@ public class BatchResultAggregationService {
 	}
 
 	/**
-	 * Cleans up interim partition directories after successful zip creation. Deletes input-partition and
-	 * output-partition directories and their contents.
+	 * Deletes all input-partition directories under the job base directory. Runs as the first step of result
+	 * aggregation, since input partitions are no longer needed once the worker steps have finished processing them,
+	 * well before the output ZIP has been assembled or validated.
 	 */
-	public void cleanupPartitionDirectories(Path jobBasePath) {
-		logger.debug("Starting cleanup of partition directories in: {}", jobBasePath);
+	public void cleanupInputPartitionDirectories(Path jobBasePath) {
+		cleanupPartitionDirectoriesWithPrefix(jobBasePath, BatchConstants.Partition.INPUT_FOLDER_NAME_PREFIX);
+	}
+
+	/**
+	 * Deletes all output-partition directories under the job base directory. Must only be called after the
+	 * consolidated ZIP has been created (and ideally validated), since aggregation reads results from these
+	 * directories.
+	 */
+	public void cleanupOutputPartitionDirectories(Path jobBasePath) {
+		cleanupPartitionDirectoriesWithPrefix(jobBasePath, BatchConstants.Partition.OUTPUT_FOLDER_NAME_PREFIX);
+	}
+
+	/**
+	 * Finds and recursively deletes all directories directly under the job base directory whose name starts with the
+	 * given prefix.
+	 */
+	private void cleanupPartitionDirectoriesWithPrefix(Path jobBasePath, String prefix) {
+		logger.debug("Starting cleanup of '{}' partition directories in: {}", prefix, jobBasePath);
 
 		if (!Files.exists(jobBasePath) || !Files.isDirectory(jobBasePath)) {
 			logger.warn("Job base directory does not exist or is not a directory: {}", jobBasePath);
@@ -768,13 +786,9 @@ public class BatchResultAggregationService {
 
 		int deletedDirs = 0;
 
-		// Find and delete all input-partition and output-partition directories
 		try (Stream<Path> files = Files.list(jobBasePath)) {
-			List<Path> partitionDirs = files.filter(Files::isDirectory).filter(dir -> {
-				String dirName = dir.getFileName().toString();
-				return dirName.startsWith(BatchConstants.Partition.INPUT_FOLDER_NAME_PREFIX)
-						|| dirName.startsWith(BatchConstants.Partition.OUTPUT_FOLDER_NAME_PREFIX);
-			}).toList();
+			List<Path> partitionDirs = files.filter(Files::isDirectory)
+					.filter(dir -> dir.getFileName().toString().startsWith(prefix)).toList();
 
 			for (Path partitionDir : partitionDirs) {
 				if (deletePartitionDirectory(partitionDir)) {
@@ -785,7 +799,7 @@ public class BatchResultAggregationService {
 			logger.error("Failed to list partition directories for cleanup: {}", jobBasePath, e);
 		}
 
-		logger.debug("Cleanup completed. Deleted {} partition directories", deletedDirs);
+		logger.debug("Cleanup completed. Deleted {} '{}' partition directories", deletedDirs, prefix);
 	}
 
 	/**

--- a/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/service/BatchResultAggregationService.java
+++ b/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/service/BatchResultAggregationService.java
@@ -764,9 +764,8 @@ public class BatchResultAggregationService {
 	}
 
 	/**
-	 * Deletes all output-partition directories under the job base directory. Must only be called after the
-	 * consolidated ZIP has been created (and ideally validated), since aggregation reads results from these
-	 * directories.
+	 * Deletes all output-partition directories under the job base directory. Must only be called after the consolidated
+	 * ZIP has been created (and ideally validated), since aggregation reads results from these directories.
 	 */
 	public void cleanupOutputPartitionDirectories(Path jobBasePath) {
 		cleanupPartitionDirectoriesWithPrefix(jobBasePath, BatchConstants.Partition.OUTPUT_FOLDER_NAME_PREFIX);

--- a/batch/src/test/java/ca/bc/gov/nrs/vdyp/batch/configuration/BatchConfigurationTest.java
+++ b/batch/src/test/java/ca/bc/gov/nrs/vdyp/batch/configuration/BatchConfigurationTest.java
@@ -280,7 +280,8 @@ class BatchConfigurationTest {
 
 		assertEquals(RepeatStatus.FINISHED, result);
 		verify(resultAggregationService).validateConsolidatedZip(mockPath);
-		verify(resultAggregationService).cleanupPartitionDirectories(tempDir);
+		verify(resultAggregationService).cleanupInputPartitionDirectories(tempDir);
+		verify(resultAggregationService).cleanupOutputPartitionDirectories(tempDir);
 	}
 
 	@Test
@@ -331,7 +332,8 @@ class BatchConfigurationTest {
 
 		assertEquals(RepeatStatus.FINISHED, result);
 		verify(resultAggregationService).validateConsolidatedZip(mockPath);
-		verify(resultAggregationService, org.mockito.Mockito.never()).cleanupPartitionDirectories(any());
+		verify(resultAggregationService).cleanupInputPartitionDirectories(tempDir);
+		verify(resultAggregationService, org.mockito.Mockito.never()).cleanupOutputPartitionDirectories(any());
 	}
 
 	@Test
@@ -509,7 +511,8 @@ class BatchConfigurationTest {
 
 		assertEquals(RepeatStatus.FINISHED, result);
 
-		verify(resultAggregationService, org.mockito.Mockito.never()).cleanupPartitionDirectories(any());
+		verify(resultAggregationService, org.mockito.Mockito.never()).cleanupInputPartitionDirectories(any());
+		verify(resultAggregationService, org.mockito.Mockito.never()).cleanupOutputPartitionDirectories(any());
 		verify(resultAggregationService, org.mockito.Mockito.never()).validateConsolidatedZip(any());
 	}
 

--- a/batch/src/test/java/ca/bc/gov/nrs/vdyp/batch/configuration/BatchConfigurationTest.java
+++ b/batch/src/test/java/ca/bc/gov/nrs/vdyp/batch/configuration/BatchConfigurationTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -333,7 +334,7 @@ class BatchConfigurationTest {
 		assertEquals(RepeatStatus.FINISHED, result);
 		verify(resultAggregationService).validateConsolidatedZip(mockPath);
 		verify(resultAggregationService).cleanupInputPartitionDirectories(tempDir);
-		verify(resultAggregationService, org.mockito.Mockito.never()).cleanupOutputPartitionDirectories(any());
+		verify(resultAggregationService, never()).cleanupOutputPartitionDirectories(any());
 	}
 
 	@Test
@@ -511,9 +512,9 @@ class BatchConfigurationTest {
 
 		assertEquals(RepeatStatus.FINISHED, result);
 
-		verify(resultAggregationService, org.mockito.Mockito.never()).cleanupInputPartitionDirectories(any());
-		verify(resultAggregationService, org.mockito.Mockito.never()).cleanupOutputPartitionDirectories(any());
-		verify(resultAggregationService, org.mockito.Mockito.never()).validateConsolidatedZip(any());
+		verify(resultAggregationService, never()).cleanupInputPartitionDirectories(any());
+		verify(resultAggregationService, never()).cleanupOutputPartitionDirectories(any());
+		verify(resultAggregationService, never()).validateConsolidatedZip(any());
 	}
 
 	@Test

--- a/batch/src/test/java/ca/bc/gov/nrs/vdyp/batch/service/BatchResultAggregationServiceTest.java
+++ b/batch/src/test/java/ca/bc/gov/nrs/vdyp/batch/service/BatchResultAggregationServiceTest.java
@@ -387,7 +387,7 @@ class BatchResultAggregationServiceTest {
 	}
 
 	@Test
-	void testCleanupPartitionDirectories_Success() throws IOException {
+	void testCleanupInputPartitionDirectories_LeavesOutputIntact() throws IOException {
 		// Setup input and output partition directories
 		Path inputPartition = tempDir.resolve("input-partition0");
 		Path outputPartition = tempDir.resolve("output-partition0");
@@ -398,10 +398,27 @@ class BatchResultAggregationServiceTest {
 		Files.writeString(inputPartition.resolve("test.csv"), "data");
 		Files.writeString(outputPartition.resolve("result.csv"), "result");
 
-		resultAggregationService.cleanupPartitionDirectories(tempDir);
+		resultAggregationService.cleanupInputPartitionDirectories(tempDir);
 
-		// Verify directories are deleted
+		// Only input directories should be deleted; output must survive until aggregation reads it
 		assertFalse(Files.exists(inputPartition));
+		assertTrue(Files.exists(outputPartition), "Output partition should not be deleted by input cleanup");
+	}
+
+	@Test
+	void testCleanupOutputPartitionDirectories_Success() throws IOException {
+		Path inputPartition = tempDir.resolve("input-partition0");
+		Path outputPartition = tempDir.resolve("output-partition0");
+		Files.createDirectories(inputPartition);
+		Files.createDirectories(outputPartition);
+
+		Files.writeString(inputPartition.resolve("test.csv"), "data");
+		Files.writeString(outputPartition.resolve("result.csv"), "result");
+
+		resultAggregationService.cleanupOutputPartitionDirectories(tempDir);
+
+		// Only output directories should be deleted
+		assertTrue(Files.exists(inputPartition), "Input partition should not be deleted by output cleanup");
 		assertFalse(Files.exists(outputPartition));
 	}
 
@@ -410,7 +427,8 @@ class BatchResultAggregationServiceTest {
 		Path nonExistent = tempDir.resolve("non-existent");
 
 		// Should not throw exception
-		assertDoesNotThrow(() -> resultAggregationService.cleanupPartitionDirectories(nonExistent));
+		assertDoesNotThrow(() -> resultAggregationService.cleanupInputPartitionDirectories(nonExistent));
+		assertDoesNotThrow(() -> resultAggregationService.cleanupOutputPartitionDirectories(nonExistent));
 	}
 
 	@Test
@@ -420,24 +438,25 @@ class BatchResultAggregationServiceTest {
 		Files.writeString(filePath, "content");
 
 		// Should not throw exception, just log warning
-		assertDoesNotThrow(() -> resultAggregationService.cleanupPartitionDirectories(filePath));
+		assertDoesNotThrow(() -> resultAggregationService.cleanupInputPartitionDirectories(filePath));
+		assertDoesNotThrow(() -> resultAggregationService.cleanupOutputPartitionDirectories(filePath));
 	}
 
 	@Test
-	void testCleanupPartitionDirectories_NestedStructure() throws IOException {
+	void testCleanupInputPartitionDirectories_NestedStructure() throws IOException {
 		// Create nested directory structure
 		Path inputPartition = tempDir.resolve("input-partition0");
 		Path nestedDir = inputPartition.resolve("nested");
 		Files.createDirectories(nestedDir);
 		Files.writeString(nestedDir.resolve("file.txt"), "data");
 
-		resultAggregationService.cleanupPartitionDirectories(tempDir);
+		resultAggregationService.cleanupInputPartitionDirectories(tempDir);
 
 		assertFalse(Files.exists(inputPartition));
 	}
 
 	@Test
-	void testCleanupPartitionDirectories_OnlyPartitionDirs() throws IOException {
+	void testCleanupInputPartitionDirectories_OnlyInputDirs() throws IOException {
 		// Create partition directories and non-partition directories
 		Path inputPartition = tempDir.resolve("input-partition0");
 		Path outputPartition = tempDir.resolve("output-partition0");
@@ -449,11 +468,11 @@ class BatchResultAggregationServiceTest {
 		Files.createDirectories(otherDir);
 		Files.writeString(otherFile, "content");
 
-		resultAggregationService.cleanupPartitionDirectories(tempDir);
+		resultAggregationService.cleanupInputPartitionDirectories(tempDir);
 
-		// Only partition directories should be deleted
+		// Only the input partition directory should be deleted
 		assertFalse(Files.exists(inputPartition));
-		assertFalse(Files.exists(outputPartition));
+		assertTrue(Files.exists(outputPartition), "Output partition should not be deleted by input cleanup");
 		assertTrue(Files.exists(otherDir), "Non-partition directory should not be deleted");
 		assertTrue(Files.exists(otherFile), "Non-partition file should not be deleted");
 	}


### PR DESCRIPTION
- Split cleanupPartitionDirectories into cleanupInputPartitionDirectories and cleanupOutputPartitionDirectories
- Input partition directories are now deleted at the very start of resultAggregationTasklet, before the ZIP is built/validated, since aggregation never reads from them
- Output partition directories are still cleaned up after ZIP creation and validation succeed, as before