### PR TITLE
VDYP-1205: Delete all batch mappings during cancel instead of assuuming there will only be one

### DIFF
--- a/backend/src/main/java/ca/bc/gov/nrs/vdyp/backend/services/ProjectionBatchMappingService.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/vdyp/backend/services/ProjectionBatchMappingService.java
@@ -68,20 +68,26 @@ public class ProjectionBatchMappingService {
 	@Transactional
 	public void cancelProjection(ProjectionEntity projectionEntity) throws ProjectionServiceException {
 		try {
-			var entity = repository.findByProjectionGUID(projectionEntity.getProjectionGUID());
+			var entityList = repository.listByProjectionGUID(projectionEntity.getProjectionGUID());
 
-			if (entity.isPresent() && entity.get().getBatchJobGUID() != null) {
-				stopBatchJob(entity.get().getBatchJobGUID(), projectionEntity.getProjectionGUID());
-			} else {
-				// Catching a race condition in which batch has already picked up the projection but backend hasn't been
+			if (entityList.isEmpty()) {
+				// Catching a race condition in which batch has already picked up the projection but backend hasn't
+				// been
 				// informed yet
 				logger.info(
-						"No batch job GUID found for projection {}; cancelling batch job by projection GUID",
+						"No batch job GUIDs found for projection {}; cancelling batch job by projection GUID",
 						projectionEntity.getProjectionGUID()
 				);
 				stopBatchJobByProjection(projectionEntity.getProjectionGUID());
+			} else {
+				// attempt to stop all known projection entities
+				for (var entity : entityList) {
+					if (entity.getBatchJobGUID() != null) {
+						stopBatchJob(entity.getBatchJobGUID(), projectionEntity.getProjectionGUID());
+						repository.delete(entity);
+					}
+				}
 			}
-			entity.ifPresent(repository::delete);
 		} catch (Exception e) {
 			throw new ProjectionServiceException("Error cancelling projection batch process", e);
 		}

--- a/backend/src/test/java/ca/bc/gov/nrs/vdyp/backend/services/ProjectionBatchMappingServiceTest.java
+++ b/backend/src/test/java/ca/bc/gov/nrs/vdyp/backend/services/ProjectionBatchMappingServiceTest.java
@@ -94,15 +94,35 @@ class ProjectionBatchMappingServiceTest {
 		mappingEntity.setBatchJobGUID(batchJobGuid);
 		mappingEntity.setProjection(projectionEntity);
 
-		when(repository.findByProjectionGUID(projectionGuid)).thenReturn(Optional.of(mappingEntity));
+		when(repository.listByProjectionGUID(projectionGuid)).thenReturn(List.of(mappingEntity));
 
 		// Act
 		service.cancelProjection(projectionEntity);
 
 		// Verify cancel called
-		verify(repository, times(1)).findByProjectionGUID(projectionGuid);
+		verify(repository, times(1)).listByProjectionGUID(projectionGuid);
 		verify(batchClient, times(1)).stopBatchJob(batchJobGuid);
 		verify(repository, times(1)).delete(mappingEntity);
+		verifyNoMoreInteractions(batchClient, repository, assembler);
+	}
+
+	@Test
+	void cancelProjection_multipleMappings_stopsAndDeletesAllBatchJobs() throws ProjectionServiceException {
+		UUID projectionGuid = UUID.randomUUID();
+		ProjectionEntity projectionEntity = projectionEntity(projectionGuid, UUID.randomUUID());
+		ProjectionBatchMappingEntity firstMapping = batchMappingEntity(projectionEntity, UUID.randomUUID());
+		ProjectionBatchMappingEntity secondMapping = batchMappingEntity(projectionEntity, UUID.randomUUID());
+
+		when(repository.listByProjectionGUID(projectionGuid)).thenReturn(List.of(firstMapping, secondMapping));
+
+		service.cancelProjection(projectionEntity);
+
+		verify(repository, times(1)).listByProjectionGUID(projectionGuid);
+		verify(batchClient, times(1)).stopBatchJob(firstMapping.getBatchJobGUID());
+		verify(batchClient, times(1)).stopBatchJob(secondMapping.getBatchJobGUID());
+		verify(batchClient, never()).stopBatchJobByProjection(any());
+		verify(repository, times(1)).delete(firstMapping);
+		verify(repository, times(1)).delete(secondMapping);
 		verifyNoMoreInteractions(batchClient, repository, assembler);
 	}
 
@@ -113,12 +133,12 @@ class ProjectionBatchMappingServiceTest {
 
 		ProjectionEntity projectionEntity = projectionEntity(projectionGuid, UUID.randomUUID());
 
-		when(repository.findByProjectionGUID(projectionGuid)).thenReturn(Optional.empty());
+		when(repository.listByProjectionGUID(projectionGuid)).thenReturn(List.of());
 
 		// Act
 		service.cancelProjection(projectionEntity);
 
-		verify(repository, times(1)).findByProjectionGUID(projectionGuid);
+		verify(repository, times(1)).listByProjectionGUID(projectionGuid);
 		verify(batchClient, times(1)).stopBatchJobByProjection(projectionGuid);
 		verify(batchClient, never()).stopBatchJob(any());
 		verify(repository, never()).delete(any());
@@ -126,8 +146,7 @@ class ProjectionBatchMappingServiceTest {
 	}
 
 	@Test
-	void cancelProjection_mappingWithoutBatchJob_batchDoesNotKnowProjection_deletesMapping()
-			throws ProjectionServiceException {
+	void cancelProjection_mappingWithoutBatchJob_doesNotCallBatchOrDeleteMapping() throws ProjectionServiceException {
 		// Arrange
 		UUID projectionGuid = UUID.randomUUID();
 
@@ -136,17 +155,35 @@ class ProjectionBatchMappingServiceTest {
 		ProjectionBatchMappingEntity mappingEntity = new ProjectionBatchMappingEntity();
 		mappingEntity.setProjection(projectionEntity);
 
-		when(repository.findByProjectionGUID(projectionGuid)).thenReturn(Optional.of(mappingEntity));
-		doThrow(new WebApplicationException(Response.status(Response.Status.NOT_FOUND).build())).when(batchClient)
-				.stopBatchJobByProjection(projectionGuid);
+		when(repository.listByProjectionGUID(projectionGuid)).thenReturn(List.of(mappingEntity));
 
 		// Act
 		service.cancelProjection(projectionEntity);
 
-		verify(repository, times(1)).findByProjectionGUID(projectionGuid);
-		verify(batchClient, times(1)).stopBatchJobByProjection(projectionGuid);
+		verify(repository, times(1)).listByProjectionGUID(projectionGuid);
+		verify(batchClient, never()).stopBatchJobByProjection(any());
 		verify(batchClient, never()).stopBatchJob(any());
-		verify(repository, times(1)).delete(mappingEntity);
+		verify(repository, never()).delete(any());
+		verifyNoMoreInteractions(batchClient, repository, assembler);
+	}
+
+	@Test
+	void cancelProjection_mixedMappings_ignoresMappingsWithoutBatchJobGuid() throws ProjectionServiceException {
+		UUID projectionGuid = UUID.randomUUID();
+		ProjectionEntity projectionEntity = projectionEntity(projectionGuid, UUID.randomUUID());
+		ProjectionBatchMappingEntity mappingWithoutBatchJob = batchMappingEntity(projectionEntity, null);
+		ProjectionBatchMappingEntity mappingWithBatchJob = batchMappingEntity(projectionEntity, UUID.randomUUID());
+
+		when(repository.listByProjectionGUID(projectionGuid))
+				.thenReturn(List.of(mappingWithoutBatchJob, mappingWithBatchJob));
+
+		service.cancelProjection(projectionEntity);
+
+		verify(repository, times(1)).listByProjectionGUID(projectionGuid);
+		verify(batchClient, times(1)).stopBatchJob(mappingWithBatchJob.getBatchJobGUID());
+		verify(batchClient, never()).stopBatchJobByProjection(any());
+		verify(repository, times(1)).delete(mappingWithBatchJob);
+		verify(repository, never()).delete(mappingWithoutBatchJob);
 		verifyNoMoreInteractions(batchClient, repository, assembler);
 	}
 
@@ -162,14 +199,14 @@ class ProjectionBatchMappingServiceTest {
 		mappingEntity.setBatchJobGUID(batchJobGuid);
 		mappingEntity.setProjection(projectionEntity);
 
-		when(repository.findByProjectionGUID(projectionGuid)).thenReturn(Optional.of(mappingEntity));
+		when(repository.listByProjectionGUID(projectionGuid)).thenReturn(List.of(mappingEntity));
 		doThrow(new WebApplicationException(Response.status(Response.Status.NOT_FOUND).build())).when(batchClient)
 				.stopBatchJob(batchJobGuid);
 
 		// Act
 		service.cancelProjection(projectionEntity);
 
-		verify(repository, times(1)).findByProjectionGUID(projectionGuid);
+		verify(repository, times(1)).listByProjectionGUID(projectionGuid);
 		verify(batchClient, times(1)).stopBatchJob(batchJobGuid);
 		verify(batchClient, never()).stopBatchJobByProjection(any());
 		verify(repository, times(1)).delete(mappingEntity);
@@ -180,20 +217,23 @@ class ProjectionBatchMappingServiceTest {
 	void cancelProjection_batchCancelFails_doesNotDeleteMapping() {
 		// Arrange
 		UUID projectionGuid = UUID.randomUUID();
+		UUID batchJobGuid = UUID.randomUUID();
 
 		ProjectionEntity projectionEntity = projectionEntity(projectionGuid, UUID.randomUUID());
 
 		ProjectionBatchMappingEntity mappingEntity = new ProjectionBatchMappingEntity();
+		mappingEntity.setBatchJobGUID(batchJobGuid);
 		mappingEntity.setProjection(projectionEntity);
 
-		when(repository.findByProjectionGUID(projectionGuid)).thenReturn(Optional.of(mappingEntity));
+		when(repository.listByProjectionGUID(projectionGuid)).thenReturn(List.of(mappingEntity));
 		doThrow(new WebApplicationException(Response.serverError().build())).when(batchClient)
-				.stopBatchJobByProjection(projectionGuid);
+				.stopBatchJob(batchJobGuid);
 
 		assertThrows(ProjectionServiceException.class, () -> service.cancelProjection(projectionEntity));
 
-		verify(repository, times(1)).findByProjectionGUID(projectionGuid);
-		verify(batchClient, times(1)).stopBatchJobByProjection(projectionGuid);
+		verify(repository, times(1)).listByProjectionGUID(projectionGuid);
+		verify(batchClient, times(1)).stopBatchJob(batchJobGuid);
+		verify(batchClient, never()).stopBatchJobByProjection(any());
 		verify(repository, never()).delete(any());
 		verifyNoMoreInteractions(batchClient, repository, assembler);
 	}
@@ -333,5 +373,12 @@ class ProjectionBatchMappingServiceTest {
 				ProjectionServiceException.class,
 				() -> service.updateFailureDetails(projectionEntity, null, null, "Projection failed")
 		);
+	}
+
+	private ProjectionBatchMappingEntity batchMappingEntity(ProjectionEntity projectionEntity, UUID batchJobGuid) {
+		ProjectionBatchMappingEntity mappingEntity = new ProjectionBatchMappingEntity();
+		mappingEntity.setProjection(projectionEntity);
+		mappingEntity.setBatchJobGUID(batchJobGuid);
+		return mappingEntity;
 	}
 }


### PR DESCRIPTION
Fix situation in which batch has multiple batch mappings when trying to cancel
Mae batch mapping cancelation more robust