### PR TITLE
Feature/VDYP-898: Cache COMS bucket id on FileSet to avoid repeated lookups

### DIFF
--- a/backend/src/main/java/ca/bc/gov/nrs/vdyp/backend/data/entities/ProjectionFileSetEntity.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/vdyp/backend/data/entities/ProjectionFileSetEntity.java
@@ -30,6 +30,9 @@ public class ProjectionFileSetEntity extends AuditableEntity {
 	@Column(name = "file_set_name", length = 4000)
 	private String fileSetName;
 
+	@Column(name = "coms_bucket_id")
+	private String comsBucketId;
+
 	public UUID getProjectionFileSetGUID() {
 		return projectionFileSetGUID;
 	}
@@ -46,6 +49,10 @@ public class ProjectionFileSetEntity extends AuditableEntity {
 		return ownerUser;
 	}
 
+	public String getComsBucketId() {
+		return comsBucketId;
+	}
+
 	public void setProjectionFileSetGUID(UUID projectionFileSetGUID) {
 		this.projectionFileSetGUID = projectionFileSetGUID;
 	}
@@ -60,6 +67,10 @@ public class ProjectionFileSetEntity extends AuditableEntity {
 
 	public void setOwnerUser(VDYPUserEntity ownerUser) {
 		this.ownerUser = ownerUser;
+	}
+
+	public void setComsBucketId(String comsBucketId) {
+		this.comsBucketId = comsBucketId;
 	}
 
 }

--- a/backend/src/main/java/ca/bc/gov/nrs/vdyp/backend/services/ProjectionFileSetService.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/vdyp/backend/services/ProjectionFileSetService.java
@@ -81,16 +81,22 @@ public class ProjectionFileSetService {
 		saveEntity.setOwnerUser(em.find(VDYPUserEntity.class, UUID.fromString(actingUser.getVdypUserGUID())));
 		saveEntity.setFileSetTypeCode(lookup.requireEntity(typeCodeModel.getCode()));
 		repository.persist(saveEntity);
+
+		// Create the COMS bucket up front and cache its id, so later file adds/deletes never need to look it up.
+		saveEntity.setComsBucketId(createCOMSBucket(saveEntity.getProjectionFileSetGUID()));
+
 		return assembler.toModel(saveEntity);
 	}
 
 	@Transactional
 	public void deleteFileSetById(UUID polygonFileSetGuid) throws ProjectionServiceException {
+		var entity = getProjectionFileSetEntity(polygonFileSetGuid);
+
 		// delete the files
 		fileMappingService.deleteFilesForSet(polygonFileSetGuid);
 
 		// delete the bucket in COMS
-		String bucketID = getCOMSBucketGUID(polygonFileSetGuid, false);
+		String bucketID = resolveBucketId(entity, false);
 		if (bucketID != null) {
 			comsClient.deleteBucket(bucketID, true); // recursive because we have should have already deleted the files
 		}
@@ -120,6 +126,7 @@ public class ProjectionFileSetService {
 		}
 	}
 
+	@Transactional
 	public FileMappingModel addNewFileToFileSet(UUID fileSetGUID, VDYPUserModel user, FileUpload file)
 			throws ProjectionServiceException {
 		// Check that the file set exists
@@ -127,7 +134,7 @@ public class ProjectionFileSetService {
 
 		ensureAuthorizedAccess(entity, user);
 
-		String bucketID = getCOMSBucketGUID(fileSetGUID, true);
+		String bucketID = resolveBucketId(entity, true);
 
 		// Ask File Mapping Service to create the file based on the meta data
 		return fileMappingService.createNewFile(bucketID, entity, file);
@@ -138,7 +145,7 @@ public class ProjectionFileSetService {
 	public FileMappingModel startFileSetFileUpload(UUID fileSetGUID, String filename)
 			throws ProjectionServiceException {
 		var entity = getProjectionFileSetEntity(fileSetGUID);
-		String bucketID = getCOMSBucketGUID(fileSetGUID, true);
+		String bucketID = resolveBucketId(entity, true);
 		return fileMappingService.createPlaceholderFile(bucketID, entity, filename);
 	}
 
@@ -146,16 +153,35 @@ public class ProjectionFileSetService {
 		return String.format("vdyp/fileset/%s", fileSetGUID);
 	}
 
-	private String getCOMSBucketGUID(UUID fileSetGUID, boolean createIfNotExist) {
+	private String createCOMSBucket(UUID fileSetGUID) {
 		String filePrefix = getBucketPrefix(fileSetGUID);
+		COMSCreateBucketRequest request = buildCreateBucketRequest(fileSetGUID, filePrefix);
+		return comsClient.createBucket(request).bucketId();
+	}
+
+	/**
+	 * Returns the fileset's COMS bucket id, preferring the cached value on the entity. Only filesets created before the
+	 * bucket id was cached (or where creation failed to persist it) fall back to a COMS lookup, whose result is then
+	 * cached on the entity for next time.
+	 */
+	private String resolveBucketId(ProjectionFileSetEntity entity, boolean createIfNotExist) {
+		if (entity.getComsBucketId() != null) {
+			return entity.getComsBucketId();
+		}
+
+		String filePrefix = getBucketPrefix(entity.getProjectionFileSetGUID());
 		List<COMSBucket> searchResponse = comsClient.searchForBucket(null, true, filePrefix, null);
 		String bucketGUID = null;
 		if (!searchResponse.isEmpty()) {
 			bucketGUID = searchResponse.get(0).bucketId();
 		} else if (createIfNotExist) {
-			COMSCreateBucketRequest request = buildCreateBucketRequest(fileSetGUID, filePrefix);
+			COMSCreateBucketRequest request = buildCreateBucketRequest(entity.getProjectionFileSetGUID(), filePrefix);
 			COMSBucket createBucketResponse = comsClient.createBucket(request);
 			bucketGUID = createBucketResponse.bucketId();
+		}
+
+		if (bucketGUID != null) {
+			entity.setComsBucketId(bucketGUID);
 		}
 		return bucketGUID;
 	}
@@ -219,11 +245,12 @@ public class ProjectionFileSetService {
 		return fileMappingService.getFilesForFileSet(fileSetGUID, download);
 	}
 
+	@Transactional
 	public void duplicateFilesFromTo(ProjectionFileSetEntity fromFileSet, ProjectionFileSetEntity toFileSet)
 			throws ProjectionServiceException {
 		List<FileMappingModel> filesToDuplicate = fileMappingService
 				.getFilesForFileSet(fromFileSet.getProjectionFileSetGUID(), true);
-		String bucketID = getCOMSBucketGUID(toFileSet.getProjectionFileSetGUID(), true);
+		String bucketID = resolveBucketId(toFileSet, true);
 		for (FileMappingModel file : filesToDuplicate) {
 			fileMappingService.duplicateFile(file, toFileSet, bucketID);
 		}

--- a/backend/src/test/java/ca/bc/gov/nrs/vdyp/backend/services/ProjectionFileSetServiceTest.java
+++ b/backend/src/test/java/ca/bc/gov/nrs/vdyp/backend/services/ProjectionFileSetServiceTest.java
@@ -142,6 +142,9 @@ class ProjectionFileSetServiceTest {
 			return null;
 		}).when(repository).persist(any(ProjectionFileSetEntity.class));
 
+		COMSBucket bucket = new COMSBucket("bucket", "bucket-name", "coms-bucket-id", "region", "endpoint", "key");
+		when(comsClient.createBucket(any())).thenReturn(bucket);
+
 		ProjectionFileSetModel result = service
 				.createEmptyFileSet(fileSetTypeCodeModel(FileSetTypeCodeModel.POLYGON), actingUser);
 
@@ -156,6 +159,9 @@ class ProjectionFileSetServiceTest {
 		assertThat(persisted.getOwnerUser()).isSameAs(ownerEntity);
 		assertThat(persisted.getFileSetTypeCode()).isSameAs(typeEntity);
 
+		assertThat(persisted.getComsBucketId()).isEqualTo("coms-bucket-id");
+		verify(comsClient).createBucket(any());
+
 		verify(em).find(VDYPUserEntity.class, ownerId);
 		verify(fileSetTypeCodeLookup).requireEntity(FileSetTypeCodeModel.POLYGON);
 	}
@@ -165,16 +171,35 @@ class ProjectionFileSetServiceTest {
 	// ------------------------------------------------------------
 
 	@Test
-	void deleteFileSetById_deletesById() throws ProjectionServiceException {
+	void deleteFileSetById_usesCachedBucketId_deletesById() throws ProjectionServiceException {
 		UUID id = UUID.randomUUID();
+		var entity = fileSetEntity(id);
+		entity.setComsBucketId("coms-bucket-id");
 
+		when(repository.findByIdOptional(id)).thenReturn(Optional.of(entity));
+
+		service.deleteFileSetById(id);
+
+		verify(repository).findByIdOptional(id);
+		verify(repository).deleteById(id);
+		verifyNoMoreInteractions(repository);
+		verify(comsClient).deleteBucket("coms-bucket-id", true);
+		verify(comsClient, never()).searchForBucket(any(), any(), any(), any());
+	}
+
+	@Test
+	void deleteFileSetById_legacyFileSetWithoutCachedBucketId_fallsBackToCOMSLookup()
+			throws ProjectionServiceException {
+		UUID id = UUID.randomUUID();
+		var entity = fileSetEntity(id);
+
+		when(repository.findByIdOptional(id)).thenReturn(Optional.of(entity));
 		COMSBucket bucket = new COMSBucket("bucket", "bucket-name", "coms-bucket-id", "region", "endpoint", "key");
 		when(comsClient.searchForBucket(any(), any(), any(), any())).thenReturn(List.of(bucket));
 
 		service.deleteFileSetById(id);
 
 		verify(repository).deleteById(id);
-		verifyNoMoreInteractions(repository);
 		verify(comsClient).deleteBucket("coms-bucket-id", true);
 	}
 
@@ -260,6 +285,27 @@ class ProjectionFileSetServiceTest {
 
 		service.addNewFileToFileSet(fileSetGuid, actingUser, null);
 		verify(fileMappingService).createNewFile("coms-bucket-id", entity, null);
+		verify(comsClient, never()).createBucket(any());
+	}
+
+	@Test
+	void addFileToSet_validUser_usesCachedBucketId_skipsCOMSLookup() throws Exception {
+		UUID fileSetGuid = UUID.randomUUID();
+		UUID ownerId = UUID.randomUUID();
+		var entity = fileSetEntity(fileSetGuid, ownerId);
+		entity.setComsBucketId("coms-bucket-id");
+		VDYPUserModel actingUser = new VDYPUserModel();
+		actingUser.setVdypUserGUID(ownerId.toString());
+
+		when(repository.findByIdOptional(fileSetGuid)).thenReturn(Optional.of(entity));
+
+		FileMappingModel fakeResult = new FileMappingModel();
+		when(fileMappingService.createNewFile("coms-bucket-id", entity, null)).thenReturn(fakeResult);
+
+		service.addNewFileToFileSet(fileSetGuid, actingUser, null);
+
+		verify(fileMappingService).createNewFile("coms-bucket-id", entity, null);
+		verify(comsClient, never()).searchForBucket(any(), any(), any(), any());
 		verify(comsClient, never()).createBucket(any());
 	}
 

--- a/db/liquibase/scripts/01_00_14/00/ddl/tables/app-vdyp.projection_file_set.sql
+++ b/db/liquibase/scripts/01_00_14/00/ddl/tables/app-vdyp.projection_file_set.sql
@@ -1,0 +1,7 @@
+ALTER TABLE "app-vdyp"."projection_file_set"
+	ADD COLUMN "coms_bucket_id" varchar(255) NULL
+;
+
+COMMENT ON COLUMN "app-vdyp"."projection_file_set"."coms_bucket_id"
+	IS 'COMS Bucket Id is the cached identifier of the COMS bucket backing this file set, avoiding a COMS lookup on every file add/delete'
+;

--- a/db/liquibase/vdyp-changelog.json
+++ b/db/liquibase/vdyp-changelog.json
@@ -655,6 +655,32 @@
           }
         ]
       }
+    },
+    {
+      "changeSet": {
+        "id": "01_00_14_00",
+        "author": "rjeong",
+        "changes": [
+          {
+            "tagDatabase": {
+              "tag": "version_01_00_14_00"
+            }
+          },
+          {
+            "sqlFile": {
+              "dbms": "postgresql",
+              "endDelimiter": ";",
+              "path": "scripts/01_00_14/00/ddl/tables/app-vdyp.projection_file_set.sql",
+              "relativeToChangelogFile": true
+            }
+          }
+        ],
+        "rollback": [
+          {
+            "sql": "ALTER TABLE \"app-vdyp\".\"projection_file_set\" DROP COLUMN IF EXISTS \"coms_bucket_id\""
+          }
+        ]
+      }
     }
   ]
 }


### PR DESCRIPTION
- FileSet now creates its COMS bucket eagerly when the FileSet is created, instead of on first file add
- The bucket id is cached on the 'projection_file_set' table ('coms_bucket_id', nullable) so file add/delete/duplicate operations read it directly instead of calling COMS's searchForBucket every time
- Existing FileSets without a cached id fall back to the old lookup-and-cache behavior