### PR TITLE
VDYP-1203: Restart inflight projections when batch restarts

### DIFF
--- a/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/configuration/BatchConfiguration.java
+++ b/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/configuration/BatchConfiguration.java
@@ -306,15 +306,22 @@ public class BatchConfiguration {
 			@Value("#{stepExecutionContext['partitionName']}") String partitionName,
 			@Value("#{stepExecution.jobExecutionId}") Long jobExecutionId,
 			@Value("#{jobParameters['" + BatchConstants.Job.GUID + "']}") String jobGuid,
+			@Value("#{jobParameters['" + BatchConstants.Chunk.SIZE + "']}") Long configuredChunkSize,
 			BatchProperties batchProperties
 	) {
+		int chunkSize = resolveChunkSize(configuredChunkSize, batchProperties);
 		logger.trace(
 				"[GUID: {}, Execution ID: {}, Partition: {}] Using BatchItemReader with chunk size: {}", jobGuid,
-				jobExecutionId, partitionName, batchProperties.getReader().getDefaultChunkSize()
+				jobExecutionId, partitionName, chunkSize
 		);
-		return new BatchItemReader(
-				partitionName, jobExecutionId, jobGuid, batchProperties.getReader().getDefaultChunkSize()
-		);
+		return new BatchItemReader(partitionName, jobExecutionId, jobGuid, chunkSize);
+	}
+
+	private int resolveChunkSize(Long configuredChunkSize, BatchProperties batchProperties) {
+		if (configuredChunkSize != null) {
+			return Math.max(configuredChunkSize.intValue(), 1);
+		}
+		return Math.max(batchProperties.getReader().getDefaultChunkSize(), 1);
 	}
 
 	@Bean

