### PR TITLE
Feature/VDYP-1219: Include polygon feature ID in projection exception messages

### DIFF
--- a/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/api/v1/exceptions/AbstractProjectionRequestException.java
+++ b/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/api/v1/exceptions/AbstractProjectionRequestException.java
@@ -49,6 +49,22 @@ public abstract class AbstractProjectionRequestException extends Exception {
 		return validationMessages;
 	}
 
+	protected static String buildContextPrefix(long featureId) {
+		return "Polygon " + featureId;
+	}
+
+	protected static String buildContextPrefix(long featureId, String layerId) {
+		return buildContextPrefix(featureId) + " Layer " + layerId;
+	}
+
+	protected static String buildContextPrefix(long featureId, String layerId, String speciesCode) {
+		return buildContextPrefix(featureId, layerId) + " Species " + speciesCode;
+	}
+
+	protected static String withContext(String contextPrefix, String message) {
+		return contextPrefix + (message != null ? ": " + message : "");
+	}
+
 	private static String buildMessage(List<ValidationMessage> validationMessages) {
 		if (validationMessages.size() > 0) {
 			StringBuffer sb = new StringBuffer(validationMessages.get(0).toString());

--- a/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/api/v1/exceptions/LayerValidationException.java
+++ b/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/api/v1/exceptions/LayerValidationException.java
@@ -17,4 +17,8 @@ public class LayerValidationException extends AbstractProjectionRequestException
 	public LayerValidationException(List<ValidationMessage> validationMessages) {
 		super(validationMessages);
 	}
+
+	public LayerValidationException(long featureId, String layerId, List<ValidationMessage> validationMessages) {
+		super(buildContextPrefix(featureId, layerId), validationMessages);
+	}
 }

--- a/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/api/v1/exceptions/PolygonExecutionException.java
+++ b/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/api/v1/exceptions/PolygonExecutionException.java
@@ -27,4 +27,16 @@ public class PolygonExecutionException extends AbstractProjectionRequestExceptio
 	public PolygonExecutionException(String message) {
 		super(message);
 	}
+
+	public PolygonExecutionException(long featureId, String message) {
+		super(withContext(buildContextPrefix(featureId), message));
+	}
+
+	public PolygonExecutionException(long featureId, String message, Throwable cause) {
+		super(withContext(buildContextPrefix(featureId), message), cause);
+	}
+
+	public PolygonExecutionException(long featureId, Throwable cause) {
+		super(withContext(buildContextPrefix(featureId), cause.getMessage()), cause);
+	}
 }

--- a/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/api/v1/exceptions/PolygonValidationException.java
+++ b/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/api/v1/exceptions/PolygonValidationException.java
@@ -21,4 +21,8 @@ public class PolygonValidationException extends AbstractProjectionRequestExcepti
 	public PolygonValidationException(List<ValidationMessage> validationMessages) {
 		super(validationMessages);
 	}
+
+	public PolygonValidationException(long featureId, ValidationMessage validationMessage) {
+		super(buildContextPrefix(featureId), List.of(validationMessage));
+	}
 }

--- a/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/api/v1/exceptions/StandYieldCalculationException.java
+++ b/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/api/v1/exceptions/StandYieldCalculationException.java
@@ -24,4 +24,41 @@ public class StandYieldCalculationException extends AbstractProjectionRequestExc
 	public StandYieldCalculationException(StandYieldMessageKind template, Object... args) {
 		super(MessageFormat.format(template.template, args).toString());
 	}
+
+	public StandYieldCalculationException(long featureId, Exception cause) {
+		super(withContext(buildContextPrefix(featureId), buildCauseMessage(cause)), cause);
+	}
+
+	public StandYieldCalculationException(long featureId, StandYieldMessageKind template, Object... args) {
+		super(withContext(buildContextPrefix(featureId), MessageFormat.format(template.template, args)));
+	}
+
+	public StandYieldCalculationException(long featureId, String layerId, Exception cause) {
+		super(withContext(buildContextPrefix(featureId, layerId), buildCauseMessage(cause)), cause);
+	}
+
+	public StandYieldCalculationException(
+			long featureId, String layerId, String speciesCode, StandYieldMessageKind template, Object... args
+	) {
+		super(
+				withContext(
+						buildContextPrefix(featureId, layerId, speciesCode),
+						MessageFormat.format(template.template, args)
+				)
+		);
+	}
+
+	public StandYieldCalculationException(
+			long featureId, String layerId, StandYieldMessageKind template, Object... args
+	) {
+		super(withContext(buildContextPrefix(featureId, layerId), MessageFormat.format(template.template, args)));
+	}
+
+	private static String buildCauseMessage(Exception cause) {
+		if (cause == null) {
+			return "null";
+		}
+		String causeDetail = cause.getMessage() != null ? ": " + cause.getMessage() : "";
+		return cause.getClass().getSimpleName() + causeDetail;
+	}
 }

--- a/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/api/v1/exceptions/YieldTableGenerationException.java
+++ b/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/api/v1/exceptions/YieldTableGenerationException.java
@@ -19,4 +19,16 @@ public class YieldTableGenerationException extends AbstractProjectionRequestExce
 	public YieldTableGenerationException(String message) {
 		super(message);
 	}
+
+	public YieldTableGenerationException(long featureId, String message) {
+		super(withContext(buildContextPrefix(featureId), message));
+	}
+
+	public YieldTableGenerationException(long featureId, String message, Exception cause) {
+		super(withContext(buildContextPrefix(featureId), message), cause);
+	}
+
+	public YieldTableGenerationException(long featureId, Exception cause) {
+		super(withContext(buildContextPrefix(featureId), cause.getMessage()), cause);
+	}
 }

--- a/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/PolygonProjectionRunner.java
+++ b/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/PolygonProjectionRunner.java
@@ -178,7 +178,7 @@ public class PolygonProjectionRunner {
 
 			state.setExecutionFolder(executionFolder);
 		} catch (IOException e) {
-			throw new PolygonExecutionException(e);
+			throw new PolygonExecutionException(polygon.getFeatureId(), e);
 		}
 	}
 
@@ -286,7 +286,7 @@ public class PolygonProjectionRunner {
 								)
 						);
 
-						throw new PolygonExecutionException(oFipResult.get());
+						throw new PolygonExecutionException(polygon.getFeatureId(), oFipResult.get());
 					}
 					break;
 				}
