### PR TITLE
Feature/VDYP-1198: Gracefully handle unknown-projection and invalid-state progress updates

### DIFF
--- a/backend/src/main/java/ca/bc/gov/nrs/vdyp/backend/endpoints/v1/mappers/ProjectionNotFoundExceptionMapper.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/vdyp/backend/endpoints/v1/mappers/ProjectionNotFoundExceptionMapper.java
@@ -11,4 +11,11 @@ public class ProjectionNotFoundExceptionMapper extends AbstractApiExceptionMappe
 	protected Response buildResponse(ProjectionNotFoundException e) {
 		return response(Response.Status.NOT_FOUND, "NOT_FOUND", e.getMessage());
 	}
+
+	@Override
+	protected void log(ProjectionNotFoundException e) {
+		// Expected/known condition (e.g. a stale batch job reporting on a projection no longer known to us) avoid a
+		// full stack trace.
+		logger.info(e.getMessage());
+	}
 }

--- a/backend/src/main/java/ca/bc/gov/nrs/vdyp/backend/endpoints/v1/mappers/ProjectionStateExceptionMapper.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/vdyp/backend/endpoints/v1/mappers/ProjectionStateExceptionMapper.java
@@ -11,4 +11,10 @@ public class ProjectionStateExceptionMapper extends AbstractApiExceptionMapper<P
 	protected Response buildResponse(ProjectionStateException e) {
 		return response(Response.Status.BAD_REQUEST, "BAD_REQUEST", e.getMessage());
 	}
+
+	@Override
+	protected void log(ProjectionStateException e) {
+		// Expected/known condition (e.g. a progress update racing against completion) - avoid a full stack trace.
+		logger.info(e.getMessage());
+	}
 }

--- a/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/service/ProjectionProgressPushScheduler.java
+++ b/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/service/ProjectionProgressPushScheduler.java
@@ -17,6 +17,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
 
 import com.google.common.base.Strings;
 
