### PR TITLE
Feature/VDYP-1193#2: Fix double-counting of internally-skipped polygons in processed count

### DIFF
--- a/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/configuration/ChunkWriteListener.java
+++ b/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/configuration/ChunkWriteListener.java
@@ -36,8 +36,11 @@ public class ChunkWriteListener implements ItemWriteListener<BatchChunkMetadata>
 
 		ExecutionContext stepCtx = stepExecution.getExecutionContext();
 
+		// A chunk's record count can include polygons extended-core itself skipped internally
+		// (meta.getSkippedPolygonCount()); those are reported separately below, so only the
+		// remainder is genuinely "processed" - otherwise they'd be double-counted.
 		int polygonsProcessed = stepCtx.getInt(BatchConstants.Job.POLYGONS_PROCESSED, 0);
-		polygonsProcessed += meta.getPolygonRecordCount();
+		polygonsProcessed += meta.getPolygonRecordCount() - meta.getSkippedPolygonCount();
 		stepCtx.putInt(BatchConstants.Job.POLYGONS_PROCESSED, polygonsProcessed);
 
 		int projectionErrors = stepCtx.getInt(BatchConstants.Job.PROJECTION_ERRORS, 0);

--- a/batch/src/test/java/ca/bc/gov/nrs/vdyp/batch/configuration/ChunkWriteListenerTest.java
+++ b/batch/src/test/java/ca/bc/gov/nrs/vdyp/batch/configuration/ChunkWriteListenerTest.java
@@ -53,9 +53,16 @@ class ChunkWriteListenerTest {
 
 		listener.afterWrite(new Chunk<>(meta));
 
-		assertThat(executionContext.getInt(BatchConstants.Job.POLYGONS_PROCESSED, 0), is(150));
+		assertThat(executionContext.getInt(BatchConstants.Job.POLYGONS_PROCESSED, 0), is(148));
 		assertThat(executionContext.getInt(BatchConstants.Job.PROJECTION_ERRORS, 0), is(3));
 		assertThat(executionContext.getInt(BatchConstants.Job.POLYGONS_SKIPPED, 0), is(2));
+
+		int processed = executionContext.getInt(BatchConstants.Job.POLYGONS_PROCESSED, 0);
+		int skipped = executionContext.getInt(BatchConstants.Job.POLYGONS_SKIPPED, 0);
+		assertThat(
+				"processed + skipped must not double-count polygons skipped within a successful chunk",
+				processed + skipped, is(meta.getPolygonRecordCount())
+		);
 	}
 
 	@Test


### PR DESCRIPTION
Fix double-counting of internally-skipped polygons in processed count