@@ -559,9 +559,10 @@ public class PolygonProjectionRunner {
 			}
 		} catch (Exception e) {
 			throw new PolygonExecutionException(
+					polygon.getFeatureId(),
 					MessageFormat.format(
-							"{0}: encountered {1} while running creating FIP input data{2}", polygon,
-							e.getClass().getName(), e.getMessage() != null ? "; reason: " + e.getMessage() : ""
+							"encountered {0} while running creating FIP input data{1}", e.getClass().getName(),
+							e.getMessage() != null ? "; reason: " + e.getMessage() : ""
 					)
 			);
 		} finally {
@@ -604,9 +605,10 @@ public class PolygonProjectionRunner {
 			}
 		} catch (Exception e) {
 			throw new PolygonExecutionException(
+					polygon.getFeatureId(),
 					MessageFormat.format(
-							"{0}: encountered {1} while running creating VRI input data{2}", polygon,
-							e.getClass().getName(), e.getMessage() != null ? "; reason: " + e.getMessage() : ""
+							"encountered {0} while running creating VRI input data{1}", e.getClass().getName(),
+							e.getMessage() != null ? "; reason: " + e.getMessage() : ""
 					), e
 			);
 		} finally {
@@ -689,10 +691,11 @@ public class PolygonProjectionRunner {
 			default: {
 				if (primaryLayerAge == null) {
 					throw new PolygonExecutionException(
+							polygon.getFeatureId(),
 							MessageFormat.format(
-									"{0}: unable to project layer {1} since the age of the polygon's primary layer can't"
-											+ " be calculated at year {2}{3}",
-									polygon, layer, polygon.getReferenceYear(),
+									"unable to project layer {0} since the age of the polygon's primary layer can't"
+											+ " be calculated at year {1}{2}",
+									layer, polygon.getReferenceYear(),
 									polygon.getPrimaryLayer() == null ? ". Reason: the polygon has no primary layer"
 											: ""
 							)
@@ -711,8 +714,9 @@ public class PolygonProjectionRunner {
 			var leadingSp0 = layer.determineLeadingSp0(0);
 			if (leadingSp0 == null) {
 				throw new PolygonExecutionException(
+						polygon.getFeatureId(),
 						MessageFormat.format(
-								"{0}: unable to project since layer {1} has no leading Sp0 at year {2}", polygon, layer,
+								"unable to project since layer {0} has no leading Sp0 at year {1}", layer,
 								polygon.getReferenceYear()
 						)
 				);
@@ -783,7 +787,8 @@ public class PolygonProjectionRunner {
 					// BACK read the backwards growth target value from entry 101 in the
 					// control file. Adjust the control file to contain this value.
 					rewriteTargetYearToBackControlFile(
-							state.getExecutionFolder(), measurementYear, yearsToGrowBack, projectionType
+							polygon.getFeatureId(), state.getExecutionFolder(), measurementYear, yearsToGrowBack,
+							projectionType
 					);
 
 					componentRunner.runBack(polygon, projectionType, state);
@@ -958,7 +963,7 @@ public class PolygonProjectionRunner {
 				yearToGrowWriter.writePolygon(polygon, measurementYear + yearsToGrow);
 			}
 		} catch (IOException e) {
-			throw new PolygonExecutionException(e);
+			throw new PolygonExecutionException(polygon.getFeatureId(), e);
 		}
 	}
 
@@ -974,13 +979,14 @@ public class PolygonProjectionRunner {
 							.collect(Collectors.joining(""))
 			);
 		} catch (IOException e) {
-			throw new PolygonExecutionException(e);
+			throw new PolygonExecutionException(polygon.getFeatureId(), e);
 		}
 		return path;
 	}
 
 	static void rewriteTargetYearToBackControlFile(
-			Path executionFolder, int measurementYear, int yearsToGrowBack, ProjectionTypeCode projectionType
+			long featureId, Path executionFolder, int measurementYear, int yearsToGrowBack,
+			ProjectionTypeCode projectionType
 	) throws PolygonExecutionException {
 
 		Path controlFilePath = Path
@@ -997,7 +1003,7 @@ public class PolygonProjectionRunner {
 			Files.delete(controlFilePath);
 			Files.move(tempControlFilePath, controlFilePath);
 		} catch (IOException e) {
-			throw new PolygonExecutionException(e);
+			throw new PolygonExecutionException(featureId, e);
 		}
 	}
 

--- a/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/RealComponentRunner.java
+++ b/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/RealComponentRunner.java
@@ -119,15 +119,17 @@ public class RealComponentRunner implements ComponentRunner {
 
 		} catch (Exception e) {
 			throw new PolygonExecutionException(
+					polygon.getFeatureId(),
 					MessageFormat.format(
-							"{0}: encountered {1} while running copyAdjustInputFilesToOutput{2}", polygon,
+							"encountered {0} while running copyAdjustInputFilesToOutput{1}",
 							e.getClass().getSimpleName(), e.getMessage() != null ? "; reason: " + e.getMessage() : ""
 					), e
 			);
 		} catch (Error e) {
 			throw new PolygonExecutionException(
+					polygon.getFeatureId(),
 					MessageFormat.format(
-							"{0}: encountered {1} while running copyAdjustInputFilesToOutput{2}", polygon,
+							"encountered {0} while running copyAdjustInputFilesToOutput{1}",
 							e.getClass().getSimpleName(), e.getMessage() != null ? "; reason: " + e.getMessage() : ""
 					), e
 			);
@@ -181,9 +183,9 @@ public class RealComponentRunner implements ComponentRunner {
 
 			state.setProcessingResults(ProjectionStageCode.Back, projectionTypeCode, Optional.empty());
 		} catch (Exception e) {
-			throw new PolygonExecutionException("Encountered exception while running BACK", e);
+			throw new PolygonExecutionException(polygon.getFeatureId(), "Encountered exception while running BACK", e);
 		} catch (Error e) {
-			throw new PolygonExecutionException("Encountered error while running BACK", e);
+			throw new PolygonExecutionException(polygon.getFeatureId(), "Encountered error while running BACK", e);
 		}
 	}
 
@@ -322,7 +324,7 @@ public class RealComponentRunner implements ComponentRunner {
 
 			return projectionResults;
 		} catch (ResourceParseException | IOException e) {
-			throw new YieldTableGenerationException(e);
+			throw new YieldTableGenerationException(polygon.getFeatureId(), e);
 		}
 	}
 

--- a/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/RealComponentRunner.java
+++ b/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/RealComponentRunner.java
@@ -117,15 +117,7 @@ public class RealComponentRunner implements ComponentRunner {
 			Path utilizationsOutputFile = Path.of(executionFolder.toString(), "vu_adj.dat");
 			Files.copy(utilizationsInputFile, utilizationsOutputFile);
 
-		} catch (Exception e) {
-			throw new PolygonExecutionException(
-					polygon.getFeatureId(),
-					MessageFormat.format(
-							"encountered {0} while running copyAdjustInputFilesToOutput{1}",
-							e.getClass().getSimpleName(), e.getMessage() != null ? "; reason: " + e.getMessage() : ""
-					), e
-			);
-		} catch (Error e) {
+		} catch (Exception | Error e) {
 			throw new PolygonExecutionException(
 					polygon.getFeatureId(),
 					MessageFormat.format(
@@ -182,10 +174,11 @@ public class RealComponentRunner implements ComponentRunner {
 			// app.doMain(controlFilePath.toAbsolutePath().toString());
 
 			state.setProcessingResults(ProjectionStageCode.Back, projectionTypeCode, Optional.empty());
-		} catch (Exception e) {
-			throw new PolygonExecutionException(polygon.getFeatureId(), "Encountered exception while running BACK", e);
-		} catch (Error e) {
-			throw new PolygonExecutionException(polygon.getFeatureId(), "Encountered error while running BACK", e);
+		} catch (Exception | Error e) {
+			throw new PolygonExecutionException(
+					polygon.getFeatureId(),
+					MessageFormat.format("Encountered {0} while running BACK", e.getClass().getSimpleName()), e
+			);
 		}
 	}
 

--- a/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/input/HcsvLayerRecordBean.java
+++ b/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/input/HcsvLayerRecordBean.java
@@ -836,7 +836,9 @@ public class HcsvLayerRecordBean {
 			// Now, throw if there's been any validation errors.
 
 			if (!bvh.getValidationMessages().isEmpty()) {
-				throw new CsvConstraintViolationException(new LayerValidationException(bvh.getValidationMessages()));
+				throw new CsvConstraintViolationException(
+						new LayerValidationException(bean.getFeatureId(), bean.layerId, bvh.getValidationMessages())
+				);
 			}
 
 			return true;

--- a/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/input/HcsvPolygonStream.java
+++ b/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/input/HcsvPolygonStream.java
@@ -270,6 +270,10 @@ public class HcsvPolygonStream extends AbstractPolygonStream {
 		} catch (Exception e) {
 			if (! (e instanceof PolygonValidationException)) {
 				var message = new ValidationMessage(ValidationMessageKind.GENERIC, e.getMessage());
+				Long currentPolygonFeatureId = nextPolygonRecord != null ? nextPolygonRecord.getFeatureId() : null;
+				if (currentPolygonFeatureId != null) {
+					throw new PolygonValidationException(currentPolygonFeatureId, message);
+				}
 				throw new PolygonValidationException(message);
 			} else {
 				throw e;

--- a/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/input/HcsvPolygonStream.java
+++ b/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/input/HcsvPolygonStream.java
@@ -181,6 +181,13 @@ public class HcsvPolygonStream extends AbstractPolygonStream {
 		}
 	}
 
+	static PolygonValidationException toPolygonValidationException(Long featureId, ValidationMessage message) {
+		if (featureId != null) {
+			return new PolygonValidationException(featureId, message);
+		}
+		return new PolygonValidationException(message);
+	}
+
 	private Polygon buildPolygon() throws PolygonValidationException {
 
 		Polygon polygon = null;
@@ -271,10 +278,7 @@ public class HcsvPolygonStream extends AbstractPolygonStream {
 			if (! (e instanceof PolygonValidationException)) {
 				var message = new ValidationMessage(ValidationMessageKind.GENERIC, e.getMessage());
 				Long currentPolygonFeatureId = nextPolygonRecord != null ? nextPolygonRecord.getFeatureId() : null;
-				if (currentPolygonFeatureId != null) {
-					throw new PolygonValidationException(currentPolygonFeatureId, message);
-				}
-				throw new PolygonValidationException(message);
+				throw toPolygonValidationException(currentPolygonFeatureId, message);
 			} else {
 				throw e;
 			}

--- a/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/input/HcsvPolygonStream.java
+++ b/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/input/HcsvPolygonStream.java
@@ -188,6 +188,11 @@ public class HcsvPolygonStream extends AbstractPolygonStream {
 		return new PolygonValidationException(message);
 	}
 
+	static PolygonValidationException
+			toPolygonValidationException(HcsvPolygonRecordBean polygonRecord, ValidationMessage message) {
+		return toPolygonValidationException(polygonRecord != null ? polygonRecord.getFeatureId() : null, message);
+	}
+
 	private Polygon buildPolygon() throws PolygonValidationException {
 
 		Polygon polygon = null;
@@ -277,8 +282,7 @@ public class HcsvPolygonStream extends AbstractPolygonStream {
 		} catch (Exception e) {
 			if (! (e instanceof PolygonValidationException)) {
 				var message = new ValidationMessage(ValidationMessageKind.GENERIC, e.getMessage());
-				Long currentPolygonFeatureId = nextPolygonRecord != null ? nextPolygonRecord.getFeatureId() : null;
-				throw toPolygonValidationException(currentPolygonFeatureId, message);
+				throw toPolygonValidationException(nextPolygonRecord, message);
 			} else {
 				throw e;
 			}

--- a/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/model/Polygon.java
+++ b/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/model/Polygon.java
@@ -990,7 +990,7 @@ public class Polygon implements Comparable<Polygon> {
 			var leadingSpecies = primaryLayer.determineLeadingSp0(0);
 			if (leadingSpecies == null || leadingSpecies.getSpeciesByPercent().isEmpty()) {
 				throw new PolygonValidationException(
-						new ValidationMessage(ValidationMessageKind.NO_LEADING_SPECIES, this, primaryLayer)
+						new ValidationMessage(ValidationMessageKind.NO_LEADING_SPECIES, primaryLayer)
 				);
 			}
 

--- a/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/output/yieldtable/AbstractCSVTypeYieldTableWriter.java
+++ b/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/output/yieldtable/AbstractCSVTypeYieldTableWriter.java
@@ -62,7 +62,7 @@ abstract class AbstractCSVTypeYieldTableWriter<T extends YieldTableRowBean> exte
 		try {
 			write(currentRecord);
 		} catch (CsvException e) {
-			throw new YieldTableGenerationException(e);
+			throw new YieldTableGenerationException(rowContext.getPolygon().getFeatureId(), e);
 		}
 	}
 

--- a/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/output/yieldtable/AbstractCSVTypeYieldTableWriter.java
+++ b/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/output/yieldtable/AbstractCSVTypeYieldTableWriter.java
@@ -66,7 +66,8 @@ abstract class AbstractCSVTypeYieldTableWriter<T extends YieldTableRowBean> exte
 		}
 	}
 
-	static YieldTableGenerationException toYieldTableGenerationException(YieldTableRowContext rowContext, CsvException e) {
+	static YieldTableGenerationException
+			toYieldTableGenerationException(YieldTableRowContext rowContext, CsvException e) {
 		return new YieldTableGenerationException(rowContext.getPolygon().getFeatureId(), e);
 	}
 

--- a/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/output/yieldtable/AbstractCSVTypeYieldTableWriter.java
+++ b/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/output/yieldtable/AbstractCSVTypeYieldTableWriter.java
@@ -62,8 +62,12 @@ abstract class AbstractCSVTypeYieldTableWriter<T extends YieldTableRowBean> exte
 		try {
 			write(currentRecord);
 		} catch (CsvException e) {
-			throw new YieldTableGenerationException(rowContext.getPolygon().getFeatureId(), e);
+			throw toYieldTableGenerationException(rowContext, e);
 		}
+	}
+
+	static YieldTableGenerationException toYieldTableGenerationException(YieldTableRowContext rowContext, CsvException e) {
+		return new YieldTableGenerationException(rowContext.getPolygon().getFeatureId(), e);
 	}
 
 	@Override

--- a/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/output/yieldtable/FullReportYieldTableWriter.java
+++ b/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/output/yieldtable/FullReportYieldTableWriter.java
@@ -320,7 +320,7 @@ class FullReportYieldTableWriter extends YieldTableWriter<TextYieldTableRowValue
 			 */
 		} catch (Exception e) {
 			throw new YieldTableGenerationException(
-					"Error writing yield table record for polygon: " + rowContext.getPolygon().getPolygonNumber(), e
+					rowContext.getPolygon().getFeatureId(), "Error writing yield table record", e
 			);
 		}
 		// Print out all the relevant information
@@ -827,6 +827,9 @@ class FullReportYieldTableWriter extends YieldTableWriter<TextYieldTableRowValue
 		try {
 			outputStream.write(String.format(message, args).getBytes());
 		} catch (IOException e) {
+			if (lastPolygonForTrailer != null) {
+				throw new YieldTableGenerationException(lastPolygonForTrailer.getFeatureId(), e);
+			}
 			throw new YieldTableGenerationException(e);
 		}
 	}

--- a/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/output/yieldtable/FullReportYieldTableWriter.java
+++ b/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/output/yieldtable/FullReportYieldTableWriter.java
@@ -827,11 +827,15 @@ class FullReportYieldTableWriter extends YieldTableWriter<TextYieldTableRowValue
 		try {
 			outputStream.write(String.format(message, args).getBytes());
 		} catch (IOException e) {
-			if (lastPolygonForTrailer != null) {
-				throw new YieldTableGenerationException(lastPolygonForTrailer.getFeatureId(), e);
-			}
-			throw new YieldTableGenerationException(e);
+			throw toYieldTableGenerationException(lastPolygonForTrailer, e);
 		}
+	}
+
+	static YieldTableGenerationException toYieldTableGenerationException(Polygon lastPolygonForTrailer, IOException e) {
+		if (lastPolygonForTrailer != null) {
+			return new YieldTableGenerationException(lastPolygonForTrailer.getFeatureId(), e);
+		}
+		return new YieldTableGenerationException(e);
 	}
 
 	@Override

--- a/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/output/yieldtable/RealProjectionResultsReader.java
+++ b/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/output/yieldtable/RealProjectionResultsReader.java
@@ -82,6 +82,7 @@ public class RealProjectionResultsReader implements ProjectionResultsReader {
 
 			if (vdypPolygon.isPresent()) {
 				throw new YieldTableGenerationException(
+						polygon.getFeatureId(),
 						MessageFormat.format(
 								"Expected exactly one polygon {0} in the projection output, but saw {1} as well",
 								expectedPolygonIdentifier, vdypPolygon.get().getPolygonIdentifier()
@@ -89,7 +90,7 @@ public class RealProjectionResultsReader implements ProjectionResultsReader {
 				);
 			}
 		} catch (ProcessingException e) {
-			throw new YieldTableGenerationException(e);
+			throw new YieldTableGenerationException(polygon.getFeatureId(), e);
 		}
 
 		return projectionResultsByYear;

--- a/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/output/yieldtable/YieldTable.java
+++ b/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/output/yieldtable/YieldTable.java
@@ -94,6 +94,29 @@ public class YieldTable implements Closeable {
 		return new YieldTable(context, outputFormat);
 	}
 
+	private static StandYieldCalculationException standYieldCalculationException(
+			YieldTableRowContext rowContext, StandYieldMessageKind template, Object... args
+	) {
+		long featureId = rowContext.getPolygon().getFeatureId();
+		if (rowContext.isPolygonTable()) {
+			return new StandYieldCalculationException(featureId, template, args);
+		}
+		return new StandYieldCalculationException(
+				featureId, rowContext.getLayerReportingInfo().getLayer().getLayerId(), template, args
+		);
+	}
+
+	private static StandYieldCalculationException
+			standYieldCalculationException(YieldTableRowContext rowContext, Exception cause) {
+		long featureId = rowContext.getPolygon().getFeatureId();
+		if (rowContext.isPolygonTable()) {
+			return new StandYieldCalculationException(featureId, cause);
+		}
+		return new StandYieldCalculationException(
+				featureId, rowContext.getLayerReportingInfo().getLayer().getLayerId(), cause
+		);
+	}
+
 	public void startGeneration() throws YieldTableGenerationException {
 		writer.writeHeader();
 	}
@@ -645,15 +668,15 @@ public class YieldTable implements Closeable {
 	) throws StandYieldCalculationException {
 
 		if (totalAge < Vdyp7Constants.MIN_SPECIES_AGE || totalAge > Vdyp7Constants.MAX_SPECIES_AGE) {
-			throw new StandYieldCalculationException(
-					StandYieldMessageKind.AGE_OUT_OF_RANGE, Vdyp7Constants.MIN_SPECIES_AGE,
+			throw standYieldCalculationException(
+					rowContext, StandYieldMessageKind.AGE_OUT_OF_RANGE, Vdyp7Constants.MIN_SPECIES_AGE,
 					Vdyp7Constants.MAX_SPECIES_AGE
 			);
 		}
 
 		var primaryLayer = rowContext.getPolygon().getPrimaryLayer();
 		if (primaryLayer == null) {
-			throw new StandYieldCalculationException(new LayerMissingException(LayerType.PRIMARY));
+			throw standYieldCalculationException(rowContext, new LayerMissingException(LayerType.PRIMARY));
 		}
 
 		var primaryLayerAge0Year = primaryLayer.determineYearAtAge(0);
@@ -1074,6 +1097,8 @@ public class YieldTable implements Closeable {
 
 		if (targetAge < Vdyp7Constants.MIN_SPECIES_AGE || Vdyp7Constants.MAX_SPECIES_AGE < targetAge) {
 			throw new StandYieldCalculationException(
+					species.getStand().getLayer().getPolygon().getFeatureId(),
+					species.getStand().getLayer().getLayerId(), species.getSpeciesCode(),
 					StandYieldMessageKind.AGE_OUT_OF_RANGE, Double.valueOf(Vdyp7Constants.MIN_SPECIES_AGE),
 					Double.valueOf(Vdyp7Constants.MAX_SPECIES_AGE)
 			);
@@ -1475,7 +1500,7 @@ public class YieldTable implements Closeable {
 
 		if (layerType != null
 				&& initialProcessingResult.map(r -> r instanceof FailedToGrowYoungStandException).orElse(false)) {
-			throw new StandYieldCalculationException(new FailedToGrowYoungStandException());
+			throw standYieldCalculationException(rowContext, new FailedToGrowYoungStandException());
 		}
 
 		LayerYields layerYields = null;
@@ -1556,7 +1581,9 @@ public class YieldTable implements Closeable {
 							stand.getSpeciesGroup().getSiteIndex(), stand.getSpeciesGroup().getYearsToBreastHeight()
 					);
 				} catch (CommonCalculatorException ex) {
-					throw new StandYieldCalculationException(ex);
+					throw new StandYieldCalculationException(
+							stand.getLayer().getPolygon().getFeatureId(), stand.getLayer().getLayerId(), ex
+					);
 				}
 			}
 
@@ -1746,7 +1773,10 @@ public class YieldTable implements Closeable {
 			calendarYear = layer.determineYearAtAge(ageToUse);
 		}
 		if (calendarYear == null || calendarYear < 0) {
-			throw new StandYieldCalculationException(StandYieldMessageKind.YEAR_OUT_OF_RANGE, calendarYear);
+			throw new StandYieldCalculationException(
+					layer.getPolygon().getFeatureId(), layer.getLayerId(), StandYieldMessageKind.YEAR_OUT_OF_RANGE,
+					calendarYear
+			);
 		}
 
 		return calendarYear;

--- a/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/output/yieldtable/YieldTable.java
+++ b/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/output/yieldtable/YieldTable.java
@@ -94,7 +94,7 @@ public class YieldTable implements Closeable {
 		return new YieldTable(context, outputFormat);
 	}
 
-	private static StandYieldCalculationException standYieldCalculationException(
+	static StandYieldCalculationException standYieldCalculationException(
 			YieldTableRowContext rowContext, StandYieldMessageKind template, Object... args
 	) {
 		long featureId = rowContext.getPolygon().getFeatureId();
@@ -106,7 +106,7 @@ public class YieldTable implements Closeable {
 		);
 	}
 
-	private static StandYieldCalculationException
+	static StandYieldCalculationException
 			standYieldCalculationException(YieldTableRowContext rowContext, Exception cause) {
 		long featureId = rowContext.getPolygon().getFeatureId();
 		if (rowContext.isPolygonTable()) {

--- a/lib/vdyp-extended-core/src/test/java/ca/bc/gov/nrs/vdyp/ecore/api/v1/exceptions/ExceptionsTest.java
+++ b/lib/vdyp-extended-core/src/test/java/ca/bc/gov/nrs/vdyp/ecore/api/v1/exceptions/ExceptionsTest.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 
 import org.junit.jupiter.api.Test;
 
+import ca.bc.gov.nrs.vdyp.ecore.model.v1.StandYieldMessageKind;
 import ca.bc.gov.nrs.vdyp.ecore.model.v1.ValidationMessage;
 import ca.bc.gov.nrs.vdyp.ecore.model.v1.ValidationMessageKind;
 
@@ -40,6 +41,25 @@ public class ExceptionsTest {
 		var e6_1 = new PolygonValidationException(validationMessage);
 		var e6 = new PolygonExecutionException("during execution", e6_1);
 		assertEquals("during execution: a validation failure", e6.getMessage());
+
+		var e7 = new PolygonExecutionException(123L, "validation error");
+		assertEquals("Polygon 123: validation error", e7.getMessage());
+
+		var e8 = new PolygonExecutionException(123L, "validation error", new IllegalStateException("illegal"));
+		assertEquals("Polygon 123: validation error", e8.getMessage());
+		assertEquals("illegal", e8.getCause().getMessage());
+
+		var e9 = new PolygonExecutionException(123L, new IllegalStateException("illegal"));
+		assertEquals("Polygon 123: illegal", e9.getMessage());
+	}
+
+	@Test
+	void PolygonValidationExceptionTest() {
+
+		var e1 = new PolygonValidationException(
+				456L, new ValidationMessage(ValidationMessageKind.GENERIC, "a failure")
+		);
+		assertEquals("Polygon 456: a failure", e1.getMessage());
 	}
 
 	@Test
@@ -49,6 +69,9 @@ public class ExceptionsTest {
 		validationMessages.add(new ValidationMessage(ValidationMessageKind.GENERIC, "validation failure"));
 		var e1_1 = new LayerValidationException(validationMessages);
 		assertEquals("validation failure", e1_1.getMessage());
+
+		var e2 = new LayerValidationException(789L, "L1", validationMessages);
+		assertEquals("Polygon 789 Layer L1: validation failure", e2.getMessage());
 	}
 
 	@Test
@@ -66,6 +89,24 @@ public class ExceptionsTest {
 		var e1 = new StandYieldCalculationException(new Exception("calculation exception"));
 		assertEquals("Exception: calculation exception", e1.getMessage());
 		assertEquals("Exception", e1.getCause().getClass().getSimpleName());
+
+		var e2 = new StandYieldCalculationException(123L, new Exception("calculation exception"));
+		assertEquals("Polygon 123: Exception: calculation exception", e2.getMessage());
+
+		var e3 = new StandYieldCalculationException(123L, StandYieldMessageKind.AGE_OUT_OF_RANGE, 0, 100);
+		assertEquals("Polygon 123: stand total age is not in the range 0 to 100, inclusive", e3.getMessage());
+
+		var e4 = new StandYieldCalculationException(123L, "L1", new Exception("calculation exception"));
+		assertEquals("Polygon 123 Layer L1: Exception: calculation exception", e4.getMessage());
+
+		var e5 = new StandYieldCalculationException(123L, "L1", StandYieldMessageKind.AGE_OUT_OF_RANGE, 0, 100);
+		assertEquals("Polygon 123 Layer L1: stand total age is not in the range 0 to 100, inclusive", e5.getMessage());
+
+		var e6 = new StandYieldCalculationException(123L, "L1", "PL", StandYieldMessageKind.AGE_OUT_OF_RANGE, 0, 100);
+		assertEquals(
+				"Polygon 123 Layer L1 Species PL: stand total age is not in the range 0 to 100, inclusive",
+				e6.getMessage()
+		);
 	}
 
 	@Test
@@ -78,6 +119,16 @@ public class ExceptionsTest {
 		var e2 = new YieldTableGenerationException("another message");
 		assertEquals("another message", e2.getMessage());
 		assertEquals(null, e2.getCause());
+
+		var e3 = new YieldTableGenerationException(123L, "message");
+		assertEquals("Polygon 123: message", e3.getMessage());
+
+		var e4 = new YieldTableGenerationException(123L, "message", new Exception("cause"));
+		assertEquals("Polygon 123: message", e4.getMessage());
+		assertEquals("Exception", e4.getCause().getClass().getSimpleName());
+
+		var e5 = new YieldTableGenerationException(123L, new Exception("cause"));
+		assertEquals("Polygon 123: cause", e5.getMessage());
 	}
 
 	@Test

--- a/lib/vdyp-extended-core/src/test/java/ca/bc/gov/nrs/vdyp/ecore/projection/BackControlFileRewriteTest.java
+++ b/lib/vdyp-extended-core/src/test/java/ca/bc/gov/nrs/vdyp/ecore/projection/BackControlFileRewriteTest.java
@@ -33,8 +33,9 @@ class BackControlFileRewriteTest {
 							.getBytes()
 			);
 
-			PolygonProjectionRunner
-					.rewriteTargetYearToBackControlFile(executionFolder, 1970, 100, ProjectionTypeCode.PRIMARY);
+			PolygonProjectionRunner.rewriteTargetYearToBackControlFile(
+					123456L, executionFolder, 1970, 100, ProjectionTypeCode.PRIMARY
+			);
 
 			String contents = Files.readString(controlFile);
 

--- a/lib/vdyp-extended-core/src/test/java/ca/bc/gov/nrs/vdyp/ecore/projection/PolygonProjectionRunnerTest.java
+++ b/lib/vdyp-extended-core/src/test/java/ca/bc/gov/nrs/vdyp/ecore/projection/PolygonProjectionRunnerTest.java
@@ -12,8 +12,11 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -133,6 +136,35 @@ public class PolygonProjectionRunnerTest {
 
 		assertThrows(PolygonExecutionException.class, unit::project);
 
+	}
+
+	@Test
+	void testBuildPolygonProjectionExecutionStructureFailsWhenDirectoryAlreadyExists()
+			throws IOException, AbstractProjectionRequestException {
+
+		var context = new ProjectionContext(ProjectionRequestKind.HCSV, "TEST", params, false);
+		var componentRunner = new RealComponentRunner();
+		var unit = PolygonProjectionRunner.of(polygon, context, componentRunner);
+
+		Files.createDirectory(Path.of(context.getExecutionFolder().toString(), polygon.toString()));
+
+		var ex = assertThrows(PolygonExecutionException.class, unit::buildPolygonProjectionExecutionStructure);
+		assertTrue(ex.getMessage().startsWith("Polygon " + polygon.getFeatureId()));
+	}
+
+	@Test
+	void testRewriteTargetYearToBackControlFileFailsWhenControlFileMissing() throws IOException {
+
+		var executionFolder = Files.createTempDirectory("back-control-file-test");
+		Files.createDirectory(Path.of(executionFolder.toString(), ProjectionTypeCode.PRIMARY.toString()));
+
+		var ex = assertThrows(
+				PolygonExecutionException.class,
+				() -> PolygonProjectionRunner.rewriteTargetYearToBackControlFile(
+						13919428L, executionFolder, 1970, 100, ProjectionTypeCode.PRIMARY
+				)
+		);
+		assertTrue(ex.getMessage().startsWith("Polygon 13919428"));
 	}
 
 	@Test

--- a/lib/vdyp-extended-core/src/test/java/ca/bc/gov/nrs/vdyp/ecore/projection/PolygonProjectionRunnerTest.java
+++ b/lib/vdyp-extended-core/src/test/java/ca/bc/gov/nrs/vdyp/ecore/projection/PolygonProjectionRunnerTest.java
@@ -15,9 +15,11 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 
@@ -149,6 +151,33 @@ public class PolygonProjectionRunnerTest {
 		Files.createDirectory(Path.of(context.getExecutionFolder().toString(), polygon.toString()));
 
 		var ex = assertThrows(PolygonExecutionException.class, unit::buildPolygonProjectionExecutionStructure);
+		assertTrue(ex.getMessage().startsWith("Polygon " + polygon.getFeatureId()));
+	}
+
+	@Test
+	void testCreateFipInputDataFailsWhenExecutionFolderMissing() throws Exception {
+
+		addStand("PL", 78.0, 8.0, 10.0);
+		var context = new ProjectionContext(ProjectionRequestKind.HCSV, "TEST", params, false);
+		layer.setAssignedProjectionType(ProjectionTypeCode.PRIMARY);
+		polygon.doCompleteDefinition(context);
+		var componentRunner = new RealComponentRunner();
+		var unit = PolygonProjectionRunner.of(polygon, context, componentRunner);
+
+		unit.buildPolygonProjectionExecutionStructure();
+
+		var polygonExecutionFolder = Path.of(context.getExecutionFolder().toString(), polygon.toString());
+		try (var paths = Files.walk(polygonExecutionFolder)) {
+			paths.sorted(Comparator.reverseOrder()).forEach(path -> {
+				try {
+					Files.delete(path);
+				} catch (IOException e) {
+					throw new UncheckedIOException(e);
+				}
+			});
+		}
+
+		var ex = assertThrows(PolygonExecutionException.class, unit::performInitialProcessing);
 		assertTrue(ex.getMessage().startsWith("Polygon " + polygon.getFeatureId()));
 	}
 

--- a/lib/vdyp-extended-core/src/test/java/ca/bc/gov/nrs/vdyp/ecore/projection/RealComponentRunnerTest.java
+++ b/lib/vdyp-extended-core/src/test/java/ca/bc/gov/nrs/vdyp/ecore/projection/RealComponentRunnerTest.java
@@ -1,0 +1,67 @@
+package ca.bc.gov.nrs.vdyp.ecore.projection;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import ca.bc.gov.nrs.vdyp.ecore.api.v1.exceptions.PolygonExecutionException;
+import ca.bc.gov.nrs.vdyp.ecore.api.v1.exceptions.YieldTableGenerationException;
+import ca.bc.gov.nrs.vdyp.ecore.model.v1.Parameters;
+import ca.bc.gov.nrs.vdyp.ecore.model.v1.ProjectionRequestKind;
+import ca.bc.gov.nrs.vdyp.ecore.projection.model.Polygon;
+import ca.bc.gov.nrs.vdyp.ecore.projection.model.enumerations.ProjectionTypeCode;
+
+class RealComponentRunnerTest {
+
+	private final RealComponentRunner unit = new RealComponentRunner();
+
+	@Test
+	void testRunAdjustFailsWhenInputFilesAreMissing() throws Exception {
+
+		var polygon = new Polygon.Builder().featureId(13919428).build();
+		var state = new PolygonProjectionState();
+		state.setExecutionFolder(Files.createTempDirectory("real-component-runner-test"));
+
+		var ex = assertThrows(
+				PolygonExecutionException.class, () -> unit.runAdjust(polygon, ProjectionTypeCode.PRIMARY, state)
+		);
+		assertTrue(ex.getMessage().startsWith("Polygon 13919428"));
+	}
+
+	@Test
+	void testRunBackFailsWhenExecutionFolderNotSet() {
+
+		var polygon = new Polygon.Builder().featureId(13919428).build();
+		var state = new PolygonProjectionState();
+
+		var ex = assertThrows(
+				PolygonExecutionException.class, () -> unit.runBack(polygon, ProjectionTypeCode.PRIMARY, state)
+		);
+		assertTrue(ex.getMessage().startsWith("Polygon 13919428"));
+	}
+
+	@Test
+	void testGenerateYieldTablesFailsWhenForwardControlFileIsMissing() throws Exception {
+
+		var polygon = new Polygon.Builder().featureId(13919428).build();
+
+		var params = new Parameters().ageStart(0).ageEnd(100)
+				.addSelectedExecutionOptionsItem(Parameters.ExecutionOption.DO_SUMMARIZE_PROJECTION_BY_POLYGON)
+				.addSelectedExecutionOptionsItem(Parameters.ExecutionOption.DO_INCLUDE_PROJECTED_MOF_VOLUMES);
+		var context = new ProjectionContext(ProjectionRequestKind.HCSV, "TEST", params, false);
+		context.createYieldTables();
+
+		var state = new PolygonProjectionState();
+		state.setExecutionFolder(context.getExecutionFolder());
+		state.setProcessingResults(ProjectionStageCode.Forward, ProjectionTypeCode.PRIMARY, Optional.empty());
+
+		var ex = assertThrows(
+				YieldTableGenerationException.class, () -> unit.generateYieldTables(context, polygon, state)
+		);
+		assertTrue(ex.getMessage().startsWith("Polygon 13919428"));
+	}
+}

--- a/lib/vdyp-extended-core/src/test/java/ca/bc/gov/nrs/vdyp/ecore/projection/input/HcsvPolygonStreamTest.java
+++ b/lib/vdyp-extended-core/src/test/java/ca/bc/gov/nrs/vdyp/ecore/projection/input/HcsvPolygonStreamTest.java
@@ -20,6 +20,8 @@ import ca.bc.gov.nrs.vdyp.ecore.api.v1.exceptions.AbstractProjectionRequestExcep
 import ca.bc.gov.nrs.vdyp.ecore.api.v1.exceptions.PolygonValidationException;
 import ca.bc.gov.nrs.vdyp.ecore.model.v1.Parameters;
 import ca.bc.gov.nrs.vdyp.ecore.model.v1.ProjectionRequestKind;
+import ca.bc.gov.nrs.vdyp.ecore.model.v1.ValidationMessage;
+import ca.bc.gov.nrs.vdyp.ecore.model.v1.ValidationMessageKind;
 import ca.bc.gov.nrs.vdyp.ecore.projection.ProjectionContext;
 import ca.bc.gov.nrs.vdyp.ecore.projection.model.Polygon;
 import ca.bc.gov.nrs.vdyp.ecore.projection.model.enumerations.InventoryStandard;
@@ -82,6 +84,20 @@ class HcsvPolygonStreamTest {
 
 		assertThat(poly.getMessages().size(), is(1));
 		assertThat(poly.getMessages().get(0).toString().contains("stockability"), is(true));
+	}
+
+	@Test
+	void testToPolygonValidationExceptionIncludesFeatureIdWhenKnown() {
+		var message = new ValidationMessage(ValidationMessageKind.GENERIC, "boom");
+		var ex = HcsvPolygonStream.toPolygonValidationException(13919428L, message);
+		assertThat(ex.getMessage(), is("Polygon 13919428: boom"));
+	}
+
+	@Test
+	void testToPolygonValidationExceptionOmitsFeatureIdWhenUnknown() {
+		var message = new ValidationMessage(ValidationMessageKind.GENERIC, "boom");
+		var ex = HcsvPolygonStream.toPolygonValidationException(null, message);
+		assertThat(ex.getMessage(), is("boom"));
 	}
 
 	@Nested

--- a/lib/vdyp-extended-core/src/test/java/ca/bc/gov/nrs/vdyp/ecore/projection/input/HcsvPolygonStreamTest.java
+++ b/lib/vdyp-extended-core/src/test/java/ca/bc/gov/nrs/vdyp/ecore/projection/input/HcsvPolygonStreamTest.java
@@ -96,8 +96,21 @@ class HcsvPolygonStreamTest {
 	@Test
 	void testToPolygonValidationExceptionOmitsFeatureIdWhenUnknown() {
 		var message = new ValidationMessage(ValidationMessageKind.GENERIC, "boom");
-		var ex = HcsvPolygonStream.toPolygonValidationException(null, message);
+		var ex = HcsvPolygonStream.toPolygonValidationException((Long) null, message);
 		assertThat(ex.getMessage(), is("boom"));
+	}
+
+	@Test
+	void testToPolygonValidationExceptionFromRecordBeanIncludesFeatureId() {
+		var records = HcsvPolygonRecordBean
+				.createHcsvPolygonStream(new ByteArrayInputStream(hcsvPolygonFileContents.getBytes())).parse();
+		var message = new ValidationMessage(ValidationMessageKind.GENERIC, "boom");
+
+		var ex = HcsvPolygonStream.toPolygonValidationException(records.get(0), message);
+		assertThat(ex.getMessage(), is("Polygon 13919428: boom"));
+
+		var ex2 = HcsvPolygonStream.toPolygonValidationException((HcsvPolygonRecordBean) null, message);
+		assertThat(ex2.getMessage(), is("boom"));
 	}
 
 	@Nested

--- a/lib/vdyp-extended-core/src/test/java/ca/bc/gov/nrs/vdyp/ecore/projection/output/yieldtable/FullReportYieldTableWriterTest.java
+++ b/lib/vdyp-extended-core/src/test/java/ca/bc/gov/nrs/vdyp/ecore/projection/output/yieldtable/FullReportYieldTableWriterTest.java
@@ -1,7 +1,11 @@
 package ca.bc.gov.nrs.vdyp.ecore.projection.output.yieldtable;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
 
 import org.junit.jupiter.api.Test;
 
@@ -28,5 +32,23 @@ class FullReportYieldTableWriterTest {
 
 		var ex = assertThrows(YieldTableGenerationException.class, () -> writer.writeRecord(rowContext));
 		assertTrue(ex.getMessage().startsWith("Polygon 13919428"));
+	}
+
+	@Test
+	void testToYieldTableGenerationExceptionIncludesFeatureIdWhenPolygonKnown() {
+
+		var polygon = new Polygon.Builder().featureId(13919428).build();
+
+		var ex = FullReportYieldTableWriter.toYieldTableGenerationException(polygon, new IOException("boom"));
+
+		assertThat(ex.getMessage(), is("Polygon 13919428: boom"));
+	}
+
+	@Test
+	void testToYieldTableGenerationExceptionOmitsFeatureIdWhenPolygonUnknown() {
+
+		var ex = FullReportYieldTableWriter.toYieldTableGenerationException(null, new IOException("boom"));
+
+		assertThat(ex.getMessage(), is("java.io.IOException: boom"));
 	}
 }

--- a/lib/vdyp-extended-core/src/test/java/ca/bc/gov/nrs/vdyp/ecore/projection/output/yieldtable/FullReportYieldTableWriterTest.java
+++ b/lib/vdyp-extended-core/src/test/java/ca/bc/gov/nrs/vdyp/ecore/projection/output/yieldtable/FullReportYieldTableWriterTest.java
@@ -1,0 +1,32 @@
+package ca.bc.gov.nrs.vdyp.ecore.projection.output.yieldtable;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import ca.bc.gov.nrs.vdyp.ecore.api.v1.exceptions.YieldTableGenerationException;
+import ca.bc.gov.nrs.vdyp.ecore.model.v1.Parameters;
+import ca.bc.gov.nrs.vdyp.ecore.model.v1.ProjectionRequestKind;
+import ca.bc.gov.nrs.vdyp.ecore.projection.PolygonProjectionState;
+import ca.bc.gov.nrs.vdyp.ecore.projection.ProjectionContext;
+import ca.bc.gov.nrs.vdyp.ecore.projection.model.Polygon;
+
+class FullReportYieldTableWriterTest {
+
+	@Test
+	void testWriteRecordFailsWhenRowContextIsIncomplete() throws Exception {
+
+		var polygon = new Polygon.Builder().featureId(13919428).build();
+		var params = new Parameters().outputFormat(Parameters.OutputFormat.YIELD_TABLE).ageStart(0).ageEnd(100);
+		var context = new ProjectionContext(ProjectionRequestKind.HCSV, "TEST", params, false);
+
+		var writer = FullReportYieldTableWriter.of(context);
+		var rowContext = YieldTableRowContext.of(context, polygon, new PolygonProjectionState(), null);
+
+		writer.startNewRecord();
+
+		var ex = assertThrows(YieldTableGenerationException.class, () -> writer.writeRecord(rowContext));
+		assertTrue(ex.getMessage().startsWith("Polygon 13919428"));
+	}
+}

--- a/lib/vdyp-extended-core/src/test/java/ca/bc/gov/nrs/vdyp/ecore/projection/output/yieldtable/RealProjectionResultsReaderTest.java
+++ b/lib/vdyp-extended-core/src/test/java/ca/bc/gov/nrs/vdyp/ecore/projection/output/yieldtable/RealProjectionResultsReaderTest.java
@@ -1,0 +1,67 @@
+package ca.bc.gov.nrs.vdyp.ecore.projection.output.yieldtable;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import java.util.HashMap;
+
+import org.junit.jupiter.api.Test;
+
+import ca.bc.gov.nrs.api.helpers.TestHelper;
+import ca.bc.gov.nrs.vdyp.common.ControlKey;
+import ca.bc.gov.nrs.vdyp.ecore.api.v1.exceptions.YieldTableGenerationException;
+import ca.bc.gov.nrs.vdyp.ecore.projection.model.Polygon;
+import ca.bc.gov.nrs.vdyp.ecore.utils.FileHelper;
+import ca.bc.gov.nrs.vdyp.test.TestUtils;
+
+class RealProjectionResultsReaderTest {
+
+	private static final Path relativeResourcePath = Path
+			.of(FileHelper.TEST_DATA_FILES, FileHelper.YIELD_TABLE_TEST_DATA, "1");
+
+	@Test
+	void testReadFailsWhenOutputFilesAreMissing() {
+
+		var controlMap = new HashMap<String, Object>();
+		controlMap.put(ControlKey.VDYP_OUTPUT_VDYP_POLYGON.name(), "does-not-exist.dat");
+		controlMap.put(ControlKey.VDYP_OUTPUT_VDYP_LAYER_BY_SPECIES.name(), "does-not-exist.dat");
+		controlMap.put(ControlKey.VDYP_OUTPUT_VDYP_LAYER_BY_SP0_BY_UTIL.name(), "does-not-exist.dat");
+
+		var polygon = new Polygon.Builder().featureId(13919428).mapSheet("093C090").polygonNumber(94833422L).build();
+
+		var unit = new RealProjectionResultsReader(controlMap);
+
+		var ex = assertThrows(YieldTableGenerationException.class, () -> unit.read(polygon));
+		assertTrue(ex.getMessage().startsWith("Polygon 13919428"));
+	}
+
+	@Test
+	void testReadFailsWhenExpectedPolygonDoesNotMatchOutput() {
+
+		var testHelper = new TestHelper();
+
+		var controlMap = new HashMap<String, Object>();
+		controlMap.put(
+				ControlKey.VDYP_OUTPUT_VDYP_POLYGON.name(),
+				testHelper.getResourceFile(relativeResourcePath, "vp_grow.dat").toString()
+		);
+		controlMap.put(
+				ControlKey.VDYP_OUTPUT_VDYP_LAYER_BY_SPECIES.name(),
+				testHelper.getResourceFile(relativeResourcePath, "vs_grow.dat").toString()
+		);
+		controlMap.put(
+				ControlKey.VDYP_OUTPUT_VDYP_LAYER_BY_SP0_BY_UTIL.name(),
+				testHelper.getResourceFile(relativeResourcePath, "vu_grow.dat").toString()
+		);
+		TestUtils.populateControlMapBecReal(controlMap);
+		TestUtils.populateControlMapGenusReal(controlMap);
+
+		var polygon = new Polygon.Builder().featureId(13919428).mapSheet("999999").polygonNumber(1L).build();
+
+		var unit = new RealProjectionResultsReader(controlMap);
+
+		var ex = assertThrows(YieldTableGenerationException.class, () -> unit.read(polygon));
+		assertTrue(ex.getMessage().startsWith("Polygon 13919428"));
+	}
+}

--- a/lib/vdyp-extended-core/src/test/java/ca/bc/gov/nrs/vdyp/ecore/projection/output/yieldtable/YieldTableTest.java
+++ b/lib/vdyp-extended-core/src/test/java/ca/bc/gov/nrs/vdyp/ecore/projection/output/yieldtable/YieldTableTest.java
@@ -16,6 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -36,6 +37,7 @@ import ca.bc.gov.nrs.vdyp.ecore.api.v1.exceptions.AbstractProjectionRequestExcep
 import ca.bc.gov.nrs.vdyp.ecore.api.v1.exceptions.StandYieldCalculationException;
 import ca.bc.gov.nrs.vdyp.ecore.model.v1.Parameters;
 import ca.bc.gov.nrs.vdyp.ecore.model.v1.ProjectionRequestKind;
+import ca.bc.gov.nrs.vdyp.ecore.model.v1.StandYieldMessageKind;
 import ca.bc.gov.nrs.vdyp.ecore.model.v1.UtilizationClassSet;
 import ca.bc.gov.nrs.vdyp.ecore.model.v1.UtilizationParameter;
 import ca.bc.gov.nrs.vdyp.ecore.projection.PolygonProjectionState;
@@ -43,6 +45,7 @@ import ca.bc.gov.nrs.vdyp.ecore.projection.ProjectionContext;
 import ca.bc.gov.nrs.vdyp.ecore.projection.ProjectionStageCode;
 import ca.bc.gov.nrs.vdyp.ecore.projection.input.HcsvPolygonStream;
 import ca.bc.gov.nrs.vdyp.ecore.projection.model.Layer;
+import ca.bc.gov.nrs.vdyp.ecore.projection.model.LayerReportingInfo;
 import ca.bc.gov.nrs.vdyp.ecore.projection.model.Polygon;
 import ca.bc.gov.nrs.vdyp.ecore.projection.model.Species;
 import ca.bc.gov.nrs.vdyp.ecore.projection.model.Stand;
@@ -110,6 +113,36 @@ class YieldTableTest {
 		assertThat(YieldTable.determineSpeciesProjectionFactor(unit, 0), closeTo(0.6, 0.00001));
 		assertThat(YieldTable.determineSpeciesProjectionFactor(unit, 1), closeTo(0.4, 0.00001));
 		assertThat(YieldTable.determineSpeciesProjectionFactor(unit, 2), closeTo(0.6, 0.00001));
+	}
+
+	@Test
+	void testStandYieldCalculationExceptionIncludesLayerForLayerTable() throws AbstractProjectionRequestException {
+
+		var parameters = new Parameters().ageStart(0).ageEnd(100);
+		var context = new ProjectionContext(ProjectionRequestKind.HCSV, TEST_PROJECTION_ID, parameters, false);
+		var polygon = new Polygon.Builder().featureId(13919428).referenceYear(2013).build();
+		var layer = new Layer.Builder().polygon(polygon).layerId("1").build();
+		var layerReportingInfo = new LayerReportingInfo.Builder().layer(layer).sourceLayerID(0).build();
+		layerReportingInfo.setSpeciesReportingInfos(new ArrayList<>());
+		var state = new PolygonProjectionState();
+
+		var layerRowContext = YieldTableRowContext.of(context, polygon, state, layerReportingInfo);
+		var polygonRowContext = YieldTableRowContext.of(context, polygon, state, null);
+
+		var templateEx = YieldTable
+				.standYieldCalculationException(layerRowContext, StandYieldMessageKind.YEAR_OUT_OF_RANGE, 5);
+		assertThat(templateEx.getMessage(), containsString("Polygon 13919428 Layer 1"));
+
+		var causeEx = YieldTable.standYieldCalculationException(layerRowContext, new IllegalStateException("boom"));
+		assertThat(causeEx.getMessage(), containsString("Polygon 13919428 Layer 1"));
+
+		var templateExPolygon = YieldTable
+				.standYieldCalculationException(polygonRowContext, StandYieldMessageKind.YEAR_OUT_OF_RANGE, 5);
+		assertThat(templateExPolygon.getMessage(), is("Polygon 13919428: calendar year must be at least zero"));
+
+		var causeExPolygon = YieldTable
+				.standYieldCalculationException(polygonRowContext, new IllegalStateException("boom"));
+		assertThat(causeExPolygon.getMessage(), containsString("Polygon 13919428"));
 	}
 
 	@Test

--- a/lib/vdyp-extended-core/src/test/java/ca/bc/gov/nrs/vdyp/ecore/projection/output/yieldtable/YieldTableTest.java
+++ b/lib/vdyp-extended-core/src/test/java/ca/bc/gov/nrs/vdyp/ecore/projection/output/yieldtable/YieldTableTest.java
@@ -125,8 +125,7 @@ class YieldTableTest {
 		var polygon = new Polygon.Builder().featureId(13919428).referenceYear(2013).build();
 		var rowContext = YieldTableRowContext.of(context, polygon, new PolygonProjectionState(), null);
 
-		var ex = AbstractCSVTypeYieldTableWriter
-				.toYieldTableGenerationException(rowContext, new CsvException("boom"));
+		var ex = AbstractCSVTypeYieldTableWriter.toYieldTableGenerationException(rowContext, new CsvException("boom"));
 
 		assertThat(ex.getMessage(), is("Polygon 13919428: boom"));
 	}

--- a/lib/vdyp-extended-core/src/test/java/ca/bc/gov/nrs/vdyp/ecore/projection/output/yieldtable/YieldTableTest.java
+++ b/lib/vdyp-extended-core/src/test/java/ca/bc/gov/nrs/vdyp/ecore/projection/output/yieldtable/YieldTableTest.java
@@ -30,6 +30,8 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.opencsv.exceptions.CsvException;
+
 import ca.bc.gov.nrs.api.helpers.ResultYieldTable;
 import ca.bc.gov.nrs.api.helpers.TestHelper;
 import ca.bc.gov.nrs.api.helpers.TestProjectionResultsReader;
@@ -113,6 +115,20 @@ class YieldTableTest {
 		assertThat(YieldTable.determineSpeciesProjectionFactor(unit, 0), closeTo(0.6, 0.00001));
 		assertThat(YieldTable.determineSpeciesProjectionFactor(unit, 1), closeTo(0.4, 0.00001));
 		assertThat(YieldTable.determineSpeciesProjectionFactor(unit, 2), closeTo(0.6, 0.00001));
+	}
+
+	@Test
+	void testToYieldTableGenerationExceptionIncludesFeatureId() throws AbstractProjectionRequestException {
+
+		var parameters = new Parameters().ageStart(0).ageEnd(100);
+		var context = new ProjectionContext(ProjectionRequestKind.HCSV, TEST_PROJECTION_ID, parameters, false);
+		var polygon = new Polygon.Builder().featureId(13919428).referenceYear(2013).build();
+		var rowContext = YieldTableRowContext.of(context, polygon, new PolygonProjectionState(), null);
+
+		var ex = AbstractCSVTypeYieldTableWriter
+				.toYieldTableGenerationException(rowContext, new CsvException("boom"));
+
+		assertThat(ex.getMessage(), is("Polygon 13919428: boom"));
 	}
 
 	@Test


### PR DESCRIPTION
- Add polygon feature ID (and layer/species where applicable) to the messages of PolygonExecutionException, PolygonValidationException, StandYieldCalculationException, LayerValidationException, and YieldTableGenerationException so that failures during polygon projection can be traced back to the specific polygon involved.