### PR TITLE
Feature/VDYP-1219#2: Preserve polygon/layer context when logging validation errors

### DIFF
--- a/backend/src/main/java/ca/bc/gov/nrs/vdyp/backend/endpoints/v1/ProjectionEndpoint.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/vdyp/backend/endpoints/v1/ProjectionEndpoint.java
@@ -151,6 +151,7 @@ public class ProjectionEndpoint implements Endpoint {
 						).build();
 			}
 		} catch (Exception e) {
+			logger.error(e.getMessage(), e);
 			return Response.status(Status.INTERNAL_SERVER_ERROR)
 					.entity(e.getMessage() == null ? "unknown reason" : e.getMessage()).build();
 		}

--- a/batch/src/test/java/ca/bc/gov/nrs/vdyp/batch/service/BatchProjectionServiceTest.java
+++ b/batch/src/test/java/ca/bc/gov/nrs/vdyp/batch/service/BatchProjectionServiceTest.java
@@ -25,6 +25,7 @@ import ca.bc.gov.nrs.vdyp.batch.exception.BatchResultStorageException;
 import ca.bc.gov.nrs.vdyp.batch.model.BatchChunkMetadata;
 import ca.bc.gov.nrs.vdyp.batch.util.BatchConstants;
 import ca.bc.gov.nrs.vdyp.batch.util.BatchUtils;
+import ca.bc.gov.nrs.vdyp.ecore.api.v1.exceptions.YieldTableGenerationException;
 import ca.bc.gov.nrs.vdyp.ecore.model.v1.Parameters;
 import ca.bc.gov.nrs.vdyp.ecore.model.v1.Parameters.OutputFormat;
 import ca.bc.gov.nrs.vdyp.ecore.projection.output.yieldtable.YieldTable;
@@ -267,6 +268,27 @@ class BatchProjectionServiceTest {
 		assertTrue(content.contains(JOB_GUID), "Skip log should contain job GUID");
 		assertTrue(content.contains("1 polygon(s)"), "Skip log should contain polygon count");
 		assertTrue(content.contains(PARTITION_NAME), "Skip log should contain partition name");
+	}
+
+	@Test
+	void testWriteChunkSkipErrorLog_IncludesFeatureIdFromYieldTableGenerationException() throws IOException,
+			NoSuchMethodException, SecurityException, IllegalAccessException, InvocationTargetException {
+		BatchChunkMetadata chunkMetadata = new BatchChunkMetadata(PARTITION_NAME, tempDir.toString(), 0L, 1, 0L, 0, 1);
+		var cause = new YieldTableGenerationException(13919428L, new IOException("disk full"));
+
+		Method method = BatchProjectionService.class
+				.getDeclaredMethod("writeChunkSkipErrorLog", BatchChunkMetadata.class, String.class);
+		method.setAccessible(true);
+
+		method.invoke(batchProjectionService, chunkMetadata, cause.getMessage());
+
+		Path outputDir = tempDir.resolve("output-" + PARTITION_NAME);
+		Path skipLog = outputDir.resolve("YieldTables_" + PARTITION_NAME + "-chunk0_SkippedChunkErrorLog.txt");
+
+		assertTrue(Files.exists(skipLog), "SkippedChunkErrorLog.txt should be created");
+
+		String content = Files.readString(skipLog);
+		assertTrue(content.contains("Polygon 13919428"), "Skip log should contain the polygon's feature ID");
 	}
 
 	@Test

