### PR TITLE
VDYP-1262: Allow admin role to bypass ownership check for view/cancel

### DIFF
--- a/backend/src/main/java/ca/bc/gov/nrs/vdyp/backend/data/models/UserTypeCodeModel.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/vdyp/backend/data/models/UserTypeCodeModel.java
@@ -29,4 +29,8 @@ public class UserTypeCodeModel extends CodeTableModel {
 		return SYSTEM.equalsIgnoreCase(this.userTypeCode);
 	}
 
+	public boolean isAdmin() {
+		return ADMIN.equalsIgnoreCase(this.userTypeCode);
+	}
+
 }

--- a/backend/src/main/java/ca/bc/gov/nrs/vdyp/backend/data/models/VDYPUserModel.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/vdyp/backend/data/models/VDYPUserModel.java
@@ -88,4 +88,8 @@ public class VDYPUserModel {
 	public boolean isSystemUser() {
 		return this.userTypeCode != null && userTypeCode.isSystemUser();
 	}
+
+	public boolean isAdmin() {
+		return this.userTypeCode != null && userTypeCode.isAdmin();
+	}
 }

--- a/backend/src/main/java/ca/bc/gov/nrs/vdyp/backend/services/ProjectionService.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/vdyp/backend/services/ProjectionService.java
@@ -629,7 +629,12 @@ public class ProjectionService {
 			return;
 		UUID vdypUserGuid = UUID.fromString(actingUser.getVdypUserGUID());
 		switch (action) {
-		case READ, UPDATE, DELETE, CANCEL:
+		case READ, CANCEL:
+			if (!actingUser.isAdmin() && !entity.getOwnerUser().getVdypUserGUID().equals(vdypUserGuid)) {
+				throw new ProjectionUnauthorizedException(entity.getProjectionGUID(), vdypUserGuid);
+			}
+			break;
+		case UPDATE, DELETE:
 			if (!entity.getOwnerUser().getVdypUserGUID().equals(vdypUserGuid)) {
 				throw new ProjectionUnauthorizedException(entity.getProjectionGUID(), vdypUserGuid);
 			}

--- a/backend/src/test/java/ca/bc/gov/nrs/vdyp/backend/services/ProjectionServiceTest.java
+++ b/backend/src/test/java/ca/bc/gov/nrs/vdyp/backend/services/ProjectionServiceTest.java
@@ -381,6 +381,41 @@ class ProjectionServiceTest {
 		);
 	}
 
+	@Test
+	void checkUserCanPerformAction_allowsAdmin_toViewAndCancelOthersProjection() {
+		UUID ownerId = UUID.randomUUID();
+		UUID adminId = UUID.randomUUID();
+		ProjectionEntity entity = projectionEntity(UUID.randomUUID(), ownerId);
+		VDYPUserModel adminUser = user(adminId);
+		UserTypeCodeModel adminUserType = new UserTypeCodeModel();
+		adminUserType.setCode(UserTypeCodeModel.ADMIN);
+		adminUser.setUserTypeCode(adminUserType);
+
+		assertDoesNotThrow(
+				() -> service.checkUserCanPerformAction(entity, adminUser, ProjectionService.ProjectionAction.READ)
+		);
+		assertDoesNotThrow(
+				() -> service.checkUserCanPerformAction(entity, adminUser, ProjectionService.ProjectionAction.CANCEL)
+		);
+	}
+
+	@Test
+	void checkUserCanPerformAction_throwsUnauthorized_whenNonAdminAccessesOthersProjection() {
+		UUID ownerId = UUID.randomUUID();
+		UUID otherUserId = UUID.randomUUID();
+		ProjectionEntity entity = projectionEntity(UUID.randomUUID(), ownerId);
+		VDYPUserModel actingUser = user(otherUserId);
+
+		assertThrows(
+				ProjectionUnauthorizedException.class,
+				() -> service.checkUserCanPerformAction(entity, actingUser, ProjectionService.ProjectionAction.READ)
+		);
+		assertThrows(
+				ProjectionUnauthorizedException.class,
+				() -> service.checkUserCanPerformAction(entity, actingUser, ProjectionService.ProjectionAction.CANCEL)
+		);
+	}
+
 	// ==========================================================
 	// checkProjectionStatusPermitsAction
 	// ==========================================================


### PR DESCRIPTION
- checkUserCanPerformAction now skips the ownership check for READ and CANCEL actions when the acting user has the ADMIN role, so admins can view/cancel projections owned by other users.