--- a/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/configuration/BatchConfiguration.java
+++ b/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/configuration/BatchConfiguration.java
@@ -110,6 +110,7 @@ public class BatchConfiguration {
 		int corePoolSize = batchProperties.getThreadPool().getCorePoolSize();
 		int maxPoolSizeMultiplier = batchProperties.getThreadPool().getMaxPoolSizeMultiplier();
 		String threadNamePrefix = batchProperties.getThreadPool().getThreadNamePrefix();
+		int awaitTerminationSeconds = batchProperties.getThreadPool().getAwaitTerminationSeconds();
 
 		ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
 		executor.setCorePoolSize(corePoolSize);
@@ -117,6 +118,8 @@ public class BatchConfiguration {
 		executor.setQueueCapacity(corePoolSize);
 		executor.setThreadNamePrefix(threadNamePrefix);
 		executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
+		executor.setWaitForTasksToCompleteOnShutdown(true);
+		executor.setAwaitTerminationSeconds(awaitTerminationSeconds);
 		executor.initialize();
 		return executor;
 	}

--- a/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/configuration/BatchItemReader.java
+++ b/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/configuration/BatchItemReader.java
@@ -1,5 +1,11 @@
 package ca.bc.gov.nrs.vdyp.batch.configuration;
 
+import static ca.bc.gov.nrs.vdyp.batch.util.BatchConstants.Chunk.CURRENT_CHUNK_NUMBER;
+import static ca.bc.gov.nrs.vdyp.batch.util.BatchConstants.Chunk.CURRENT_LAYER_CHUNK_OFFSET;
+import static ca.bc.gov.nrs.vdyp.batch.util.BatchConstants.Chunk.CURRENT_POLYGON_CHUNK_START_BYTE_OFFSET;
+import static ca.bc.gov.nrs.vdyp.batch.util.BatchConstants.Chunk.NUM_PROCESSED_POLYGON_RECORDS;
+import static ca.bc.gov.nrs.vdyp.batch.util.BatchConstants.Chunk.TOTAL_POLYGON_RECORDS;
+
 import java.io.BufferedReader;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -57,6 +63,9 @@ public class BatchItemReader implements ItemStreamReader<BatchChunkMetadata> {
 
 	// Number of processed polygon data records so far (excluding headers and blank lines)
 	private int numProcessedPolygonRecords = 0;
+
+	// The number of this chunk
+	private int currentChunkNumber = 0;
 
 	// Current read positions in the files (byte offset where chunk will be read from)
 	private long currentPolygonChunkStartByteOffset = 0;
@@ -144,7 +153,7 @@ public class BatchItemReader implements ItemStreamReader<BatchChunkMetadata> {
 
 		BatchChunkMetadata metadata = new BatchChunkMetadata(
 				partitionName, jobBaseDir, polygonChunkMetaData.getStartByte(), polygonChunkMetaData.getRecordCount(),
-				layerChunkMetadata.getStartByte(), layerChunkMetadata.getRecordCount()
+				layerChunkMetadata.getStartByte(), layerChunkMetadata.getRecordCount(), currentChunkNumber
 		);
 
 		logger.trace(
@@ -156,6 +165,7 @@ public class BatchItemReader implements ItemStreamReader<BatchChunkMetadata> {
 		);
 
 		// Update position for next read
+		currentChunkNumber++;
 		numProcessedPolygonRecords += polygonRecordsInThisChunk;
 		currentPolygonChunkStartByteOffset = polygonChunkMetaData.getEndByte();
 		currentLayerChunkStartByteOffset = layerChunkMetadata.getEndByte();
@@ -202,13 +212,17 @@ public class BatchItemReader implements ItemStreamReader<BatchChunkMetadata> {
 			this.polygonFilePath = partitionDir.resolve(BatchConstants.Partition.INPUT_POLYGON_FILE_NAME);
 			this.layerFilePath = partitionDir.resolve(BatchConstants.Partition.INPUT_LAYER_FILE_NAME);
 
-			this.totalPolygonDataRecords = countTotalDataRecords(this.polygonFilePath);
+			boolean restoredState = restorePersistedState(executionContext);
+			if (!restoredState) {
+				this.currentChunkNumber = 1;
+				this.totalPolygonDataRecords = countTotalDataRecords(this.polygonFilePath);
 
-			// Initialize the current read position as the byte offset of the first data record (skipping headers and
-			// blank lines)
-			this.currentPolygonChunkStartByteOffset = findFirstDataRecordByteOffset(this.polygonFilePath);
-			this.currentLayerChunkStartByteOffset = findFirstDataRecordByteOffset(this.layerFilePath);
-
+				// Initialize the current read position as the byte offset of the first data record (skipping headers
+				// and
+				// blank lines)
+				this.currentPolygonChunkStartByteOffset = findFirstDataRecordByteOffset(this.polygonFilePath);
+				this.currentLayerChunkStartByteOffset = findFirstDataRecordByteOffset(this.layerFilePath);
+			}
 			readerOpened = true;
 			logger.trace(
 					"[GUID: {}, EXEID: {}, Partition: {}] BatchItemReader opened successfully. Total polygon records: {}, First polygon byte: {}, First layer byte: {}",
@@ -224,9 +238,35 @@ public class BatchItemReader implements ItemStreamReader<BatchChunkMetadata> {
 		}
 	}
 
+	private boolean restorePersistedState(ExecutionContext executionContext) {
+		boolean hasRestoreState = executionContext.containsKey(CURRENT_CHUNK_NUMBER);
+		boolean restoredState = false;
+
+		if (hasRestoreState) {
+			this.currentChunkNumber = executionContext.getInt(CURRENT_CHUNK_NUMBER);
+			this.totalPolygonDataRecords = executionContext.getInt(TOTAL_POLYGON_RECORDS);
+			this.numProcessedPolygonRecords = executionContext.getInt(NUM_PROCESSED_POLYGON_RECORDS);
+			this.currentPolygonChunkStartByteOffset = executionContext.getLong(CURRENT_POLYGON_CHUNK_START_BYTE_OFFSET);
+			this.currentLayerChunkStartByteOffset = executionContext.getLong(CURRENT_LAYER_CHUNK_OFFSET);
+			restoredState = true;
+			logger.info(
+					"[GUID: {}, EXEID: {}, Partition: {}] Restored persisted state from ExecutionContext: currentChunkNumber={}, totalPolygonRecords={}, numProcessedPolygonRecords={}, currentPolygonChunkStartByteOffset={}, currentLayerChunkStartByteOffset={}",
+					jobGuid, jobExecutionId, partitionName, currentChunkNumber, totalPolygonDataRecords,
+					numProcessedPolygonRecords, currentPolygonChunkStartByteOffset, currentLayerChunkStartByteOffset
+			);
+		}
+
+		return restoredState;
+	}
+
 	@Override
 	public void update(@NonNull ExecutionContext executionContext) {
-		// No state to persist
+		// Persist current chunk details so we can resume without starting form the beginning
+		executionContext.putInt(CURRENT_CHUNK_NUMBER, this.currentChunkNumber);
+		executionContext.putInt(TOTAL_POLYGON_RECORDS, this.totalPolygonDataRecords);
+		executionContext.putInt(NUM_PROCESSED_POLYGON_RECORDS, this.numProcessedPolygonRecords);
+		executionContext.putLong(CURRENT_POLYGON_CHUNK_START_BYTE_OFFSET, this.currentPolygonChunkStartByteOffset);
+		executionContext.putLong(CURRENT_LAYER_CHUNK_OFFSET, this.currentLayerChunkStartByteOffset);
 	}
 
 	@Override

--- a/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/configuration/BatchProperties.java
+++ b/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/configuration/BatchProperties.java
@@ -151,6 +151,7 @@ public class BatchProperties {
 		private int maxPoolSizeMultiplier;
 		private String threadNamePrefix;
 		private int maxJobThreads;
+		private int awaitTerminationSeconds;
 
 		public int getCorePoolSize() {
 			return corePoolSize;
@@ -182,6 +183,14 @@ public class BatchProperties {
 
 		public void setMaxJobThreads(int maxJobThreads) {
 			this.maxJobThreads = maxJobThreads;
+		}
+
+		public int getAwaitTerminationSeconds() {
+			return awaitTerminationSeconds;
+		}
+
+		public void setAwaitTerminationSeconds(int awaitTerminationSeconds) {
+			this.awaitTerminationSeconds = awaitTerminationSeconds;
 		}
 
 	}

--- a/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/controller/BatchController.java
+++ b/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/controller/BatchController.java
@@ -64,6 +64,9 @@ public class BatchController {
 	@Value("${batch.partition.job-search-chunk-size}")
 	private int jobSearchChunkSize;
 
+	@Value("${batch.reader.default-chunk-size}")
+	private Integer defaultChunkSize;
+
 	public BatchController(
 			@Qualifier("asyncJobLauncher") JobLauncher jobLauncher,
 			@Qualifier("fetchAndPartitionJob") Job fetchAndPartitionJob, JobExplorer jobExplorer,
@@ -333,7 +336,7 @@ public class BatchController {
 			// Pass defaultNumPartitions as a safe fallback in case the tasklet cannot determine the count.
 			JobParameters jobParameters = buildJobParameters(
 					projectionParametersJson, defaultNumPartitions, jobGuid, jobTimestamp, jobBaseDir.toString(),
-					projectionGuid
+					projectionGuid, defaultChunkSize
 			);
 			JobExecution jobExecution = jobLauncher.run(fetchAndPartitionJob, jobParameters);
 
@@ -390,14 +393,15 @@ public class BatchController {
 	/** Builds job parameters for GUID-based flow (files fetched from COMS by DownloadAndPartitionTasklet). */
 	private JobParameters buildJobParameters(
 			String projectionParametersJson, Integer numPartitions, String jobGuid, String jobTimestamp,
-			String jobBaseDir, UUID projectionGUID
+			String jobBaseDir, UUID projectionGUID, Integer chunkSize
 	) {
 		return new JobParametersBuilder().addString(BatchConstants.Job.GUID, jobGuid)
 				.addString(BatchConstants.Projection.PARAMETERS_JSON, projectionParametersJson)
 				.addString(BatchConstants.Job.TIMESTAMP, jobTimestamp)
 				.addString(BatchConstants.Job.BASE_DIR, jobBaseDir)
 				.addString(BatchConstants.GuidInput.PROJECTION_GUID, projectionGUID.toString())
-				.addLong(BatchConstants.Partition.NUMBER, numPartitions.longValue()).toJobParameters();
+				.addLong(BatchConstants.Partition.NUMBER, numPartitions.longValue())
+				.addLong(BatchConstants.Chunk.SIZE, chunkSize.longValue(), false).toJobParameters();
 	}
 
 	private void buildSuccessResponse(Map<String, Object> response, JobExecution jobExecution) {

--- a/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/messaging/consumer/BatchRequestConsumer.java
+++ b/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/messaging/consumer/BatchRequestConsumer.java
@@ -192,4 +192,9 @@ public class BatchRequestConsumer implements SmartLifecycle {
 	public boolean isRunning() {
 		return running.get();
 	}
+
+	@Override
+	public int getPhase() {
+		return 0;
+	}
 }

--- a/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/messaging/consumer/BatchRequestConsumer.java
+++ b/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/messaging/consumer/BatchRequestConsumer.java
@@ -158,6 +158,7 @@ public class BatchRequestConsumer implements SmartLifecycle {
 		String jobGuid = BatchUtils.createJobGuid();
 		String jobTimestamp = BatchUtils.createJobTimestamp();
 		Integer numPartitions = batchProperties.getPartition().getDefaultNumberOfPartitions();
+		Integer chunkSize = batchProperties.getReader().getDefaultChunkSize();
 		Path jobBaseDir = createJobBaseDirectory(jobGuid);
 
 		JobParameters parameters = new JobParametersBuilder().addString(BatchConstants.Job.GUID, jobGuid)
@@ -165,7 +166,8 @@ public class BatchRequestConsumer implements SmartLifecycle {
 				.addString(BatchConstants.Job.TIMESTAMP, jobTimestamp)
 				.addString(BatchConstants.Job.BASE_DIR, jobBaseDir.toString())
 				.addString(BatchConstants.GuidInput.PROJECTION_GUID, request.projectionID().toString())
-				.addLong(BatchConstants.Partition.NUMBER, numPartitions.longValue()).toJobParameters();
+				.addLong(BatchConstants.Partition.NUMBER, numPartitions.longValue())
+				.addLong(BatchConstants.Chunk.SIZE, chunkSize.longValue(), false).toJobParameters();
 
 		logger.info("[GUID: {}] Launching NATS batch request for projection {}", jobGuid, request.projectionID());
 		jobLauncher.run(vdypBatchJob, parameters);

--- a/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/model/BatchChunkMetadata.java
+++ b/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/model/BatchChunkMetadata.java
@@ -15,6 +15,8 @@ public class BatchChunkMetadata {
 	@NonNull
 	private final String jobBaseDir;
 
+	private final int currentChunkNumber;
+
 	// Polygon file metadata
 	private final long polygonStartByte; // Start byte offset of polygon data records in this chunk
 	private final int polygonRecordCount; // Number of polygon data records in this chunk
@@ -28,7 +30,7 @@ public class BatchChunkMetadata {
 
 	public BatchChunkMetadata(
 			@NonNull String partitionName, @NonNull String jobBaseDir, long polygonStartByte, int polygonRecordCount,
-			long layerStartByte, int layerRecordCount
+			long layerStartByte, int layerRecordCount, int currentChunkNumber
 	) {
 		this.partitionName = partitionName;
 		this.jobBaseDir = jobBaseDir;
@@ -36,6 +38,7 @@ public class BatchChunkMetadata {
 		this.polygonRecordCount = polygonRecordCount;
 		this.layerStartByte = layerStartByte;
 		this.layerRecordCount = layerRecordCount;
+		this.currentChunkNumber = currentChunkNumber;
 	}
 
 	@NonNull
@@ -46,6 +49,10 @@ public class BatchChunkMetadata {
 	@NonNull
 	public String getJobBaseDir() {
 		return jobBaseDir;
+	}
+
+	public int getCurrentChunkNumber() {
+		return currentChunkNumber;
 	}
 
 	public long getPolygonStartByte() {
@@ -68,7 +75,8 @@ public class BatchChunkMetadata {
 	public String toString() {
 		return "ChunkMetadata{" + "partitionName='" + partitionName + '\'' + ", jobBaseDir='" + jobBaseDir + '\''
 				+ ", polygonStartByte=" + polygonStartByte + ", polygonRecordCount=" + polygonRecordCount
-				+ ", layerStartByte=" + layerStartByte + ", layerRecordCount=" + layerRecordCount + '}';
+				+ ", layerStartByte=" + layerStartByte + ", layerRecordCount=" + layerRecordCount
+				+ ", currentChunkNumber=" + currentChunkNumber + '}';
 	}
 
 	public void setErrorCount(int errorLogCount) {

--- a/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/service/BatchProjectionService.java
+++ b/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/service/BatchProjectionService.java
@@ -59,6 +59,7 @@ public class BatchProjectionService {
 
 		String partitionName = chunkMetadata.getPartitionName();
 		String jobBaseDir = chunkMetadata.getJobBaseDir();
+		int chunkNumber = chunkMetadata.getCurrentChunkNumber();
 		long polygonStartByte = chunkMetadata.getPolygonStartByte();
 		int polygonRecordCount = chunkMetadata.getPolygonRecordCount();
 
@@ -74,25 +75,24 @@ public class BatchProjectionService {
 			// Create input streams directly from partition files
 			inputStreams = createInputStreamsFromChunkMetadata(chunkMetadata);
 
-			String batchProjectionId = BatchUtils
-					.buildBatchProjectionId(jobExecutionId, partitionName, ProjectionRequestKind.HCSV);
+			String chunkFilePrefix = BatchUtils.batchChunkFilenamePrefix(chunkNumber);
 
 			try (
 					ProjectionRunner runner = new ProjectionRunner(
-							ProjectionRequestKind.HCSV, batchProjectionId, projectionParameters, false
+							ProjectionRequestKind.HCSV, chunkFilePrefix, projectionParameters, false
 					)
 			) {
 
 				logger.debug(
 						"[GUID: {}, EXEID: {}] Running HCSV projection {} for chunk of {} records in partition {}",
-						jobGuid, jobExecutionId, batchProjectionId, polygonRecordCount, partitionName
+						jobGuid, jobExecutionId, chunkFilePrefix, polygonRecordCount, partitionName
 				);
 
 				// Run the projection on the streamed data
 				runner.run(inputStreams);
 
 				// Store intermediate results
-				storeChunkIntermediateResults(runner, outputPartitionDir, batchProjectionId, polygonRecordCount);
+				storeChunkIntermediateResults(runner, outputPartitionDir, chunkFilePrefix, polygonRecordCount);
 
 				updateChunkMetaDataFromRunner(runner, chunkMetadata);
 
@@ -350,17 +350,17 @@ public class BatchProjectionService {
 	 * @throws IOException if result storage fails
 	 */
 	private void storeChunkIntermediateResults(
-			ProjectionRunner runner, Path partitionOutputDir, String projectionId, int recordCount
+			ProjectionRunner runner, Path partitionOutputDir, String filePrefix, int recordCount
 	) throws IOException {
 
-		logger.debug("Storing intermediate results for chunk projection {} ({} records)", projectionId, recordCount);
+		logger.debug("Storing intermediate results for chunk projection {} ({} records)", filePrefix, recordCount);
 
-		storeChunkYieldTables(runner, partitionOutputDir, projectionId, recordCount);
+		storeChunkYieldTables(runner, partitionOutputDir, filePrefix, recordCount);
 
-		storeChunkLogs(runner, partitionOutputDir, projectionId, recordCount);
+		storeChunkLogs(runner, partitionOutputDir, filePrefix, recordCount);
 
 		logger.debug(
-				"Successfully stored intermediate results for chunk projection {} ({} records) in {}", projectionId,
+				"Successfully stored intermediate results for chunk projection {} ({} records) in {}", filePrefix,
 				recordCount, partitionOutputDir
 		);
 	}
@@ -370,7 +370,7 @@ public class BatchProjectionService {
 	 *
 	 * @throws IOException if yield table storage fails
 	 */
-	private void storeChunkYieldTables(ProjectionRunner runner, Path partitionDir, String projectionId, int recordCount)
+	private void storeChunkYieldTables(ProjectionRunner runner, Path partitionDir, String filePrefix, int recordCount)
 			throws IOException {
 		if (runner == null || runner.getContext() == null) {
 			logger.warn("Cannot store yield tables: ProjectionRunner or context is null");
@@ -381,18 +381,18 @@ public class BatchProjectionService {
 		if (yieldTables == null || yieldTables.isEmpty()) {
 			logger.warn(
 					"WARNING: No yield tables returned from extended-core for projection {} ({} input records)",
-					projectionId, recordCount
+					filePrefix, recordCount
 			);
 			return;
 		}
 
 		logger.trace(
 				"Extended-core returned {} yield table(s) for projection {} ({} input records)", yieldTables.size(),
-				projectionId, recordCount
+				filePrefix, recordCount
 		);
 
 		for (YieldTable yieldTable : yieldTables) {
-			storeYieldTable(yieldTable, partitionDir, projectionId, recordCount);
+			storeYieldTable(yieldTable, partitionDir, filePrefix, recordCount);
 		}
 	}
 
@@ -401,16 +401,16 @@ public class BatchProjectionService {
 	 *
 	 * @throws IOException if file copy fails
 	 */
-	private void storeYieldTable(YieldTable yieldTable, Path partitionDir, String projectionId, int recordCount)
+	private void storeYieldTable(YieldTable yieldTable, Path partitionDir, String filePrefix, int recordCount)
 			throws IOException {
 		if (yieldTable == null) {
-			logger.warn("Skipping null yield table in projection {}", projectionId);
+			logger.warn("Skipping null yield table in projection {}", filePrefix);
 			return;
 		}
 
 		String yieldTableFileName = yieldTable.getOutputFormat().getYieldTableFileName();
 		// Add chunk prefix to maintain traceability
-		String prefixedFileName = String.format("YieldTables_%s_%s", projectionId, yieldTableFileName);
+		String prefixedFileName = String.format("%s_%s", filePrefix, yieldTableFileName);
 		Path yieldTablePath = partitionDir.resolve(prefixedFileName);
 
 		try (InputStream yieldTableStream = yieldTable.getAsStream()) {
@@ -441,7 +441,7 @@ public class BatchProjectionService {
 	 *
 	 * @throws IOException if log file storage fails
 	 */
-	private void storeChunkLogs(ProjectionRunner runner, Path partitionDir, String projectionId, int recordCount)
+	private void storeChunkLogs(ProjectionRunner runner, Path partitionDir, String filePrefix, int recordCount)
 			throws IOException {
 		if (runner == null || runner.getContext() == null || runner.getContext().getParams() == null) {
 			logger.warn("Cannot store logs: ProjectionRunner, context, or params is null");
@@ -452,23 +452,23 @@ public class BatchProjectionService {
 
 		// Store progress log if enabled
 		if (params.containsOption(ExecutionOption.DO_ENABLE_PROGRESS_LOGGING)) {
-			storeProgressLog(runner, partitionDir, projectionId, recordCount);
+			storeProgressLog(runner, partitionDir, filePrefix, recordCount);
 		}
 
 		// Store error log if enabled
 		if (params.containsOption(ExecutionOption.DO_ENABLE_ERROR_LOGGING)) {
-			storeErrorLog(runner, partitionDir, projectionId, recordCount);
+			storeErrorLog(runner, partitionDir, filePrefix, recordCount);
 		}
 
 		// Store debug log if enabled
 		if (params.containsOption(ExecutionOption.DO_ENABLE_DEBUG_LOGGING)) {
-			storeDebugLog(partitionDir, projectionId, recordCount);
+			storeDebugLog(partitionDir, filePrefix, recordCount);
 		}
 	}
 
-	private void storeProgressLog(ProjectionRunner runner, Path partitionDir, String projectionId, int recordCount)
+	private void storeProgressLog(ProjectionRunner runner, Path partitionDir, String filePrefix, int recordCount)
 			throws IOException {
-		String progressLogFileName = String.format("YieldTables_%s_ProgressLog.txt", projectionId);
+		String progressLogFileName = String.format("%s_ProgressLog.txt", filePrefix);
 		Path progressLogPath = partitionDir.resolve(progressLogFileName);
 
 		try (InputStream progressStream = runner.getProgressStream()) {
@@ -492,9 +492,9 @@ public class BatchProjectionService {
 		}
 	}
 
-	private void storeErrorLog(ProjectionRunner runner, Path partitionDir, String projectionId, int recordCount)
+	private void storeErrorLog(ProjectionRunner runner, Path partitionDir, String filePrefix, int recordCount)
 			throws IOException {
-		String errorLogFileName = String.format("YieldTables_%s_ErrorLog.txt", projectionId);
+		String errorLogFileName = String.format("%s_ErrorLog.txt", filePrefix);
 		Path errorLogPath = partitionDir.resolve(errorLogFileName);
 
 		try (InputStream errorStream = runner.getErrorStream()) {
@@ -518,8 +518,8 @@ public class BatchProjectionService {
 		}
 	}
 
-	private void storeDebugLog(Path partitionDir, String projectionId, int recordCount) throws IOException {
-		String debugLogFileName = String.format("YieldTables_%s_DebugLog.txt", projectionId);
+	private void storeDebugLog(Path partitionDir, String filePrefix, int recordCount) throws IOException {
+		String debugLogFileName = String.format("%s_DebugLog.txt", filePrefix);
 		Path debugLogPath = partitionDir.resolve(debugLogFileName);
 
 		Files.write(debugLogPath, new byte[0], StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);

--- a/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/service/BatchRecoveryMetadataService.java
+++ b/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/service/BatchRecoveryMetadataService.java
@@ -24,11 +24,15 @@ public class BatchRecoveryMetadataService {
 
 	@Transactional
 	public void markStaleExecutionFailed(Long jobExecutionId) {
-		markStaleExecutionFailed(jobExecutionId, "Marked FAILED during startup recovery after abrupt shutdown");
+		markStaleExecutionFailedInternal(jobExecutionId, "Marked FAILED during startup recovery after abrupt shutdown");
 	}
 
 	@Transactional
 	public JobExecution markStaleExecutionFailed(Long jobExecutionId, String exitDescription) {
+		return markStaleExecutionFailedInternal(jobExecutionId, exitDescription);
+	}
+
+	private JobExecution markStaleExecutionFailedInternal(Long jobExecutionId, String exitDescription) {
 		JobExecution jobExecution = jobExplorer.getJobExecution(jobExecutionId);
 
 		if (jobExecution == null) {

--- a/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/service/BatchRecoveryMetadataService.java
+++ b/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/service/BatchRecoveryMetadataService.java
@@ -1,0 +1,64 @@
+package ca.bc.gov.nrs.vdyp.batch.service;
+
+import java.time.LocalDateTime;
+
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.explore.JobExplorer;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class BatchRecoveryMetadataService {
+
+	private final JobExplorer jobExplorer;
+	private final JobRepository jobRepository;
+
+	public BatchRecoveryMetadataService(JobExplorer jobExplorer, JobRepository jobRepository) {
+		this.jobExplorer = jobExplorer;
+		this.jobRepository = jobRepository;
+	}
+
+	@Transactional
+	public void markStaleExecutionFailed(Long jobExecutionId) {
+		markStaleExecutionFailed(jobExecutionId, "Marked FAILED during startup recovery after abrupt shutdown");
+	}
+
+	@Transactional
+	public JobExecution markStaleExecutionFailed(Long jobExecutionId, String exitDescription) {
+		JobExecution jobExecution = jobExplorer.getJobExecution(jobExecutionId);
+
+		if (jobExecution == null) {
+			throw new IllegalStateException("Could not find JobExecution " + jobExecutionId);
+		}
+
+		if (!isRunningOrStopping(jobExecution.getStatus())) {
+			return jobExecution;
+		}
+
+		LocalDateTime now = LocalDateTime.now();
+
+		for (StepExecution stepExecution : jobExecution.getStepExecutions()) {
+			if (isRunningOrStopping(stepExecution.getStatus())) {
+				stepExecution.setStatus(BatchStatus.FAILED);
+				stepExecution.setExitStatus(ExitStatus.FAILED.addExitDescription(exitDescription));
+				stepExecution.setEndTime(now);
+				jobRepository.update(stepExecution);
+			}
+		}
+
+		jobExecution.setStatus(BatchStatus.FAILED);
+		jobExecution.setExitStatus(ExitStatus.FAILED.addExitDescription(exitDescription));
+		jobExecution.setEndTime(now);
+
+		jobRepository.update(jobExecution);
+		return jobExecution;
+	}
+
+	private boolean isRunningOrStopping(BatchStatus status) {
+		return status == BatchStatus.STARTING || status == BatchStatus.STARTED || status == BatchStatus.STOPPING;
+	}
+}

--- a/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/service/DownloadAndPartitionTasklet.java
+++ b/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/service/DownloadAndPartitionTasklet.java
@@ -83,7 +83,7 @@ public class DownloadAndPartitionTasklet extends VdypFileTasklet {
 				totalPolygons = BatchUtils.countDataRecords(reader);
 			}
 
-			int chunkSize = batchProperties.getReader().getDefaultChunkSize();
+			int chunkSize = resolveChunkSize(stepExecution);
 			int maxJobThreads = batchProperties.getThreadPool().getMaxJobThreads();
 			computedPartitions = BatchUtils.calculateThreadsForJob(totalPolygons, chunkSize, maxJobThreads);
 
@@ -125,6 +125,14 @@ public class DownloadAndPartitionTasklet extends VdypFileTasklet {
 
 	protected void deleteDirectory(Path dir) throws IOException {
 		BatchUtils.deleteDirectoryRecursively(dir);
+	}
+
+	private int resolveChunkSize(StepExecution stepExecution) {
+		Long chunkSize = stepExecution.getJobExecution().getJobParameters().getLong(BatchConstants.Chunk.SIZE);
+		if (chunkSize != null) {
+			return Math.max(chunkSize.intValue(), 1);
+		}
+		return Math.max(batchProperties.getReader().getDefaultChunkSize(), 1);
 	}
 
 	private void pushInitialProgress(int totalPolygons) {

--- a/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/service/ProjectionProgressPushScheduler.java
+++ b/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/service/ProjectionProgressPushScheduler.java
@@ -72,26 +72,19 @@ public class ProjectionProgressPushScheduler {
 
 	private void pushProgressForJob(JobExecution job, String projectionGUID) {
 		String batchJobGUID = job.getJobParameters().getString(BatchConstants.Job.GUID);
-		int totalPolygons = job.getExecutionContext().getInt(BatchConstants.Job.TOTAL_POLYGONS, 0);
-		int workers = BatchUtils.calculateActiveWorkers(job, true);
-		int polygonsProcessed = 0;
-		int errorCount = 0;
-		int polygonsSkipped = 0;
-		for (StepExecution step : job.getStepExecutions()) {
-			if (step.getStepName().startsWith(BatchConstants.Job.WORKER_STEP_NAME)) {
-				ExecutionContext stepCtx = step.getExecutionContext();
-				polygonsProcessed += stepCtx.getInt(BatchConstants.Job.POLYGONS_PROCESSED, 0);
-				errorCount += stepCtx.getInt(BatchConstants.Job.PROJECTION_ERRORS, 0);
-				polygonsSkipped += stepCtx.getInt(BatchConstants.Job.POLYGONS_SKIPPED, 0);
-			}
+		ProgressSnapshot progress = buildRestartAwareProgress(job);
+		if (progress.isEmpty()) {
+			return;
 		}
 
-		Triple<Integer, Integer, Integer> checkTriple = Triple.of(polygonsProcessed, errorCount, polygonsSkipped);
+		Triple<Integer, Integer, Integer> checkTriple = Triple
+				.of(progress.polygonsProcessed(), progress.errorCount(), progress.polygonsSkipped());
 		int newHash = checkTriple.hashCode();
 		Integer previousHash = lastProgressHashByProjection.put(projectionGUID, newHash);
 		if (previousHash == null || previousHash != newHash) {
 			VDYPProjectionProgressUpdate payload = new VDYPProjectionProgressUpdate(
-					batchJobGUID, totalPolygons, polygonsProcessed, errorCount, polygonsSkipped, workers
+					batchJobGUID, progress.totalPolygons(), progress.polygonsProcessed(), progress.errorCount(),
+					progress.polygonsSkipped(), progress.workers()
 			);
 			progressExecutor.execute(() -> {
 				try {
@@ -100,6 +93,61 @@ public class ProjectionProgressPushScheduler {
 					logger.error("Error pushing progress to VDYP", logMe);
 				}
 			});
+		}
+	}
+
+	private ProgressSnapshot buildRestartAwareProgress(JobExecution runningJob) {
+		Map<String, ProgressSnapshot> bestProgressByWorkerStep = new HashMap<>();
+		int totalPolygons = runningJob.getExecutionContext().getInt(BatchConstants.Job.TOTAL_POLYGONS, 0);
+
+		for (JobExecution jobExecution : jobExplorer.getJobExecutions(runningJob.getJobInstance())) {
+			totalPolygons = Math.max(
+					totalPolygons, jobExecution.getExecutionContext().getInt(BatchConstants.Job.TOTAL_POLYGONS, 0)
+			);
+			for (StepExecution step : jobExecution.getStepExecutions()) {
+				if (step.getStepName().startsWith(BatchConstants.Job.WORKER_STEP_NAME)) {
+					bestProgressByWorkerStep.merge(
+							step.getStepName(), progressFromStep(step), ProjectionProgressPushScheduler::maxProgress
+					);
+				}
+			}
+		}
+
+		int workers = BatchUtils.calculateActiveWorkers(runningJob, true);
+		int polygonsProcessed = 0;
+		int errorCount = 0;
+		int polygonsSkipped = 0;
+		for (ProgressSnapshot progress : bestProgressByWorkerStep.values()) {
+			polygonsProcessed += progress.polygonsProcessed();
+			errorCount += progress.errorCount();
+			polygonsSkipped += progress.polygonsSkipped();
+		}
+
+		return new ProgressSnapshot(totalPolygons, polygonsProcessed, errorCount, polygonsSkipped, workers);
+	}
+
+	private static ProgressSnapshot progressFromStep(StepExecution step) {
+		ExecutionContext stepCtx = step.getExecutionContext();
+		return new ProgressSnapshot(
+				0, stepCtx.getInt(BatchConstants.Job.POLYGONS_PROCESSED, 0),
+				stepCtx.getInt(BatchConstants.Job.PROJECTION_ERRORS, 0),
+				stepCtx.getInt(BatchConstants.Job.POLYGONS_SKIPPED, 0), 0
+		);
+	}
+
+	private static ProgressSnapshot maxProgress(ProgressSnapshot left, ProgressSnapshot right) {
+		return left.progressTotal() >= right.progressTotal() ? left : right;
+	}
+
+	private record ProgressSnapshot(
+			int totalPolygons, int polygonsProcessed, int errorCount, int polygonsSkipped, int workers
+	) {
+		boolean isEmpty() {
+			return totalPolygons == 0 && progressTotal() == 0;
+		}
+
+		int progressTotal() {
+			return polygonsProcessed + errorCount + polygonsSkipped;
 		}
 	}
 }

--- a/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/service/StartupRecoveryService.java
+++ b/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/service/StartupRecoveryService.java
@@ -1,0 +1,183 @@
+package ca.bc.gov.nrs.vdyp.batch.service;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.explore.JobExplorer;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.item.ExecutionContext;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.SmartLifecycle;
+import org.springframework.stereotype.Component;
+
+import ca.bc.gov.nrs.vdyp.batch.client.vdyp.VdypClient;
+import ca.bc.gov.nrs.vdyp.batch.util.BatchConstants;
+import ca.bc.gov.nrs.vdyp.batch.util.BatchUtils;
+
+@Component
+public class StartupRecoveryService implements SmartLifecycle {
+
+	private static final Logger logger = LoggerFactory.getLogger(StartupRecoveryService.class);
+
+	private static final String JOB_NAME = "VdypFetchAndPartitionJob";
+	private static final String MISSING_PARTITION_INPUTS_EXIT_DESCRIPTION = "Marked FAILED during startup recovery because partition input directories are missing";
+
+	private final JobExplorer jobExplorer;
+	private final JobLauncher jobLauncher;
+	private final Job fetchAndPartitionJob;
+	private final BatchRecoveryMetadataService recoveryMetadataService;
+	private final VdypClient vdypClient;
+
+	private volatile boolean running = false;
+
+	public StartupRecoveryService(
+			JobExplorer jobExplorer, @Qualifier("asyncJobLauncher") JobLauncher jobLauncher,
+			@Qualifier("fetchAndPartitionJob") Job fetchAndPartitionJob,
+			BatchRecoveryMetadataService recoveryMetadataService, VdypClient vdypClient
+	) {
+		this.jobExplorer = jobExplorer;
+		this.jobLauncher = jobLauncher;
+		this.fetchAndPartitionJob = fetchAndPartitionJob;
+		this.recoveryMetadataService = recoveryMetadataService;
+		this.vdypClient = vdypClient;
+	}
+
+	@Override
+	public void start() {
+		try {
+			Set<JobExecution> runningExecutions = jobExplorer.findRunningJobExecutions(JOB_NAME);
+
+			if (runningExecutions.isEmpty()) {
+				logger.info("No stale running executions found for job {}", JOB_NAME);
+				this.running = true;
+				return;
+			}
+
+			for (JobExecution jobExecution : runningExecutions) {
+				Long oldExecutionId = jobExecution.getId();
+
+				logger.warn(
+						"Recovering stale job execution. jobName={}, executionId={}, status={}", JOB_NAME,
+						oldExecutionId, jobExecution.getStatus()
+				);
+
+				if (cannotRestartCompletedPartitionStep(jobExecution)) {
+					JobExecution failedExecution = recoveryMetadataService
+							.markStaleExecutionFailed(oldExecutionId, MISSING_PARTITION_INPUTS_EXIT_DESCRIPTION);
+					notifyBackendOfRecoveryFailure(failedExecution);
+					logger.warn(
+							"Not restarting stale job execution because partition inputs are missing. executionId={}",
+							oldExecutionId
+					);
+					continue;
+				}
+
+				recoveryMetadataService.markStaleExecutionFailed(oldExecutionId);
+
+				JobExecution newExecution = jobLauncher.run(fetchAndPartitionJob, jobExecution.getJobParameters());
+
+				logger.info(
+						"Restarted stale job execution. oldExecutionId={}, newExecutionId={}", oldExecutionId,
+						newExecution.getId()
+				);
+			}
+
+			this.running = true;
+		} catch (Exception e) {
+			logger.error("Batch startup recovery failed. Refusing to start batch consumer.", e);
+			throw new IllegalStateException("Batch startup recovery failed", e);
+		}
+	}
+
+	private boolean cannotRestartCompletedPartitionStep(JobExecution jobExecution) {
+		if (!isStepCompleted(jobExecution, BatchConstants.Job.FETCH_AND_PARTITION_FILES_STEP_NAME)
+				|| isStepCompleted(jobExecution, BatchConstants.Job.MASTER_STEP_NAME)) {
+			return false;
+		}
+
+		JobParameters jobParameters = jobExecution.getJobParameters();
+		String jobBaseDir = jobParameters.getString(BatchConstants.Job.BASE_DIR);
+		if (jobBaseDir == null || jobBaseDir.isBlank()) {
+			return true;
+		}
+
+		int partitionCount = partitionCount(jobExecution);
+		for (int i = 0; i < partitionCount; i++) {
+			String partitionName = BatchConstants.Partition.PREFIX + i;
+			Path partitionDir = Paths.get(jobBaseDir, BatchUtils.buildInputPartitionFolderName(partitionName));
+			if (Files.notExists(partitionDir)) {
+				logger.warn(
+						"Cannot restart stale job execution {} from masterStep because partition directory is missing: {}",
+						jobExecution.getId(), partitionDir
+				);
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private boolean isStepCompleted(JobExecution jobExecution, String stepName) {
+		return jobExecution.getStepExecutions().stream()
+				.filter(stepExecution -> stepName.equals(stepExecution.getStepName()))
+				.anyMatch(stepExecution -> BatchStatus.COMPLETED.equals(stepExecution.getStatus()));
+	}
+
+	private int partitionCount(JobExecution jobExecution) {
+		ExecutionContext executionContext = jobExecution.getExecutionContext();
+		if (executionContext.containsKey(BatchConstants.Job.COMPUTED_PARTITIONS)) {
+			return executionContext.getInt(BatchConstants.Job.COMPUTED_PARTITIONS);
+		}
+
+		Long parameterValue = jobExecution.getJobParameters().getLong(BatchConstants.Partition.NUMBER);
+		return parameterValue == null ? 0 : parameterValue.intValue();
+	}
+
+	private void notifyBackendOfRecoveryFailure(JobExecution jobExecution) {
+		String projectionGuid = jobExecution.getJobParameters().getString(BatchConstants.GuidInput.PROJECTION_GUID);
+		String jobGuid = jobExecution.getJobParameters().getString(BatchConstants.Job.GUID);
+		if (projectionGuid == null || projectionGuid.isBlank()) {
+			logger.warn(
+					"[GUID: {}] Cannot notify backend of recovery failure because projection GUID is missing", jobGuid
+			);
+			return;
+		}
+
+		try {
+			vdypClient.markComplete(projectionGuid, false, BatchUtils.buildFailureProgress(jobGuid, jobExecution));
+		} catch (Exception e) {
+			logger.warn(
+					"[GUID: {}] Failed to notify backend of unrestartable stale job {}: {}", jobGuid,
+					jobExecution.getId(), e.getMessage()
+			);
+		}
+	}
+
+	@Override
+	public void stop() {
+		this.running = false;
+	}
+
+	@Override
+	public boolean isRunning() {
+		return this.running;
+	}
+
+	@Override
+	public boolean isAutoStartup() {
+		return true;
+	}
+
+	@Override
+	public int getPhase() {
+		return Integer.MIN_VALUE;
+	}
+}

--- a/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/util/BatchConstants.java
+++ b/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/util/BatchConstants.java
@@ -90,6 +90,14 @@ public final class BatchConstants {
 		}
 	}
 
+	public static final class Chunk {
+		public static final String TOTAL_POLYGON_RECORDS = "totalPolygonRecords";
+		public static final String NUM_PROCESSED_POLYGON_RECORDS = "numProcessedPolygonRecords";
+		public static final String CURRENT_CHUNK_NUMBER = "currentChunkNumber";
+		public static final String CURRENT_POLYGON_CHUNK_START_BYTE_OFFSET = "currentPolygonChunkOffset";
+		public static final String CURRENT_LAYER_CHUNK_OFFSET = "currentLayerChunkOffset";
+	}
+
 	public static final class Projection {
 		public static final String PARAMETERS_JSON = "projectionParametersJson";
 

--- a/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/util/BatchConstants.java
+++ b/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/util/BatchConstants.java
@@ -91,6 +91,7 @@ public final class BatchConstants {
 	}
 
 	public static final class Chunk {
+		public static final String SIZE = "chunkSize";
 		public static final String TOTAL_POLYGON_RECORDS = "totalPolygonRecords";
 		public static final String NUM_PROCESSED_POLYGON_RECORDS = "numProcessedPolygonRecords";
 		public static final String CURRENT_CHUNK_NUMBER = "currentChunkNumber";

--- a/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/util/BatchConstants.java
+++ b/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/util/BatchConstants.java
@@ -96,6 +96,9 @@ public final class BatchConstants {
 		public static final String CURRENT_CHUNK_NUMBER = "currentChunkNumber";
 		public static final String CURRENT_POLYGON_CHUNK_START_BYTE_OFFSET = "currentPolygonChunkOffset";
 		public static final String CURRENT_LAYER_CHUNK_OFFSET = "currentLayerChunkOffset";
+
+		private Chunk() {
+		}
 	}
 
 	public static final class Projection {

--- a/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/util/BatchUtils.java
+++ b/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/util/BatchUtils.java
@@ -84,6 +84,18 @@ public final class BatchUtils {
 	}
 
 	/**
+	 * Builds a unique batch projection ID for VDYP projection operations.
+	 *
+	 * @param chunkNumber the number from 1-X of the chunk in this partition
+	 * @return the batch projection ID (e.g., "batch-1-partition0-projection-HCSV-2025_10_02_14_06_43_4933")
+	 */
+	public static String batchChunkFilenamePrefix(int chunkNumber) {
+		StringBuilder sb = new StringBuilder("chunk-");
+		sb.append(String.format("%06d", chunkNumber));
+		return sb.toString();
+	}
+
+	/**
 	 * Extracts the first field from a CSV line, handling both quoted and unquoted fields.
 	 *
 	 * Supports standard CSV quoting: - Unquoted: "value,other" -> "value" - Quoted: ""value"",other" -> "value" - With

--- a/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/util/BatchUtils.java
+++ b/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/util/BatchUtils.java
@@ -84,10 +84,11 @@ public final class BatchUtils {
 	}
 
 	/**
-	 * Builds a unique batch projection ID for VDYP projection operations.
+	 * Builds a unique prefix for VDYP outputfiles based on chunk number
 	 *
 	 * @param chunkNumber the number from 1-X of the chunk in this partition
-	 * @return the batch projection ID (e.g., "batch-1-partition0-projection-HCSV-2025_10_02_14_06_43_4933")
+	 * @return a chunk identifier prefix (e.g., "chunk-00000X) that should sort alphabetically and be reproducible for
+	 *         the same chunk
 	 */
 	public static String batchChunkFilenamePrefix(int chunkNumber) {
 		StringBuilder sb = new StringBuilder("chunk-");

--- a/batch/src/main/resources/application.properties
+++ b/batch/src/main/resources/application.properties
@@ -8,6 +8,8 @@ spring.application.name=VDYP Batch Processing API
 # Server Configuration
 server.port=8081
 server.servlet.context-path=/vdyp-batch
+server.shutdown=graceful
+spring.lifecycle.timeout-per-shutdown-phase=${BATCH_SHUTDOWN_PHASE_TIMEOUT:330s}
 
 # Multipart File Upload Configuration
 spring.servlet.multipart.max-file-size=500MB
@@ -57,6 +59,8 @@ batch.thread-pool.max-pool-size-multiplier=1
 batch.thread-pool.thread-name-prefix=vdyp-batch-thread-
 # Maximum threads a single job may consume (scales with polygon count up to this cap)
 batch.thread-pool.max-job-threads=${BATCH_MAX_JOB_THREADS:6}
+# Keep JDBC resources open while in-flight batch work finishes during graceful shutdown.
+batch.thread-pool.await-termination-seconds=${BATCH_THREAD_POOL_AWAIT_TERMINATION_SECONDS:330}
 
 # Production Error Handling Configuration
 batch.retry.max-attempts=3

--- a/batch/src/test/java/ca/bc/gov/nrs/vdyp/batch/configuration/BatchConfigurationTest.java
+++ b/batch/src/test/java/ca/bc/gov/nrs/vdyp/batch/configuration/BatchConfigurationTest.java
@@ -130,6 +130,7 @@ class BatchConfigurationTest {
 		when(threadPool.getCorePoolSize()).thenReturn(4);
 		when(threadPool.getMaxPoolSizeMultiplier()).thenReturn(2);
 		when(threadPool.getThreadNamePrefix()).thenReturn("VDYP-Worker-");
+		when(threadPool.getAwaitTerminationSeconds()).thenReturn(330);
 		when(reader.getDefaultChunkSize()).thenReturn(10);
 	}
 
@@ -592,6 +593,7 @@ class BatchConfigurationTest {
 		verify(threadPool).getCorePoolSize();
 		verify(threadPool).getMaxPoolSizeMultiplier();
 		verify(threadPool).getThreadNamePrefix();
+		verify(threadPool).getAwaitTerminationSeconds();
 	}
 
 	@Test

--- a/batch/src/test/java/ca/bc/gov/nrs/vdyp/batch/configuration/BatchConfigurationTest.java
+++ b/batch/src/test/java/ca/bc/gov/nrs/vdyp/batch/configuration/BatchConfigurationTest.java
@@ -616,12 +616,21 @@ class BatchConfigurationTest {
 	}
 
 	@Test
-	void testPartitionReader() {
+	void testPartitionReader_UsesConfiguredChunkSize() {
 		var partitionReader = configuration
-				.partitionReader("partition-1", TEST_JOB_EXECUTION_ID, TEST_JOB_GUID, batchProperties);
+				.partitionReader("partition-1", TEST_JOB_EXECUTION_ID, TEST_JOB_GUID, 25L, batchProperties);
 
 		assertNotNull(partitionReader);
-		verify(reader, org.mockito.Mockito.times(2)).getDefaultChunkSize();
+		verify(reader, never()).getDefaultChunkSize();
+	}
+
+	@Test
+	void testPartitionReader_WhenChunkSizeParameterMissing_UsesDefaultChunkSize() {
+		var partitionReader = configuration
+				.partitionReader("partition-1", TEST_JOB_EXECUTION_ID, TEST_JOB_GUID, null, batchProperties);
+
+		assertNotNull(partitionReader);
+		verify(reader, org.mockito.Mockito.times(1)).getDefaultChunkSize();
 	}
 
 	@Test

--- a/batch/src/test/java/ca/bc/gov/nrs/vdyp/batch/configuration/BatchItemProcessorTest.java
+++ b/batch/src/test/java/ca/bc/gov/nrs/vdyp/batch/configuration/BatchItemProcessorTest.java
@@ -113,6 +113,6 @@ class BatchItemProcessorTest {
 	}
 
 	private BatchChunkMetadata createChunkMetadata(String partitionName, int recordCount) {
-		return new BatchChunkMetadata(partitionName, "/tmp/test-job", 0L, recordCount, 0L, 0);
+		return new BatchChunkMetadata(partitionName, "/tmp/test-job", 0L, recordCount, 0L, 0, 1);
 	}
 }

--- a/batch/src/test/java/ca/bc/gov/nrs/vdyp/batch/configuration/BatchItemReaderTest.java
+++ b/batch/src/test/java/ca/bc/gov/nrs/vdyp/batch/configuration/BatchItemReaderTest.java
@@ -188,7 +188,7 @@ class BatchItemReaderTest {
 
 	@Test
 	void testBatchChunkMetadata_ToString() {
-		BatchChunkMetadata metadata = new BatchChunkMetadata("partition-1", "/path/to/job", 100L, 5, 200L, 3);
+		BatchChunkMetadata metadata = new BatchChunkMetadata("partition-1", "/path/to/job", 100L, 5, 200L, 3, 1);
 		String result = metadata.toString();
 
 		assertNotNull(result);

--- a/batch/src/test/java/ca/bc/gov/nrs/vdyp/batch/configuration/BatchItemWriterTest.java
+++ b/batch/src/test/java/ca/bc/gov/nrs/vdyp/batch/configuration/BatchItemWriterTest.java
@@ -254,6 +254,6 @@ class BatchItemWriterTest {
 	}
 
 	private BatchChunkMetadata createMockChunkMetadata(String partitionName, int recordCount) {
-		return new BatchChunkMetadata(partitionName, "/tmp/test-job", 0L, recordCount, 0L, 0);
+		return new BatchChunkMetadata(partitionName, "/tmp/test-job", 0L, recordCount, 0L, 0, 1);
 	}
 }

--- a/batch/src/test/java/ca/bc/gov/nrs/vdyp/batch/configuration/BatchSkipPolicyTest.java
+++ b/batch/src/test/java/ca/bc/gov/nrs/vdyp/batch/configuration/BatchSkipPolicyTest.java
@@ -174,6 +174,6 @@ class BatchSkipPolicyTest {
 	}
 
 	private BatchChunkMetadata createChunkMetadata(String partitionName) {
-		return new BatchChunkMetadata(partitionName, "/tmp/test-job", 0L, 1, 0L, 0);
+		return new BatchChunkMetadata(partitionName, "/tmp/test-job", 0L, 1, 0L, 0, 1);
 	}
 }

--- a/batch/src/test/java/ca/bc/gov/nrs/vdyp/batch/controller/BatchControllerTest.java
+++ b/batch/src/test/java/ca/bc/gov/nrs/vdyp/batch/controller/BatchControllerTest.java
@@ -16,6 +16,7 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
@@ -85,6 +86,7 @@ class BatchControllerTest {
 		ReflectionTestUtils.setField(batchController, "batchRootDirectory", tempDir);
 		ReflectionTestUtils.setField(batchController, "defaultNumPartitions", 4);
 		ReflectionTestUtils.setField(batchController, "jobSearchChunkSize", 1000);
+		ReflectionTestUtils.setField(batchController, "defaultChunkSize", 150);
 	}
 
 	@Test
@@ -117,6 +119,10 @@ class BatchControllerTest {
 		assertEquals(200, response.getStatusCode().value());
 		assertNotNull(response.getBody());
 		assertTrue(response.getBody().containsKey("jobExecutionId"));
+
+		ArgumentCaptor<JobParameters> parametersCaptor = ArgumentCaptor.forClass(JobParameters.class);
+		verify(jobLauncher).run(any(), parametersCaptor.capture());
+		assertEquals(150L, parametersCaptor.getValue().getLong(BatchConstants.Chunk.SIZE));
 	}
 
 	@Test

--- a/batch/src/test/java/ca/bc/gov/nrs/vdyp/batch/exception/BatchProjectionExceptionTest.java
+++ b/batch/src/test/java/ca/bc/gov/nrs/vdyp/batch/exception/BatchProjectionExceptionTest.java
@@ -21,7 +21,7 @@ class BatchProjectionExceptionTest {
 	@Test
 	void testHandleProjectionFailure_WithValidException() {
 		RuntimeException cause = new RuntimeException("Projection algorithm failed");
-		BatchChunkMetadata chunkMetadata = new BatchChunkMetadata("partition-1", "/tmp/job", 100L, 2, 200L, 4);
+		BatchChunkMetadata chunkMetadata = new BatchChunkMetadata("partition-1", "/tmp/job", 100L, 2, 200L, 4, 1);
 		String jobGuid = "job-guid-456";
 		Long jobExecutionId = 600L;
 		String partitionName = "partition-1";
@@ -44,7 +44,7 @@ class BatchProjectionExceptionTest {
 	@Test
 	void testHandleProjectionFailure_WithFirstFeatureId_IncludesFeatureIdInMessageAndException() {
 		RuntimeException cause = new RuntimeException("Projection algorithm failed");
-		BatchChunkMetadata chunkMetadata = new BatchChunkMetadata("partition-1", "/tmp/job", 100L, 2, 200L, 4);
+		BatchChunkMetadata chunkMetadata = new BatchChunkMetadata("partition-1", "/tmp/job", 100L, 2, 200L, 4, 1);
 
 		BatchProjectionException exception = BatchProjectionException.handleProjectionFailure(
 				cause, chunkMetadata, "job-guid-456", 600L, "partition-1", "123456789", logger
@@ -57,7 +57,7 @@ class BatchProjectionExceptionTest {
 	@Test
 	void testHandleProjectionFailure_WithNullExceptionMessage() {
 		RuntimeException cause = new RuntimeException((String) null);
-		BatchChunkMetadata chunkMetadata = new BatchChunkMetadata("partition-nomsg", "/tmp/job", 0L, 1, 0L, 0);
+		BatchChunkMetadata chunkMetadata = new BatchChunkMetadata("partition-nomsg", "/tmp/job", 0L, 1, 0L, 0, 1);
 		String jobGuid = "job-guid-789";
 		Long jobExecutionId = 700L;
 		String partitionName = "partition-nomsg";
@@ -72,7 +72,7 @@ class BatchProjectionExceptionTest {
 	@Test
 	void testHandleProjectionFailure_IsSkippableAndNotRetryable() {
 		RuntimeException cause = new RuntimeException("Test");
-		BatchChunkMetadata chunkMetadata = new BatchChunkMetadata("partition-test", "/tmp/job", 0L, 5, 0L, 0);
+		BatchChunkMetadata chunkMetadata = new BatchChunkMetadata("partition-test", "/tmp/job", 0L, 5, 0L, 0, 1);
 
 		BatchProjectionException exception = BatchProjectionException
 				.handleProjectionFailure(cause, chunkMetadata, "guid", 1L, "partition-test", logger);

--- a/batch/src/test/java/ca/bc/gov/nrs/vdyp/batch/messaging/consumer/BatchRequestConsumerTest.java
+++ b/batch/src/test/java/ca/bc/gov/nrs/vdyp/batch/messaging/consumer/BatchRequestConsumerTest.java
@@ -73,6 +73,9 @@ class BatchRequestConsumerTest {
 	private BatchProperties.PartitionProperties partitionProperties;
 
 	@Mock
+	private BatchProperties.ReaderProperties readerProperties;
+
+	@Mock
 	private ThreadPoolTaskExecutor taskExecutor;
 
 	@Mock
@@ -112,6 +115,7 @@ class BatchRequestConsumerTest {
 		assertTrue(Files.exists(Path.of(parameters.getString(BatchConstants.Job.BASE_DIR))));
 		assertEquals(jobId.toString(), parameters.getString(BatchConstants.GuidInput.PROJECTION_GUID));
 		assertEquals(2L, parameters.getLong(BatchConstants.Partition.NUMBER));
+		assertEquals(150L, parameters.getLong(BatchConstants.Chunk.SIZE));
 		verify(message).ack();
 		verify(message, never()).nak();
 	}
@@ -251,6 +255,8 @@ class BatchRequestConsumerTest {
 	private void givenBatchProperties(int numberOfPartitions) {
 		when(batchProperties.getPartition()).thenReturn(partitionProperties);
 		when(partitionProperties.getDefaultNumberOfPartitions()).thenReturn(numberOfPartitions);
+		when(batchProperties.getReader()).thenReturn(readerProperties);
+		when(readerProperties.getDefaultChunkSize()).thenReturn(150);
 		when(batchProperties.getRootDirectory()).thenReturn(tempDir.toString());
 	}
 

--- a/batch/src/test/java/ca/bc/gov/nrs/vdyp/batch/service/BatchProjectionServiceTest.java
+++ b/batch/src/test/java/ca/bc/gov/nrs/vdyp/batch/service/BatchProjectionServiceTest.java
@@ -50,7 +50,7 @@ class BatchProjectionServiceTest {
 	@Test
 	void testPerformProjectionForChunk_WithMissingPartitionFiles() {
 		// Create chunk metadata pointing to non-existent partition files
-		BatchChunkMetadata chunkMetadata = new BatchChunkMetadata(PARTITION_NAME, tempDir.toString(), 0L, 1, 0L, 0);
+		BatchChunkMetadata chunkMetadata = new BatchChunkMetadata(PARTITION_NAME, tempDir.toString(), 0L, 1, 0L, 0, 1);
 
 		BatchResultStorageException exception = assertThrows(BatchResultStorageException.class, () -> {
 			batchProjectionService.performProjectionForChunk(chunkMetadata, parameters, JOB_EXECUTION_ID, JOB_GUID);
@@ -64,7 +64,7 @@ class BatchProjectionServiceTest {
 		// Create partition structure with invalid polygon data
 		createPartitionStructure(PARTITION_NAME, List.of("123456789,MAP1"), List.of("123456789,P"));
 
-		BatchChunkMetadata chunkMetadata = new BatchChunkMetadata(PARTITION_NAME, tempDir.toString(), 0L, 1, 0L, 0);
+		BatchChunkMetadata chunkMetadata = new BatchChunkMetadata(PARTITION_NAME, tempDir.toString(), 0L, 1, 0L, 0, 1);
 
 		BatchProjectionException exception = assertThrows(BatchProjectionException.class, () -> {
 			batchProjectionService.performProjectionForChunk(chunkMetadata, parameters, JOB_EXECUTION_ID, JOB_GUID);
@@ -86,7 +86,7 @@ class BatchProjectionServiceTest {
 				List.of("100000000,P", "200000000,P", "300000000,P")
 		);
 
-		BatchChunkMetadata chunkMetadata = new BatchChunkMetadata(PARTITION_NAME, tempDir.toString(), 0L, 3, 0L, 0);
+		BatchChunkMetadata chunkMetadata = new BatchChunkMetadata(PARTITION_NAME, tempDir.toString(), 0L, 3, 0L, 0, 1);
 
 		assertThrows(BatchProjectionException.class, () -> {
 			batchProjectionService.performProjectionForChunk(chunkMetadata, parameters, JOB_EXECUTION_ID, JOB_GUID);
@@ -99,7 +99,7 @@ class BatchProjectionServiceTest {
 		createPartitionStructure(PARTITION_NAME, generatePolygonLines(10), generateLayerLines(10));
 
 		// Process chunk: startIndex=5, recordCount=3 (records 5, 6, 7)
-		BatchChunkMetadata chunkMetadata = new BatchChunkMetadata(PARTITION_NAME, tempDir.toString(), 0L, 3, 0L, 0);
+		BatchChunkMetadata chunkMetadata = new BatchChunkMetadata(PARTITION_NAME, tempDir.toString(), 0L, 3, 0L, 0, 1);
 
 		assertThrows(BatchProjectionException.class, () -> {
 			batchProjectionService.performProjectionForChunk(chunkMetadata, parameters, JOB_EXECUTION_ID, JOB_GUID);
@@ -231,7 +231,7 @@ class BatchProjectionServiceTest {
 	@Test
 	void testPerformProjectionForChunk_IOException_WritesSkipErrorLog() throws IOException {
 		// Missing partition files -> NoSuchFileException (IOException) -> SkippedChunkErrorLog written
-		BatchChunkMetadata chunkMetadata = new BatchChunkMetadata(PARTITION_NAME, tempDir.toString(), 0L, 5, 0L, 0);
+		BatchChunkMetadata chunkMetadata = new BatchChunkMetadata(PARTITION_NAME, tempDir.toString(), 0L, 5, 0L, 0, 1);
 
 		assertThrows(BatchResultStorageException.class, () -> {
 			batchProjectionService.performProjectionForChunk(chunkMetadata, parameters, JOB_EXECUTION_ID, JOB_GUID);
@@ -252,7 +252,7 @@ class BatchProjectionServiceTest {
 	void testPerformProjectionForChunk_UnexpectedException_WritesSkipErrorLog() throws IOException {
 		// Invalid polygon data -> exception from extended-core -> SkippedChunkErrorLog written
 		createPartitionStructure(PARTITION_NAME, List.of("123456789,MAP1"), List.of("123456789,P"));
-		BatchChunkMetadata chunkMetadata = new BatchChunkMetadata(PARTITION_NAME, tempDir.toString(), 0L, 1, 0L, 0);
+		BatchChunkMetadata chunkMetadata = new BatchChunkMetadata(PARTITION_NAME, tempDir.toString(), 0L, 1, 0L, 0, 1);
 
 		assertThrows(BatchProjectionException.class, () -> {
 			batchProjectionService.performProjectionForChunk(chunkMetadata, parameters, JOB_EXECUTION_ID, JOB_GUID);

--- a/batch/src/test/java/ca/bc/gov/nrs/vdyp/batch/service/BatchProjectionServiceTest.java
+++ b/batch/src/test/java/ca/bc/gov/nrs/vdyp/batch/service/BatchProjectionServiceTest.java
@@ -198,7 +198,7 @@ class BatchProjectionServiceTest {
 
 		method.invoke(batchProjectionService, mockYieldTable, outputDir, "projection1", 10);
 
-		Path expectedFile = outputDir.resolve("YieldTables_projection1_test_yield_table.txt");
+		Path expectedFile = outputDir.resolve("projection1_test_yield_table.txt");
 		assertTrue(Files.exists(expectedFile));
 		assertTrue(Files.size(expectedFile) > 0);
 	}
@@ -223,7 +223,7 @@ class BatchProjectionServiceTest {
 
 		method.invoke(batchProjectionService, mockYieldTable, outputDir, "projection1", 5);
 
-		Path expectedFile = outputDir.resolve("YieldTables_projection1_empty_table.txt");
+		Path expectedFile = outputDir.resolve("projection1_empty_table.txt");
 		assertTrue(Files.exists(expectedFile));
 		assertEquals(0L, Files.size(expectedFile));
 	}
@@ -281,7 +281,7 @@ class BatchProjectionServiceTest {
 
 		method.invoke(batchProjectionService, outputDir, "projection1", 10);
 
-		Path debugLogFile = outputDir.resolve("YieldTables_projection1_DebugLog.txt");
+		Path debugLogFile = outputDir.resolve("projection1_DebugLog.txt");
 		assertTrue(Files.exists(debugLogFile));
 		assertEquals(0L, Files.size(debugLogFile));
 	}

--- a/batch/src/test/java/ca/bc/gov/nrs/vdyp/batch/service/BatchRecoveryMetadataServiceTest.java
+++ b/batch/src/test/java/ca/bc/gov/nrs/vdyp/batch/service/BatchRecoveryMetadataServiceTest.java
@@ -1,0 +1,149 @@
+package ca.bc.gov.nrs.vdyp.batch.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.explore.JobExplorer;
+import org.springframework.batch.core.repository.JobRepository;
+
+@ExtendWith(MockitoExtension.class)
+class BatchRecoveryMetadataServiceTest {
+
+	private static final String DEFAULT_EXIT_DESCRIPTION = "Marked FAILED during startup recovery after abrupt shutdown";
+
+	@Mock
+	JobExplorer jobExplorer;
+
+	@Mock
+	JobRepository jobRepository;
+
+	BatchRecoveryMetadataService service;
+
+	@BeforeEach
+	void setUp() {
+		service = new BatchRecoveryMetadataService(jobExplorer, jobRepository);
+	}
+
+	@Test
+	void markStaleExecutionFailed_whenExecutionDoesNotExist_throws() {
+		when(jobExplorer.getJobExecution(1L)).thenReturn(null);
+
+		IllegalStateException exception = assertThrows(
+				IllegalStateException.class, () -> service.markStaleExecutionFailed(1L)
+		);
+
+		assertEquals("Could not find JobExecution 1", exception.getMessage());
+		verifyNoInteractions(jobRepository);
+	}
+
+	@Test
+	void markStaleExecutionFailed_whenExecutionAlreadyTerminal_returnsWithoutUpdatingMetadata() {
+		JobExecution jobExecution = jobExecutionWithStatus(BatchStatus.COMPLETED);
+		when(jobExplorer.getJobExecution(1L)).thenReturn(jobExecution);
+
+		JobExecution result = service.markStaleExecutionFailed(1L, "custom description");
+
+		assertSame(jobExecution, result);
+		assertEquals(BatchStatus.COMPLETED, jobExecution.getStatus());
+		verifyNoInteractions(jobRepository);
+	}
+
+	@Test
+	void markStaleExecutionFailed_whenExecutionIsRunning_marksJobAndRunningStepsFailed() {
+		JobExecution jobExecution = jobExecutionWithStatus(BatchStatus.STARTED);
+		StepExecution startedStep = stepExecution("startedStep", jobExecution, BatchStatus.STARTED);
+		StepExecution stoppingStep = stepExecution("stoppingStep", jobExecution, BatchStatus.STOPPING);
+		StepExecution completedStep = stepExecution("completedStep", jobExecution, BatchStatus.COMPLETED);
+		LocalDateTime completedStepEndTime = LocalDateTime.now().minusMinutes(1);
+		completedStep.setExitStatus(ExitStatus.COMPLETED);
+		completedStep.setEndTime(completedStepEndTime);
+		jobExecution.addStepExecutions(List.of(startedStep, stoppingStep, completedStep));
+		when(jobExplorer.getJobExecution(1L)).thenReturn(jobExecution);
+
+		LocalDateTime beforeCall = LocalDateTime.now();
+		JobExecution result = service.markStaleExecutionFailed(1L, "custom description");
+		LocalDateTime afterCall = LocalDateTime.now();
+
+		assertSame(jobExecution, result);
+		assertFailed(jobExecution, "custom description", beforeCall, afterCall);
+		assertFailed(startedStep, "custom description", beforeCall, afterCall);
+		assertFailed(stoppingStep, "custom description", beforeCall, afterCall);
+		assertEquals(BatchStatus.COMPLETED, completedStep.getStatus());
+		assertEquals(ExitStatus.COMPLETED, completedStep.getExitStatus());
+		assertEquals(completedStepEndTime, completedStep.getEndTime());
+		verify(jobRepository).update(startedStep);
+		verify(jobRepository).update(stoppingStep);
+		verify(jobRepository, never()).update(completedStep);
+		verify(jobRepository).update(jobExecution);
+	}
+
+	@Test
+	void markStaleExecutionFailed_withDefaultExitDescription_usesStartupRecoveryDescription() {
+		JobExecution jobExecution = jobExecutionWithStatus(BatchStatus.STARTING);
+		StepExecution startingStep = stepExecution("startingStep", jobExecution, BatchStatus.STARTING);
+		jobExecution.addStepExecutions(List.of(startingStep));
+		when(jobExplorer.getJobExecution(1L)).thenReturn(jobExecution);
+
+		service.markStaleExecutionFailed(1L);
+
+		assertEquals(BatchStatus.FAILED, jobExecution.getStatus());
+		assertTrue(jobExecution.getExitStatus().getExitDescription().contains(DEFAULT_EXIT_DESCRIPTION));
+		assertEquals(BatchStatus.FAILED, startingStep.getStatus());
+		assertTrue(startingStep.getExitStatus().getExitDescription().contains(DEFAULT_EXIT_DESCRIPTION));
+		verify(jobRepository).update(startingStep);
+		verify(jobRepository).update(jobExecution);
+	}
+
+	private JobExecution jobExecutionWithStatus(BatchStatus status) {
+		JobExecution jobExecution = new JobExecution(1L);
+		jobExecution.setStatus(status);
+		return jobExecution;
+	}
+
+	private StepExecution stepExecution(String stepName, JobExecution jobExecution, BatchStatus status) {
+		StepExecution stepExecution = new StepExecution(stepName, jobExecution);
+		stepExecution.setStatus(status);
+		return stepExecution;
+	}
+
+	private void assertFailed(
+			JobExecution jobExecution, String exitDescription, LocalDateTime beforeCall, LocalDateTime afterCall
+	) {
+		assertEquals(BatchStatus.FAILED, jobExecution.getStatus());
+		assertTrue(jobExecution.getExitStatus().getExitDescription().contains(exitDescription));
+		assertTimestampBetween(jobExecution.getEndTime(), beforeCall, afterCall);
+	}
+
+	private void assertFailed(
+			StepExecution stepExecution, String exitDescription, LocalDateTime beforeCall, LocalDateTime afterCall
+	) {
+		assertEquals(BatchStatus.FAILED, stepExecution.getStatus());
+		assertTrue(stepExecution.getExitStatus().getExitDescription().contains(exitDescription));
+		assertTimestampBetween(stepExecution.getEndTime(), beforeCall, afterCall);
+	}
+
+	private void assertTimestampBetween(LocalDateTime actual, LocalDateTime beforeCall, LocalDateTime afterCall) {
+		assertNotNull(actual);
+		assertTrue(!actual.isBefore(beforeCall), "Expected timestamp to be on or after the call started");
+		assertTrue(!actual.isAfter(afterCall), "Expected timestamp to be on or before the call returned");
+	}
+}

--- a/batch/src/test/java/ca/bc/gov/nrs/vdyp/batch/service/ProjectionProgressPushSchedulerTest.java
+++ b/batch/src/test/java/ca/bc/gov/nrs/vdyp/batch/service/ProjectionProgressPushSchedulerTest.java
@@ -1,7 +1,9 @@
 package ca.bc.gov.nrs.vdyp.batch.service;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -19,6 +21,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobInstance;
 import org.springframework.batch.core.JobParameter;
 import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.StepExecution;
@@ -27,6 +30,7 @@ import org.springframework.batch.item.ExecutionContext;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 import ca.bc.gov.nrs.vdyp.batch.client.vdyp.VdypClient;
+import ca.bc.gov.nrs.vdyp.batch.model.VDYPProjectionProgressUpdate;
 import ca.bc.gov.nrs.vdyp.batch.util.BatchConstants;
 
 @ExtendWith(MockitoExtension.class)
@@ -71,7 +75,8 @@ class ProjectionProgressPushSchedulerTest {
 		params.put(BatchConstants.Job.GUID, new JobParameter<>(batchJobGuid, String.class, true));
 		JobParameters jobParameters = new JobParameters(params);
 
-		JobExecution job = new JobExecution(1L, jobParameters);
+		JobInstance jobInstance = new JobInstance(1L, "VdypFetchAndPartitionJob");
+		JobExecution job = new JobExecution(jobInstance, 1L, jobParameters);
 		ExecutionContext jobCtx = new ExecutionContext();
 		jobCtx.putInt(BatchConstants.Job.TOTAL_POLYGONS, 10);
 		job.setExecutionContext(jobCtx);
@@ -93,6 +98,7 @@ class ProjectionProgressPushSchedulerTest {
 
 		when(taskExecutor.getThreadPoolExecutor().getQueue().remainingCapacity()).thenReturn(1);
 		when(jobExplorer.findRunningJobExecutions("VdypFetchAndPartitionJob")).thenReturn(Set.of(job));
+		when(jobExplorer.getJobExecutions(jobInstance)).thenReturn(List.of(job));
 		ArgumentCaptor<Runnable> runnableCaptor = ArgumentCaptor.forClass(Runnable.class);
 
 		scheduler.pushProgress();
@@ -101,6 +107,46 @@ class ProjectionProgressPushSchedulerTest {
 		// 👇 THIS executes your lambda
 		runnableCaptor.getValue().run();
 
+	}
+
+	@Test
+	void pushProgress_restartWithNoCurrentCounts_usesPriorExecutionProgress() {
+		var params = new HashMap<String, JobParameter<?>>();
+		String projectionGuid = java.util.UUID.randomUUID().toString();
+		String batchJobGuid = java.util.UUID.randomUUID().toString();
+
+		params.put(BatchConstants.GuidInput.PROJECTION_GUID, new JobParameter<>(projectionGuid, String.class, true));
+		params.put(BatchConstants.Job.GUID, new JobParameter<>(batchJobGuid, String.class, true));
+		JobParameters jobParameters = new JobParameters(params);
+		JobInstance jobInstance = new JobInstance(1L, "VdypFetchAndPartitionJob");
+
+		JobExecution priorExecution = new JobExecution(jobInstance, 1L, jobParameters);
+		ExecutionContext priorJobCtx = new ExecutionContext();
+		priorJobCtx.putInt(BatchConstants.Job.TOTAL_POLYGONS, 10);
+		priorExecution.setExecutionContext(priorJobCtx);
+		StepExecution priorWorker = new StepExecution("workerStep:partition0", priorExecution);
+		ExecutionContext priorStepCtx = new ExecutionContext();
+		priorStepCtx.putInt(BatchConstants.Job.POLYGONS_PROCESSED, 7);
+		priorWorker.setExecutionContext(priorStepCtx);
+		priorExecution.addStepExecutions(List.of(priorWorker));
+
+		JobExecution restartedExecution = new JobExecution(jobInstance, 2L, jobParameters);
+		restartedExecution.setExecutionContext(new ExecutionContext());
+
+		when(taskExecutor.getThreadPoolExecutor().getQueue().remainingCapacity()).thenReturn(1);
+		when(jobExplorer.findRunningJobExecutions("VdypFetchAndPartitionJob")).thenReturn(Set.of(restartedExecution));
+		when(jobExplorer.getJobExecutions(jobInstance)).thenReturn(List.of(restartedExecution, priorExecution));
+		ArgumentCaptor<Runnable> runnableCaptor = ArgumentCaptor.forClass(Runnable.class);
+		ArgumentCaptor<VDYPProjectionProgressUpdate> payloadCaptor = ArgumentCaptor
+				.forClass(VDYPProjectionProgressUpdate.class);
+
+		scheduler.pushProgress();
+		verify(taskExecutor).execute(runnableCaptor.capture());
+		runnableCaptor.getValue().run();
+
+		verify(vdypClient).pushProgress(eq(projectionGuid), payloadCaptor.capture());
+		assertEquals(10, payloadCaptor.getValue().totalPolygons());
+		assertEquals(7, payloadCaptor.getValue().polygonsProcessed());
 	}
 
 }

--- a/batch/src/test/java/ca/bc/gov/nrs/vdyp/batch/service/StartupRecoveryServiceTest.java
+++ b/batch/src/test/java/ca/bc/gov/nrs/vdyp/batch/service/StartupRecoveryServiceTest.java
@@ -1,0 +1,173 @@
+package ca.bc.gov.nrs.vdyp.batch.service;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.explore.JobExplorer;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.item.ExecutionContext;
+
+import ca.bc.gov.nrs.vdyp.batch.client.vdyp.VdypClient;
+import ca.bc.gov.nrs.vdyp.batch.model.VDYPProjectionProgressUpdate;
+import ca.bc.gov.nrs.vdyp.batch.util.BatchConstants;
+
+@ExtendWith(MockitoExtension.class)
+class StartupRecoveryServiceTest {
+
+	@Mock
+	JobExplorer jobExplorer;
+
+	@Mock
+	JobLauncher jobLauncher;
+
+	@Mock
+	Job fetchAndPartitionJob;
+
+	@Mock
+	BatchRecoveryMetadataService recoveryMetadataService;
+
+	@Mock
+	VdypClient vdypClient;
+
+	@TempDir
+	Path tempDir;
+
+	StartupRecoveryService service;
+
+	@BeforeEach
+	void setUp() {
+		service = new StartupRecoveryService(
+				jobExplorer, jobLauncher, fetchAndPartitionJob, recoveryMetadataService, vdypClient
+		);
+	}
+
+	@Test
+	void start_whenNoStaleExecutions_marksServiceRunningWithoutLaunchingJob() throws Exception {
+		when(jobExplorer.findRunningJobExecutions("VdypFetchAndPartitionJob")).thenReturn(Set.of());
+
+		service.start();
+
+		assertTrue(service.isRunning());
+		verifyNoInteractions(jobLauncher, recoveryMetadataService);
+	}
+
+	@Test
+	void start_whenStaleExecutionExists_marksItFailedThenRestartsWithAsyncLauncher() throws Exception {
+		JobParameters parameters = new JobParametersBuilder()
+				.addString(BatchConstants.Job.GUID, "7c26643a-50cb-497e-a539-afac6966ecea").toJobParameters();
+		JobExecution staleExecution = new JobExecution(1L, parameters);
+		staleExecution.setStatus(BatchStatus.STARTED);
+		JobExecution restartedExecution = new JobExecution(2L, parameters);
+
+		when(jobExplorer.findRunningJobExecutions("VdypFetchAndPartitionJob")).thenReturn(Set.of(staleExecution));
+		when(jobLauncher.run(fetchAndPartitionJob, parameters)).thenReturn(restartedExecution);
+
+		service.start();
+
+		assertTrue(service.isRunning());
+		InOrder inOrder = inOrder(recoveryMetadataService, jobLauncher);
+		inOrder.verify(recoveryMetadataService).markStaleExecutionFailed(1L);
+		inOrder.verify(jobLauncher).run(fetchAndPartitionJob, parameters);
+	}
+
+	@Test
+	void start_whenProcessingRestartNeedsMissingPartitions_failsWithoutRestarting() throws Exception {
+		JobExecution staleExecution = staleExecutionWithBaseDir(tempDir.resolve("missing-base"));
+		staleExecution.addStepExecutions(
+				List.of(
+						stepExecution(
+								BatchConstants.Job.FETCH_AND_PARTITION_FILES_STEP_NAME, staleExecution,
+								BatchStatus.COMPLETED
+						), stepExecution(BatchConstants.Job.MASTER_STEP_NAME, staleExecution, BatchStatus.STARTED)
+				)
+		);
+		JobExecution failedExecution = staleExecutionWithBaseDir(tempDir.resolve("missing-base"));
+		failedExecution.setStatus(BatchStatus.FAILED);
+
+		when(jobExplorer.findRunningJobExecutions("VdypFetchAndPartitionJob")).thenReturn(Set.of(staleExecution));
+		when(recoveryMetadataService.markStaleExecutionFailed(eq(1L), any())).thenReturn(failedExecution);
+
+		service.start();
+
+		assertTrue(service.isRunning());
+		verify(recoveryMetadataService).markStaleExecutionFailed(
+				1L, "Marked FAILED during startup recovery because partition input directories are missing"
+		);
+		verify(vdypClient).markComplete(eq("projection-guid"), eq(false), any(VDYPProjectionProgressUpdate.class));
+		verify(jobLauncher, never()).run(eq(fetchAndPartitionJob), any());
+	}
+
+	@Test
+	void start_whenAggregationRestartHasMissingPartitions_stillRestarts() throws Exception {
+		JobExecution staleExecution = staleExecutionWithBaseDir(tempDir.resolve("missing-base"));
+		staleExecution.addStepExecutions(
+				List.of(
+						stepExecution(
+								BatchConstants.Job.FETCH_AND_PARTITION_FILES_STEP_NAME, staleExecution,
+								BatchStatus.COMPLETED
+						), stepExecution(BatchConstants.Job.MASTER_STEP_NAME, staleExecution, BatchStatus.COMPLETED),
+						stepExecution(BatchConstants.Job.POST_PROCESSING_STEP_NAME, staleExecution, BatchStatus.STARTED)
+				)
+		);
+		JobExecution restartedExecution = new JobExecution(2L, staleExecution.getJobParameters());
+
+		when(jobExplorer.findRunningJobExecutions("VdypFetchAndPartitionJob")).thenReturn(Set.of(staleExecution));
+		when(jobLauncher.run(fetchAndPartitionJob, staleExecution.getJobParameters())).thenReturn(restartedExecution);
+
+		service.start();
+
+		assertTrue(service.isRunning());
+		verify(recoveryMetadataService).markStaleExecutionFailed(1L);
+		verify(jobLauncher).run(fetchAndPartitionJob, staleExecution.getJobParameters());
+	}
+
+	@Test
+	void stop_marksServiceNotRunning() {
+		service.stop();
+
+		assertFalse(service.isRunning());
+	}
+
+	private JobExecution staleExecutionWithBaseDir(Path baseDir) {
+		JobParameters parameters = new JobParametersBuilder()
+				.addString(BatchConstants.Job.GUID, "7c26643a-50cb-497e-a539-afac6966ecea")
+				.addString(BatchConstants.GuidInput.PROJECTION_GUID, "projection-guid")
+				.addString(BatchConstants.Job.BASE_DIR, baseDir.toString()).addLong(BatchConstants.Partition.NUMBER, 2L)
+				.toJobParameters();
+		JobExecution execution = new JobExecution(1L, parameters);
+		execution.setStatus(BatchStatus.STARTED);
+		ExecutionContext executionContext = execution.getExecutionContext();
+		executionContext.putInt(BatchConstants.Job.COMPUTED_PARTITIONS, 2);
+		return execution;
+	}
+
+	private StepExecution stepExecution(String stepName, JobExecution jobExecution, BatchStatus status) {
+		StepExecution stepExecution = new StepExecution(stepName, jobExecution);
+		stepExecution.setStatus(status);
+		return stepExecution;
+	}
+}

--- a/batch/src/test/java/ca/bc/gov/nrs/vdyp/batch/service/StartupRecoveryServiceTest.java
+++ b/batch/src/test/java/ca/bc/gov/nrs/vdyp/batch/service/StartupRecoveryServiceTest.java
@@ -66,7 +66,7 @@ class StartupRecoveryServiceTest {
 	}
 
 	@Test
-	void start_whenNoStaleExecutions_marksServiceRunningWithoutLaunchingJob() throws Exception {
+	void start_whenNoStaleExecutions_marksServiceRunningWithoutLaunchingJob() {
 		when(jobExplorer.findRunningJobExecutions("VdypFetchAndPartitionJob")).thenReturn(Set.of());
 
 		service.start();

--- a/charts/app/values-dev.yaml
+++ b/charts/app/values-dev.yaml
@@ -248,7 +248,8 @@ batch:
   #-- enable or disable batch
   enabled: true
   #-- the deployment strategy, can be "Recreate" or "RollingUpdate"
-  deploymentStrategy: RollingUpdate
+  # Recreate so in-flight projections can be restarted after the service is restarted.
+  deploymentStrategy: Recreate
   #-- autoscaling for the component. it is optional and is an object.
   autoscaling:
     #-- enable or disable autoscaling.

--- a/charts/app/values-prod.yaml
+++ b/charts/app/values-prod.yaml
@@ -248,7 +248,8 @@ batch:
   #-- enable or disable batch
   enabled: true
   #-- the deployment strategy, can be "Recreate" or "RollingUpdate"
-  deploymentStrategy: RollingUpdate
+  # Recreate so in-flight projections can be restarted after the service is restarted.
+  deploymentStrategy: Recreate
   #-- autoscaling for the component. it is optional and is an object.
   autoscaling:
     #-- enable or disable autoscaling.

--- a/charts/app/values-test.yaml
+++ b/charts/app/values-test.yaml
@@ -248,7 +248,8 @@ batch:
   #-- enable or disable batch
   enabled: true
   #-- the deployment strategy, can be "Recreate" or "RollingUpdate"
-  deploymentStrategy: RollingUpdate
+  # Recreate so in-flight projections can be restarted after the service is restarted.
+  deploymentStrategy: Recreate
   #-- autoscaling for the component. it is optional and is an object.
   autoscaling:
     #-- enable or disable autoscaling.

--- a/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/output/yieldtable/CSVYieldTableRowValuesBean.java
+++ b/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/output/yieldtable/CSVYieldTableRowValuesBean.java
@@ -48,7 +48,7 @@ public class CSVYieldTableRowValuesBean implements YieldTableRowBean {
 			var strategy = new CustomMappingStrategy<CSVYieldTableRowValuesBean>(filteredFields);
 			strategy.setType(CSVYieldTableRowValuesBean.class);
 			return new StatefulBeanToCsvBuilder<CSVYieldTableRowValuesBean>(writer).withMappingStrategy(strategy)
-					.build();
+					.withApplyQuotesToAll(false).build();
 		} else {
 			return new StatefulBeanToCsvBuilder<CSVYieldTableRowValuesBean>(writer).build();
 		}

--- a/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/output/yieldtable/CSVYieldTableRowValuesBean.java
+++ b/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/output/yieldtable/CSVYieldTableRowValuesBean.java
@@ -48,7 +48,7 @@ public class CSVYieldTableRowValuesBean implements YieldTableRowBean {
 			var strategy = new CustomMappingStrategy<CSVYieldTableRowValuesBean>(filteredFields);
 			strategy.setType(CSVYieldTableRowValuesBean.class);
 			return new StatefulBeanToCsvBuilder<CSVYieldTableRowValuesBean>(writer).withMappingStrategy(strategy)
-					.withApplyQuotesToAll(false).build();
+					.build();
 		} else {
 			return new StatefulBeanToCsvBuilder<CSVYieldTableRowValuesBean>(writer).build();
 		}


### PR DESCRIPTION
- Made some simplifying updates to the folder/file structure for batch item read write
- Added a service that restarts projections that would otherwise be stuck when Batch starts up.
- Changed to Recreate to ensure the stalled services are able to picked up by the new service without the old service competing with it..