--- a/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/api/v1/exceptions/AbstractProjectionRequestException.java
+++ b/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/api/v1/exceptions/AbstractProjectionRequestException.java
@@ -11,14 +11,23 @@ public abstract class AbstractProjectionRequestException extends Exception {
 	private static final long serialVersionUID = -3349545755843821804L;
 	private final List<ValidationMessage> validationMessages;
 
+	/**
+	 * The polygon/layer/species context (e.g. "Polygon 123 Layer 1") this exception was raised against, if any. Only
+	 * populated by the AbstractProjectionRequestException(String, List) constructor, since the other constructors
+	 * already bake any context directly into their single GENERIC validation message.
+	 */
+	private final String contextPrefix;
+
 	public AbstractProjectionRequestException(List<ValidationMessage> validationMessages) {
 		super(buildMessage(validationMessages));
 		this.validationMessages = validationMessages;
+		this.contextPrefix = null;
 	}
 
 	public AbstractProjectionRequestException(String message, List<ValidationMessage> validationMessages) {
 		super( (message != null ? (message + ": ") : "") + buildMessage(validationMessages));
 		this.validationMessages = validationMessages;
+		this.contextPrefix = message;
 	}
 
 	public AbstractProjectionRequestException(Throwable cause) {
@@ -27,6 +36,7 @@ public abstract class AbstractProjectionRequestException extends Exception {
 		if (cause.getMessage() != null) {
 			validationMessages.add(new ValidationMessage(ValidationMessageKind.GENERIC, cause.getMessage()));
 		}
+		this.contextPrefix = null;
 	}
 
 	public AbstractProjectionRequestException(String message, Throwable e) {
@@ -35,6 +45,7 @@ public abstract class AbstractProjectionRequestException extends Exception {
 		if (message != null) {
 			validationMessages.add(new ValidationMessage(ValidationMessageKind.GENERIC, message));
 		}
+		this.contextPrefix = null;
 	}
 
 	public AbstractProjectionRequestException(String message) {
@@ -43,10 +54,31 @@ public abstract class AbstractProjectionRequestException extends Exception {
 		if (message != null) {
 			validationMessages.add(new ValidationMessage(ValidationMessageKind.GENERIC, message));
 		}
+		this.contextPrefix = null;
 	}
 
 	public List<ValidationMessage> getValidationMessages() {
 		return validationMessages;
+	}
+
+	/**
+	 * @return the polygon/layer/species context this exception was raised against (e.g. "Polygon 123 Layer 1"), or null
+	 *         if this exception's validation messages already carry that context individually.
+	 */
+	public String getContextPrefix() {
+		return contextPrefix;
+	}
+
+	/**
+	 * Prepends contextPrefix to message, e.g. "Polygon 123: some problem". If message already starts with that same
+	 * prefix (some validation message templates already embed the polygon/layer identity on their own), the prefix is
+	 * not repeated.
+	 */
+	public static String prefixMessage(String contextPrefix, String message) {
+		if (message != null && message.startsWith(contextPrefix + ": ")) {
+			return message;
+		}
+		return contextPrefix + ": " + message;
 	}
 
 	protected static String buildContextPrefix(long featureId) {
@@ -54,10 +86,16 @@ public abstract class AbstractProjectionRequestException extends Exception {
 	}
 
 	protected static String buildContextPrefix(long featureId, String layerId) {
+		if (layerId == null) {
+			return buildContextPrefix(featureId);
+		}
 		return buildContextPrefix(featureId) + " Layer " + layerId;
 	}
 
 	protected static String buildContextPrefix(long featureId, String layerId, String speciesCode) {
+		if (speciesCode == null) {
+			return buildContextPrefix(featureId, layerId);
+		}
 		return buildContextPrefix(featureId, layerId) + " Species " + speciesCode;
 	}
 

--- a/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/ProjectionRunner.java
+++ b/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/ProjectionRunner.java
@@ -138,18 +138,14 @@ public class ProjectionRunner implements Closeable {
 						}
 
 					} catch (PolygonExecutionException e) {
-						for (ValidationMessage m : e.getValidationMessages()) {
-							context.logError(m.getKind().template, m.getArgs());
-						}
+						logValidationMessages(e);
 
 						if (e.getCause() instanceof PolygonValidationException pve) {
 							throw pve;
 						}
 					}
 				} catch (PolygonValidationException e) {
-					for (ValidationMessage m : e.getValidationMessages()) {
-						context.logError(m.getKind().template, m.getArgs());
-					}
+					logValidationMessages(e);
 
 					if (polygon != null) {
 						for (var message : polygon.getMessages()) {
@@ -178,6 +174,23 @@ public class ProjectionRunner implements Closeable {
 			}
 		} finally {
 			context.endRun();
+		}
+	}
+
+	/**
+	 * Logs each of the given exception's validation messages to the error log, one line per message. If the exception
+	 * carries a separate polygon/layer context prefix (see AbstractProjectionRequestException.getContextPrefix()), that
+	 * prefix is prepended to each line; otherwise the message is logged as-is, since in that case any such context was
+	 * already baked into the message itself at construction time.
+	 */
+	private void logValidationMessages(AbstractProjectionRequestException e) {
+		String contextPrefix = e.getContextPrefix();
+		for (ValidationMessage m : e.getValidationMessages()) {
+			if (contextPrefix != null) {
+				context.logError(AbstractProjectionRequestException.prefixMessage(contextPrefix, m.getMessage()));
+			} else {
+				context.logError(m.getKind().template, m.getArgs());
+			}
 		}
 	}
 

--- a/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/input/HcsvPolygonStream.java
+++ b/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/input/HcsvPolygonStream.java
@@ -122,7 +122,7 @@ public class HcsvPolygonStream extends AbstractPolygonStream {
 	private void collectMessages(List<ValidationMessage> messages, Exception e) {
 		if (e instanceof CsvConstraintViolationException cve) {
 			if (cve.getSourceObject() instanceof AbstractProjectionRequestException apre) {
-				messages.addAll(apre.getValidationMessages());
+				messages.addAll(withContextPrefix(apre));
 			} else {
 				throw new IllegalStateException(
 						"Expecting instanceof AbstractProjectionRequestException; saw instead " + e.getClass().getName()
@@ -134,6 +134,27 @@ public class HcsvPolygonStream extends AbstractPolygonStream {
 					"Expecting instanceof CsvConstraintViolationException; saw instead " + e.getClass().getName()
 			);
 		}
+	}
+
+	/**
+	 * Multiple exceptions (e.g. from several layers of the same polygon) are merged into a single flat list of
+	 * ValidationMessages here, so any polygon/layer context captured by the given exception (see
+	 * AbstractProjectionRequestException.getContextPrefix()) must be baked into each individual message now, before
+	 * that context is lost - a single prefix on the merged, multi-source list wouldn't correctly represent messages
+	 * that came from different layers.
+	 */
+	private static List<ValidationMessage> withContextPrefix(AbstractProjectionRequestException apre) {
+		String contextPrefix = apre.getContextPrefix();
+		if (contextPrefix == null) {
+			return apre.getValidationMessages();
+		}
+		return apre.getValidationMessages().stream()
+				.map(
+						m -> new ValidationMessage(
+								ValidationMessageKind.GENERIC,
+								AbstractProjectionRequestException.prefixMessage(contextPrefix, m.getMessage())
+						)
+				).toList();
 	}
 
 	private void advanceToFirstPolygon() {

--- a/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/output/yieldtable/YieldTable.java
+++ b/lib/vdyp-extended-core/src/main/java/ca/bc/gov/nrs/vdyp/ecore/projection/output/yieldtable/YieldTable.java
@@ -1531,7 +1531,8 @@ public class YieldTable implements Closeable {
 				var ucReportingLevel = context.getParams().getUtils().get(sp0Name);
 
 				layerYields = getYields(
-						calendarYear, ucReportingLevel, projectedSp0, stand == null ? projectedLayer : projectedSp0
+						rowContext, calendarYear, ucReportingLevel, projectedSp0,
+						stand == null ? projectedLayer : projectedSp0
 				);
 			}
 
@@ -1638,12 +1639,12 @@ public class YieldTable implements Closeable {
 	}
 
 	LayerYields getYields(
-			int calendarYear, UtilizationClassSet ucReportingLevel, VdypSpecies projectedSp0,
-			VdypUtilizationHolder entity
+			YieldTableRowContext rowContext, int calendarYear, UtilizationClassSet ucReportingLevel,
+			VdypSpecies projectedSp0, VdypUtilizationHolder entity
 	) throws StandYieldCalculationException {
 		if (projectedSp0 == null || entity == null) {
-			throw new StandYieldCalculationException(
-					new IllegalArgumentException("Cannot calculate yields with a null primary Species")
+			throw standYieldCalculationException(
+					rowContext, new IllegalArgumentException("Cannot calculate yields with a null primary Species")
 			);
 		}
 

--- a/lib/vdyp-extended-core/src/test/java/ca/bc/gov/nrs/vdyp/ecore/projection/output/yieldtable/YieldTableTest.java
+++ b/lib/vdyp-extended-core/src/test/java/ca/bc/gov/nrs/vdyp/ecore/projection/output/yieldtable/YieldTableTest.java
@@ -1244,11 +1244,14 @@ class YieldTableTest {
 		var context = new ProjectionContext(ProjectionRequestKind.HCSV, TEST_PROJECTION_ID, parameters, false);
 
 		var yieldTable = YieldTable.of(context);
+		var polygon = new Polygon.Builder().featureId(13919428).build();
+		var rowContext = YieldTableRowContext.of(context, polygon, new PolygonProjectionState(), null);
 
-		assertThrows(
+		var ex = assertThrows(
 				StandYieldCalculationException.class,
-				() -> yieldTable.getYields(2020, UtilizationClassSet._7_5, null, null)
+				() -> yieldTable.getYields(rowContext, 2020, UtilizationClassSet._7_5, null, null)
 		);
+		assertThat(ex.getMessage(), containsString("Polygon 13919428"));
 	}
 
 	@Test
@@ -1258,13 +1261,16 @@ class YieldTableTest {
 		var context = new ProjectionContext(ProjectionRequestKind.HCSV, TEST_PROJECTION_ID, parameters, false);
 
 		var yieldTable = YieldTable.of(context);
+		var polygon = new Polygon.Builder().featureId(13919428).build();
+		var rowContext = YieldTableRowContext.of(context, polygon, new PolygonProjectionState(), null);
 		VdypSpecies species = new VdypSpecies.Builder().genus("PL", 1).polygonIdentifier("12345689", 2020)
 				.layerType(LayerType.PRIMARY).build();
 
-		assertThrows(
+		var ex = assertThrows(
 				StandYieldCalculationException.class,
-				() -> yieldTable.getYields(2020, UtilizationClassSet._7_5, species, null)
+				() -> yieldTable.getYields(rowContext, 2020, UtilizationClassSet._7_5, species, null)
 		);
+		assertThat(ex.getMessage(), containsString("Polygon 13919428"));
 	}
 
 	@Test
@@ -1274,6 +1280,8 @@ class YieldTableTest {
 		var context = new ProjectionContext(ProjectionRequestKind.HCSV, TEST_PROJECTION_ID, parameters, false);
 
 		var yieldTable = YieldTable.of(context);
+		var polygon = new Polygon.Builder().featureId(13919428).build();
+		var rowContext = YieldTableRowContext.of(context, polygon, new PolygonProjectionState(), null);
 
 		VdypSpecies species = VdypSpecies.build(sb -> {
 			sb.genus("PL", 1);
@@ -1303,7 +1311,7 @@ class YieldTableTest {
 			);
 		});
 
-		var result = yieldTable.getYields(2020, UtilizationClassSet._7_5, species, species);
+		var result = yieldTable.getYields(rowContext, 2020, UtilizationClassSet._7_5, species, species);
 		assertThat(result, recordHasProperty("basalArea75cm", Matchers.closeTo(14.9620, 0.014)));
 		assertThat(result, recordHasProperty("basalArea125cm", Matchers.closeTo(12.7926, 0.012)));
 		assertThat(result, recordHasProperty("basalArea", Matchers.closeTo(14.9620, 0.014)));
@@ -1317,6 +1325,8 @@ class YieldTableTest {
 		var context = new ProjectionContext(ProjectionRequestKind.HCSV, TEST_PROJECTION_ID, parameters, false);
 
 		var yieldTable = YieldTable.of(context);
+		var polygon = new Polygon.Builder().featureId(13919428).build();
+		var rowContext = YieldTableRowContext.of(context, polygon, new PolygonProjectionState(), null);
 
 		VdypSpecies species = VdypSpecies.build(sb -> {
 			sb.genus("PL", 1);
@@ -1346,7 +1356,7 @@ class YieldTableTest {
 			);
 		});
 
-		var result = yieldTable.getYields(2020, UtilizationClassSet._12_5, species, species);
+		var result = yieldTable.getYields(rowContext, 2020, UtilizationClassSet._12_5, species, species);
 		assertThat(result, recordHasProperty("basalArea75cm", Matchers.closeTo(14.9620, 0.014)));
 		assertThat(result, recordHasProperty("basalArea125cm", Matchers.closeTo(12.7926, 0.012)));
 		assertThat(result, recordHasProperty("basalArea", Matchers.closeTo(12.7926, 0.012)));


### PR DESCRIPTION
- PolygonValidationException/LayerValidationException carry a polygon/layer context prefix, but the error log was reading getValidationMessages() instead of getMessage(), silently dropping that context.
- Expose the prefix via getContextPrefix() and log it alongside each validation message, without duplicating it or losing per-layer context when messages from multiple layers are merged.