@@ -29,19 +30,24 @@ import ca.bc.gov.nrs.vdyp.batch.util.BatchUtils;
 @EnableScheduling
 public class ProjectionProgressPushScheduler {
 	private static final Logger logger = LoggerFactory.getLogger(ProjectionProgressPushScheduler.class);
+	private static final String PROJECTION_CANCELLED_REASON = "Projection cancelled";
+
 	private final JobExplorer jobExplorer;
 	private final VdypClient vdypClient;
 	private final ThreadPoolTaskExecutor progressExecutor;
+	private final BatchRecoveryMetadataService batchRecoveryMetadataService;
 
 	private final Map<String, Integer> lastProgressHashByProjection = new HashMap<>();
 
 	public ProjectionProgressPushScheduler(
 			JobExplorer jobExplorer, VdypClient vdypClient,
-			@Qualifier("backendProgressExecutor") ThreadPoolTaskExecutor executor
+			@Qualifier("backendProgressExecutor") ThreadPoolTaskExecutor executor,
+			BatchRecoveryMetadataService batchRecoveryMetadataService
 	) {
 		this.jobExplorer = jobExplorer;
 		this.vdypClient = vdypClient;
 		this.progressExecutor = executor;
+		this.batchRecoveryMetadataService = batchRecoveryMetadataService;
 	}
 
 	/**
@@ -89,6 +95,20 @@ public class ProjectionProgressPushScheduler {
 			progressExecutor.execute(() -> {
 				try {
 					vdypClient.pushProgress(projectionGUID, payload);
+				} catch (HttpClientErrorException.NotFound e) {
+					// Backend has no record of this projection - nothing further to push. Fail the job (if it
+					// isn't already terminal) rather than retrying against a projection that no longer exists.
+					logger.info(
+							"Projection {} is not known to backend; failing job {} as '{}'", projectionGUID,
+							job.getId(), PROJECTION_CANCELLED_REASON
+					);
+					batchRecoveryMetadataService.markStaleExecutionFailed(job.getId(), PROJECTION_CANCELLED_REASON);
+				} catch (HttpClientErrorException.BadRequest e) {
+					// Backend's current state for this projection doesn't permit a progress update (e.g. it has
+					// already reached a terminal state) - expected race, nothing more to do here.
+					logger.info(
+							"Backend rejected progress update for projection {}: {}", projectionGUID, e.getMessage()
+					);
 				} catch (Exception logMe) {
 					logger.error("Error pushing progress to VDYP", logMe);
 				}

--- a/batch/src/test/java/ca/bc/gov/nrs/vdyp/batch/service/ProjectionProgressPushSchedulerTest.java
+++ b/batch/src/test/java/ca/bc/gov/nrs/vdyp/batch/service/ProjectionProgressPushSchedulerTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -27,7 +28,9 @@ import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.StepExecution;
 import org.springframework.batch.core.explore.JobExplorer;
 import org.springframework.batch.item.ExecutionContext;
+import org.springframework.http.HttpStatus;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.web.client.HttpClientErrorException;
 
 import ca.bc.gov.nrs.vdyp.batch.client.vdyp.VdypClient;
 import ca.bc.gov.nrs.vdyp.batch.model.VDYPProjectionProgressUpdate;
@@ -48,14 +51,41 @@ class ProjectionProgressPushSchedulerTest {
 	ThreadPoolExecutor threadPoolExecutor;
 	@Mock
 	BlockingQueue<Runnable> queue;
+	@Mock
+	BatchRecoveryMetadataService batchRecoveryMetadataService;
 
 	ProjectionProgressPushScheduler scheduler;
 
 	@BeforeEach
 	void setUp() {
-		scheduler = new ProjectionProgressPushScheduler(jobExplorer, vdypClient, taskExecutor);
+		scheduler = new ProjectionProgressPushScheduler(
+				jobExplorer, vdypClient, taskExecutor, batchRecoveryMetadataService
+		);
 		when(taskExecutor.getThreadPoolExecutor()).thenReturn(threadPoolExecutor);
 		when(threadPoolExecutor.getQueue()).thenReturn(queue);
+	}
+
+	private JobExecution runningJobWithProgress(String projectionGuid, String batchJobGuid) {
+		var params = new HashMap<String, JobParameter<?>>();
+		params.put(BatchConstants.GuidInput.PROJECTION_GUID, new JobParameter<>(projectionGuid, String.class, true));
+		params.put(BatchConstants.Job.GUID, new JobParameter<>(batchJobGuid, String.class, true));
+		JobParameters jobParameters = new JobParameters(params);
+
+		JobInstance jobInstance = new JobInstance(1L, "VdypFetchAndPartitionJob");
+		JobExecution job = new JobExecution(jobInstance, 1L, jobParameters);
+		ExecutionContext jobCtx = new ExecutionContext();
+		jobCtx.putInt(BatchConstants.Job.TOTAL_POLYGONS, 10);
+		job.setExecutionContext(jobCtx);
+		ExecutionContext stepCtx = new ExecutionContext();
+		StepExecution step = new StepExecution("workerStep", job);
+		stepCtx.putInt(BatchConstants.Job.POLYGONS_PROCESSED, 5);
+		step.setExecutionContext(stepCtx);
+		job.addStepExecutions(List.of(step));
+
+		when(taskExecutor.getThreadPoolExecutor().getQueue().remainingCapacity()).thenReturn(1);
+		when(jobExplorer.findRunningJobExecutions("VdypFetchAndPartitionJob")).thenReturn(Set.of(job));
+		when(jobExplorer.getJobExecutions(jobInstance)).thenReturn(List.of(job));
+		return job;
 	}
 
 	@Test
@@ -107,6 +137,56 @@ class ProjectionProgressPushSchedulerTest {
 		// 👇 THIS executes your lambda
 		runnableCaptor.getValue().run();
 
+	}
+
+	@Test
+	void pushProgress_backendReportsUnknownProjection_failsJobAsCancelled() {
+		String projectionGuid = java.util.UUID.randomUUID().toString();
+		String batchJobGuid = java.util.UUID.randomUUID().toString();
+		JobExecution job = runningJobWithProgress(projectionGuid, batchJobGuid);
+
+		doThrow(HttpClientErrorException.NotFound.create(HttpStatus.NOT_FOUND, "Not Found", null, null, null))
+				.when(vdypClient).pushProgress(eq(projectionGuid), any());
+
+		ArgumentCaptor<Runnable> runnableCaptor = ArgumentCaptor.forClass(Runnable.class);
+		scheduler.pushProgress();
+		verify(taskExecutor).execute(runnableCaptor.capture());
+		runnableCaptor.getValue().run();
+
+		verify(batchRecoveryMetadataService).markStaleExecutionFailed(job.getId(), "Projection cancelled");
+	}
+
+	@Test
+	void pushProgress_unexpectedError_isLoggedAndDoesNotFailJob() {
+		String projectionGuid = java.util.UUID.randomUUID().toString();
+		String batchJobGuid = java.util.UUID.randomUUID().toString();
+		runningJobWithProgress(projectionGuid, batchJobGuid);
+
+		doThrow(new RuntimeException("connection reset")).when(vdypClient).pushProgress(eq(projectionGuid), any());
+
+		ArgumentCaptor<Runnable> runnableCaptor = ArgumentCaptor.forClass(Runnable.class);
+		scheduler.pushProgress();
+		verify(taskExecutor).execute(runnableCaptor.capture());
+		runnableCaptor.getValue().run();
+
+		verify(batchRecoveryMetadataService, never()).markStaleExecutionFailed(any(), any());
+	}
+
+	@Test
+	void pushProgress_backendReportsStateNotPermitted_doesNotFailJob() {
+		String projectionGuid = java.util.UUID.randomUUID().toString();
+		String batchJobGuid = java.util.UUID.randomUUID().toString();
+		runningJobWithProgress(projectionGuid, batchJobGuid);
+
+		doThrow(HttpClientErrorException.BadRequest.create(HttpStatus.BAD_REQUEST, "Bad Request", null, null, null))
+				.when(vdypClient).pushProgress(eq(projectionGuid), any());
+
+		ArgumentCaptor<Runnable> runnableCaptor = ArgumentCaptor.forClass(Runnable.class);
+		scheduler.pushProgress();
+		verify(taskExecutor).execute(runnableCaptor.capture());
+		runnableCaptor.getValue().run();
+
+		verify(batchRecoveryMetadataService, never()).markStaleExecutionFailed(any(), any());
 	}
 
 	@Test


### PR DESCRIPTION
Batch progress updates for a projection backend no longer recognizes, or whose state doesn't permit an update, are now treated as expected conditions instead of logged as raw exceptions.

- Backend: suppress full stack trace logging for ProjectionNotFoundException and ProjectionStateException on progress updates.
- Batch: on a "projection not known" response, fail the job with reason "Projection cancelled" (if not already failed); on a "state doesn't allow update" response, log concisely without failing the job further.