### PR TITLE
Feature/VDYP-1264: Add identity provider (IDIR/BCeID) tracking to VDYP_User

### DIFF
--- a/backend/src/main/java/ca/bc/gov/nrs/vdyp/backend/data/assemblers/IdentityProviderCodeResourceAssembler.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/vdyp/backend/data/assemblers/IdentityProviderCodeResourceAssembler.java
@@ -1,0 +1,15 @@
+package ca.bc.gov.nrs.vdyp.backend.data.assemblers;
+
+import ca.bc.gov.nrs.vdyp.backend.data.entities.IdentityProviderCodeEntity;
+import ca.bc.gov.nrs.vdyp.backend.data.models.IdentityProviderCodeModel;
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
+public class IdentityProviderCodeResourceAssembler
+		extends CodeTableResourceAssembler<IdentityProviderCodeEntity, IdentityProviderCodeModel> {
+
+	public IdentityProviderCodeResourceAssembler() {
+		super(IdentityProviderCodeEntity::new, IdentityProviderCodeModel::new);
+	}
+
+}

--- a/backend/src/main/java/ca/bc/gov/nrs/vdyp/backend/data/assemblers/VDYPUserResourceAssembler.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/vdyp/backend/data/assemblers/VDYPUserResourceAssembler.java
@@ -10,9 +10,11 @@ import jakarta.enterprise.context.ApplicationScoped;
 public class VDYPUserResourceAssembler {
 
 	UserTypeCodeResourceAssembler utra;
+	IdentityProviderCodeResourceAssembler ipcra;
 
 	public VDYPUserResourceAssembler() {
 		utra = new UserTypeCodeResourceAssembler();
+		ipcra = new IdentityProviderCodeResourceAssembler();
 	}
 
 	public VDYPUserEntity toEntity(VDYPUserModel model) {
@@ -24,6 +26,7 @@ public class VDYPUserResourceAssembler {
 		entity.setVdypUserGUID(model.getVdypUserGUID() == null ? null : UUID.fromString(model.getVdypUserGUID()));
 		entity.setOidcGUID(model.getOidcGUID());
 		entity.setUserTypeCode(utra.toEntity(model.getUserTypeCode()));
+		entity.setIdentityProviderCode(ipcra.toEntity(model.getIdentityProviderCode()));
 		entity.setFirstName(model.getFirstName());
 		entity.setLastName(model.getLastName());
 		entity.setDisplayName(model.getDisplayName());
@@ -40,6 +43,7 @@ public class VDYPUserResourceAssembler {
 		model.setVdypUserGUID(entity.getVdypUserGUID() == null ? null : entity.getVdypUserGUID().toString());
 		model.setOidcGUID(entity.getOidcGUID());
 		model.setUserTypeCode(utra.toModel(entity.getUserTypeCode()));
+		model.setIdentityProviderCode(ipcra.toModel(entity.getIdentityProviderCode()));
 		model.setFirstName(entity.getFirstName());
 		model.setLastName(entity.getLastName());
 		model.setDisplayName(entity.getDisplayName());

--- a/backend/src/main/java/ca/bc/gov/nrs/vdyp/backend/data/entities/IdentityProviderCodeEntity.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/vdyp/backend/data/entities/IdentityProviderCodeEntity.java
@@ -1,0 +1,22 @@
+package ca.bc.gov.nrs.vdyp.backend.data.entities;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "identity_provider_code")
+public class IdentityProviderCodeEntity extends CodeTableEntity {
+	@Id
+	@Column(name = "identity_provider_code", length = 10, nullable = false)
+	private String identityProviderCode;
+
+	public String getCode() {
+		return identityProviderCode;
+	}
+
+	public void setCode(String code) {
+		this.identityProviderCode = code;
+	}
+}

--- a/backend/src/main/java/ca/bc/gov/nrs/vdyp/backend/data/entities/VDYPUserEntity.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/vdyp/backend/data/entities/VDYPUserEntity.java
@@ -31,6 +31,12 @@ public class VDYPUserEntity extends AuditableEntity {
 	@JoinColumn(name = "user_type_code", referencedColumnName = "user_type_code", nullable = false, updatable = true)
 	private UserTypeCodeEntity userTypeCode;
 
+	@ManyToOne
+	@JoinColumn(
+			name = "identity_provider_code", referencedColumnName = "identity_provider_code", nullable = true, updatable = true
+	)
+	private IdentityProviderCodeEntity identityProviderCode;
+
 	@Column(name = "first_name", length = 50)
 	private String firstName;
 
@@ -53,6 +59,10 @@ public class VDYPUserEntity extends AuditableEntity {
 
 	public UserTypeCodeEntity getUserTypeCode() {
 		return userTypeCode;
+	}
+
+	public IdentityProviderCodeEntity getIdentityProviderCode() {
+		return identityProviderCode;
 	}
 
 	public String getFirstName() {
@@ -81,6 +91,10 @@ public class VDYPUserEntity extends AuditableEntity {
 
 	public void setUserTypeCode(UserTypeCodeEntity userTypeCode) {
 		this.userTypeCode = userTypeCode;
+	}
+
+	public void setIdentityProviderCode(IdentityProviderCodeEntity identityProviderCode) {
+		this.identityProviderCode = identityProviderCode;
 	}
 
 	public void setFirstName(String firstName) {

--- a/backend/src/main/java/ca/bc/gov/nrs/vdyp/backend/data/models/IdentityProviderCodeModel.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/vdyp/backend/data/models/IdentityProviderCodeModel.java
@@ -1,0 +1,26 @@
+package ca.bc.gov.nrs.vdyp.backend.data.models;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+/**
+ * Model layer object to represent an Identity Provider Code. Equality and hashCode are fully defined in the parent
+ * class {@link CodeTableModel}. (explicitly calling the abstract getCode() method for the sake of comparison
+ */
+@SuppressWarnings("squid:S2160")
+
+@RegisterForReflection
+public class IdentityProviderCodeModel extends CodeTableModel {
+	public static final String IDIR = "IDIR";
+	public static final String BCEID = "BCEID";
+	private String identityProviderCode;
+
+	@Override
+	public String getCode() {
+		return identityProviderCode;
+	}
+
+	@Override
+	public void setCode(String code) {
+		this.identityProviderCode = code;
+	}
+}

--- a/backend/src/main/java/ca/bc/gov/nrs/vdyp/backend/data/models/VDYPUserModel.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/vdyp/backend/data/models/VDYPUserModel.java
@@ -9,6 +9,7 @@ public class VDYPUserModel {
 	private String vdypUserGUID;
 	private String oidcGUID;
 	private UserTypeCodeModel userTypeCode;
+	private IdentityProviderCodeModel identityProviderCode;
 	private String firstName;
 	private String lastName;
 	private String displayName;
@@ -24,6 +25,10 @@ public class VDYPUserModel {
 
 	public UserTypeCodeModel getUserTypeCode() {
 		return userTypeCode;
+	}
+
+	public IdentityProviderCodeModel getIdentityProviderCode() {
+		return identityProviderCode;
 	}
 
 	public String getFirstName() {
@@ -52,6 +57,10 @@ public class VDYPUserModel {
 
 	public void setUserTypeCode(UserTypeCodeModel userTypeCode) {
 		this.userTypeCode = userTypeCode;
+	}
+
+	public void setIdentityProviderCode(IdentityProviderCodeModel identityProviderCode) {
+		this.identityProviderCode = identityProviderCode;
 	}
 
 	public void setFirstName(String firstName) {

--- a/backend/src/main/java/ca/bc/gov/nrs/vdyp/backend/data/repositories/IdentityProviderCodeRepository.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/vdyp/backend/data/repositories/IdentityProviderCodeRepository.java
@@ -1,0 +1,10 @@
+package ca.bc.gov.nrs.vdyp.backend.data.repositories;
+
+import ca.bc.gov.nrs.vdyp.backend.data.entities.IdentityProviderCodeEntity;
+import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class IdentityProviderCodeRepository implements PanacheRepositoryBase<IdentityProviderCodeEntity, String> {
+
+}

--- a/backend/src/main/java/ca/bc/gov/nrs/vdyp/backend/services/IdentityProviderCodeLookup.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/vdyp/backend/services/IdentityProviderCodeLookup.java
@@ -1,0 +1,66 @@
+package ca.bc.gov.nrs.vdyp.backend.services;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ca.bc.gov.nrs.vdyp.backend.data.assemblers.IdentityProviderCodeResourceAssembler;
+import ca.bc.gov.nrs.vdyp.backend.data.entities.IdentityProviderCodeEntity;
+import ca.bc.gov.nrs.vdyp.backend.data.models.IdentityProviderCodeModel;
+import ca.bc.gov.nrs.vdyp.backend.data.repositories.IdentityProviderCodeRepository;
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class IdentityProviderCodeLookup
+		extends AbstractCodeTableLookup<IdentityProviderCodeModel, IdentityProviderCodeEntity> {
+
+	private static final Logger logger = LoggerFactory.getLogger(IdentityProviderCodeLookup.class);
+	IdentityProviderCodeRepository repository;
+	IdentityProviderCodeResourceAssembler assembler;
+
+	private Map<String, String> mapClaimValueToIdentityProviderCode;
+
+	public IdentityProviderCodeLookup(
+			IdentityProviderCodeRepository repository, IdentityProviderCodeResourceAssembler assembler
+	) {
+		this.repository = repository;
+		this.assembler = assembler;
+		ensureClaimValueMap();
+	}
+
+	private void ensureClaimValueMap() {
+		mapClaimValueToIdentityProviderCode = new HashMap<>();
+		mapClaimValueToIdentityProviderCode.put("AZUREIDIR", IdentityProviderCodeModel.IDIR);
+		mapClaimValueToIdentityProviderCode.put("BCEIDBUSINESS", IdentityProviderCodeModel.BCEID);
+	}
+
+	@Override
+	protected Stream<IdentityProviderCodeModel> loadAllModels() {
+		return repository.listAll().stream().map(assembler::toModel);
+	}
+
+	@Override
+	protected Stream<IdentityProviderCodeEntity> loadAllEntities() {
+		return repository.listAll().stream();
+	}
+
+	/**
+	 * Maps a JWT {@code identity_provider} claim value (e.g. {@code azureidir}, {@code bceidbusiness}) to the
+	 * corresponding {@link IdentityProviderCodeModel}.
+	 *
+	 * @param identityProviderClaim the raw claim value from the JWT, may be null
+	 *
+	 * @return the matching model, or empty if the claim is null or unrecognized
+	 */
+	public Optional<IdentityProviderCodeModel> getIdentityProviderCodeFromClaim(String identityProviderClaim) {
+		if (identityProviderClaim == null) {
+			logger.debug("No identity_provider claim found");
+			return Optional.empty();
+		}
+		return findModel(mapClaimValueToIdentityProviderCode.getOrDefault(normalize(identityProviderClaim), ""));
+	}
+}

--- a/backend/src/main/java/ca/bc/gov/nrs/vdyp/backend/services/VDYPUserService.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/vdyp/backend/services/VDYPUserService.java
@@ -13,6 +13,7 @@ import org.slf4j.LoggerFactory;
 
 import ca.bc.gov.nrs.vdyp.backend.data.assemblers.VDYPUserResourceAssembler;
 import ca.bc.gov.nrs.vdyp.backend.data.entities.VDYPUserEntity;
+import ca.bc.gov.nrs.vdyp.backend.data.models.IdentityProviderCodeModel;
 import ca.bc.gov.nrs.vdyp.backend.data.models.UserTypeCodeModel;
 import ca.bc.gov.nrs.vdyp.backend.data.models.VDYPUserModel;
 import ca.bc.gov.nrs.vdyp.backend.data.repositories.VDYPUserRepository;
@@ -27,15 +28,18 @@ public class VDYPUserService {
 	private final VDYPUserRepository userRepository;
 	private final VDYPUserResourceAssembler assembler;
 	private final UserTypeCodeLookup userTypeLookup;
+	private final IdentityProviderCodeLookup identityProviderLookup;
 
 	private VDYPUserModel systemUserCache = null;
 
 	public VDYPUserService(
-			VDYPUserRepository userRepository, VDYPUserResourceAssembler assembler, UserTypeCodeLookup userTypeLookup
+			VDYPUserRepository userRepository, VDYPUserResourceAssembler assembler, UserTypeCodeLookup userTypeLookup,
+			IdentityProviderCodeLookup identityProviderLookup
 	) {
 		this.userRepository = userRepository;
 		this.assembler = assembler;
 		this.userTypeLookup = userTypeLookup;
+		this.identityProviderLookup = identityProviderLookup;
 
 	}
 
@@ -83,6 +87,10 @@ public class VDYPUserService {
 		if (identityToken instanceof JsonWebToken jwt) {
 			String oidcId = jwt.getName();
 			logger.debug("Checking for user with oidcId {}", oidcId);
+			String identityProviderClaim = jwt.getClaim("identity_provider");
+			IdentityProviderCodeModel identityProviderCode = identityProviderLookup
+					.getIdentityProviderCodeFromClaim(identityProviderClaim).orElse(null);
+
 			Optional<VDYPUserEntity> userOption = userRepository.findByOIDC(oidcId);
 			if (userOption.isEmpty()) {
 				Set<String> roles = identity.getRoles();
@@ -104,6 +112,7 @@ public class VDYPUserService {
 					newUser.setLastName(lastName);
 					newUser.setDisplayName(displayName);
 					newUser.setEmail(email);
+					newUser.setIdentityProviderCode(identityProviderCode);
 
 					logger.debug(
 							"Creating new user with oidcId {}, firstName {}, lastName {}, usertypeCode {}", oidcId,
@@ -115,7 +124,12 @@ public class VDYPUserService {
 					return getSystemUser();
 				}
 			}
-			return assembler.toModel(userOption.get());
+			VDYPUserEntity existingUser = userOption.get();
+			if (identityProviderCode != null) {
+				existingUser
+						.setIdentityProviderCode(identityProviderLookup.requireEntity(identityProviderCode.getCode()));
+			}
+			return assembler.toModel(existingUser);
 		} else {
 			return null;
 		}

--- a/backend/src/test/java/ca/bc/gov/nrs/vdyp/backend/services/IdentityProviderCodeLookupTest.java
+++ b/backend/src/test/java/ca/bc/gov/nrs/vdyp/backend/services/IdentityProviderCodeLookupTest.java
@@ -1,0 +1,67 @@
+package ca.bc.gov.nrs.vdyp.backend.services;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mockito;
+
+import ca.bc.gov.nrs.vdyp.backend.data.assemblers.IdentityProviderCodeResourceAssembler;
+import ca.bc.gov.nrs.vdyp.backend.data.entities.IdentityProviderCodeEntity;
+import ca.bc.gov.nrs.vdyp.backend.data.models.IdentityProviderCodeModel;
+import ca.bc.gov.nrs.vdyp.backend.data.repositories.IdentityProviderCodeRepository;
+
+class IdentityProviderCodeLookupTest {
+	IdentityProviderCodeRepository repository;
+
+	IdentityProviderCodeResourceAssembler assembler;
+
+	IdentityProviderCodeLookup lookup;
+
+	IdentityProviderCodeEntity idir = new IdentityProviderCodeEntity();
+	IdentityProviderCodeEntity bceid = new IdentityProviderCodeEntity();
+
+	@BeforeEach
+	void setup() {
+		repository = Mockito.mock(IdentityProviderCodeRepository.class);
+		assembler = new IdentityProviderCodeResourceAssembler();
+
+		idir.setCode(IdentityProviderCodeModel.IDIR);
+		idir.setDisplayOrder(BigDecimal.ONE);
+		bceid.setCode(IdentityProviderCodeModel.BCEID);
+		bceid.setDisplayOrder(BigDecimal.TEN);
+
+		when(repository.listAll()).thenReturn(List.of(idir, bceid));
+		lookup = new IdentityProviderCodeLookup(repository, assembler);
+		lookup.init();
+	}
+
+	static List<Arguments> claimAndExpectedCode() {
+		return List.of(
+				Arguments.of("azureidir", "IDIR"), //
+				Arguments.of("AzureIDIR", "IDIR"), //
+				Arguments.of("bceidbusiness", "BCEID"), //
+				Arguments.of("BCeIDBusiness", "BCEID"), //
+				Arguments.of("unknown-idp", null), //
+				Arguments.of((String) null, null)
+		);
+	}
+
+	@ParameterizedTest
+	@MethodSource("claimAndExpectedCode")
+	void test_getIdentityProviderCodeFromClaim(String claim, String expectedCode) {
+		var result = lookup.getIdentityProviderCodeFromClaim(claim);
+		if (expectedCode == null) {
+			Assertions.assertTrue(result.isEmpty());
+		} else {
+			assertThat(result.get().getCode()).isEqualTo(expectedCode);
+		}
+	}
+}

--- a/backend/src/test/java/ca/bc/gov/nrs/vdyp/backend/services/VDYPUserServiceTest.java
+++ b/backend/src/test/java/ca/bc/gov/nrs/vdyp/backend/services/VDYPUserServiceTest.java
@@ -24,7 +24,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import ca.bc.gov.nrs.vdyp.backend.data.assemblers.VDYPUserResourceAssembler;
+import ca.bc.gov.nrs.vdyp.backend.data.entities.IdentityProviderCodeEntity;
 import ca.bc.gov.nrs.vdyp.backend.data.entities.VDYPUserEntity;
+import ca.bc.gov.nrs.vdyp.backend.data.models.IdentityProviderCodeModel;
 import ca.bc.gov.nrs.vdyp.backend.data.models.UserTypeCodeModel;
 import ca.bc.gov.nrs.vdyp.backend.data.models.VDYPUserModel;
 import ca.bc.gov.nrs.vdyp.backend.data.repositories.VDYPUserRepository;
@@ -42,6 +44,9 @@ class VDYPUserServiceTest {
 	UserTypeCodeLookup userTypeLookup;
 
 	@Mock
+	IdentityProviderCodeLookup identityProviderLookup;
+
+	@Mock
 	SecurityIdentity identity;
 
 	@Mock
@@ -52,7 +57,7 @@ class VDYPUserServiceTest {
 	@BeforeEach
 	void setUp() {
 		assembler = new VDYPUserResourceAssembler();
-		service = new VDYPUserService(userRepository, assembler, userTypeLookup) {
+		service = new VDYPUserService(userRepository, assembler, userTypeLookup, identityProviderLookup) {
 
 		};
 	}
@@ -131,6 +136,7 @@ class VDYPUserServiceTest {
 		when(jwt.getName()).thenReturn("1234567890@fakeid");
 		when(jwt.getClaim("given_name")).thenReturn("Russell");
 		when(jwt.getClaim("family_name")).thenReturn("Wilson");
+		when(jwt.getClaim("identity_provider")).thenReturn(null);
 
 		// no existing user
 		when(userRepository.findByOIDC("1234567890@fakeid")).thenReturn(Optional.empty());
@@ -152,6 +158,61 @@ class VDYPUserServiceTest {
 		assertThat(result.getFirstName()).isEqualTo("Russell");
 		assertThat(result.getLastName()).isEqualTo("Wilson");
 		assertThat(result.getUserTypeCode()).isEqualTo(userTypeCode);
+	}
+
+	@Test
+	void ensureVDYPUserFromSecurityIdentity_createsNewUser_setsIdentityProviderCode() {
+		when(identity.isAnonymous()).thenReturn(false);
+		when(identity.getPrincipal()).thenReturn(jwt);
+		when(jwt.getName()).thenReturn("1234567890@fakeid");
+		when(jwt.getClaim("given_name")).thenReturn("Russell");
+		when(jwt.getClaim("family_name")).thenReturn("Wilson");
+		when(jwt.getClaim("identity_provider")).thenReturn("azureidir");
+
+		when(userRepository.findByOIDC("1234567890@fakeid")).thenReturn(Optional.empty());
+
+		Set<String> roles = Set.of("Admin");
+		when(identity.getRoles()).thenReturn(roles);
+
+		UserTypeCodeModel userTypeCode = new UserTypeCodeModel();
+		userTypeCode.setCode("ADMIN");
+		when(userTypeLookup.getUserTypeCodeFromExternalRoles(roles)).thenReturn(userTypeCode);
+
+		IdentityProviderCodeModel idpCode = new IdentityProviderCodeModel();
+		idpCode.setCode(IdentityProviderCodeModel.IDIR);
+		when(identityProviderLookup.getIdentityProviderCodeFromClaim("azureidir")).thenReturn(Optional.of(idpCode));
+
+		VDYPUserModel result = service.ensureVDYPUserFromSecurityIdentity(identity);
+
+		assertThat(result).isNotNull();
+		assertThat(result.getIdentityProviderCode()).isEqualTo(idpCode);
+	}
+
+	@Test
+	void ensureVDYPUserFromSecurityIdentity_updatesIdentityProviderCode_onExistingUser() {
+		when(identity.isAnonymous()).thenReturn(false);
+		when(identity.getPrincipal()).thenReturn(jwt);
+		when(jwt.getName()).thenReturn("1234567890@fakeid");
+		when(jwt.getClaim("identity_provider")).thenReturn("bceidbusiness");
+
+		VDYPUserEntity entity = new VDYPUserEntity();
+		UUID internalID = UUID.randomUUID();
+		entity.setVdypUserGUID(internalID);
+		when(userRepository.findByOIDC("1234567890@fakeid")).thenReturn(Optional.of(entity));
+
+		IdentityProviderCodeModel idpCode = new IdentityProviderCodeModel();
+		idpCode.setCode(IdentityProviderCodeModel.BCEID);
+		when(identityProviderLookup.getIdentityProviderCodeFromClaim("bceidbusiness"))
+				.thenReturn(Optional.of(idpCode));
+
+		IdentityProviderCodeEntity idpEntity = new IdentityProviderCodeEntity();
+		idpEntity.setCode(IdentityProviderCodeModel.BCEID);
+		when(identityProviderLookup.requireEntity(IdentityProviderCodeModel.BCEID)).thenReturn(idpEntity);
+
+		VDYPUserModel result = service.ensureVDYPUserFromSecurityIdentity(identity);
+
+		assertThat(result.getVdypUserGUID()).isEqualTo(internalID.toString());
+		assertThat(result.getIdentityProviderCode().getCode()).isEqualTo(IdentityProviderCodeModel.BCEID);
 	}
 
 	@Test

--- a/db/liquibase/scripts/01_00_15/00/ddl/tables/app-vdyp.identity_provider_code.sql
+++ b/db/liquibase/scripts/01_00_15/00/ddl/tables/app-vdyp.identity_provider_code.sql
@@ -1,0 +1,74 @@
+/* Drop Tables */
+
+DROP TABLE IF EXISTS "app-vdyp"."identity_provider_code" CASCADE
+;
+
+/* Create Tables */
+
+CREATE TABLE "app-vdyp"."identity_provider_code"
+(
+	"identity_provider_code" varchar(10) NOT NULL,    -- identity_provider_code: Identity Provider Code is a code representing the identity provider used to authenticate a user profile. Values are: - IDIR - BCeID
+	"description" varchar(200) NOT NULL,    -- DESCRIPTION is the display quality description of the code value.
+	"display_order" decimal(3) NULL,    -- DISPLAY ORDER is to allow non alphabetic sorting e.g. M T W Th F S S.
+	"effective_date" DATE NOT NULL   DEFAULT CURRENT_DATE,    -- EFFECTIVE_DATE is the date code value becomes effective.
+	"expiry_date" DATE NOT NULL   DEFAULT '9999-12-31',    -- EXPIRY_DATE is the date code value expires.
+	"revision_count" decimal(10) NOT NULL   DEFAULT 0,    -- REVISION_COUNT is the number of times that the row of data has been changed. The column is used for optimistic locking via application code.
+	"create_user" varchar(64) NOT NULL,    -- CREATE_USER is an audit column that indicates the user that created the record.
+	"create_date" TIMESTAMP NOT NULL   DEFAULT now(),    -- CREATE_DATE is the date and time the row of data was created.
+	"update_user" varchar(64) NOT NULL,    -- UPDATE_USER is an audit column that indicates the user that updated the record.
+	"update_date" TIMESTAMP NOT NULL   DEFAULT now()    -- UPDATE_DATE is the date and time the row of data was updated.
+)
+TABLESPACE	PG_DEFAULT
+;
+
+/* Create Primary Keys, Indexes, Uniques, Checks */
+
+ALTER TABLE "app-vdyp"."identity_provider_code" ADD CONSTRAINT "idpcode_pk"
+	PRIMARY KEY ("identity_provider_code")
+;
+
+/* Create Table Comments, Sequences for Autonumber Columns */
+
+COMMENT ON TABLE "app-vdyp"."identity_provider_code"
+	IS 'Identity Provider Code is a code representing the identity provider used to authenticate a user profile. Values are: - IDIR - BCeID'
+;
+
+COMMENT ON COLUMN "app-vdyp"."identity_provider_code"."identity_provider_code"
+	IS 'identity_provider_code: Identity Provider Code is a code representing the identity provider used to authenticate a user profile. Values are: - IDIR - BCeID'
+;
+
+COMMENT ON COLUMN "app-vdyp"."identity_provider_code"."description"
+	IS 'DESCRIPTION is the display quality description of the code value.'
+;
+
+COMMENT ON COLUMN "app-vdyp"."identity_provider_code"."display_order"
+	IS 'DISPLAY ORDER is to allow non alphabetic sorting e.g. M T W Th F S S.'
+;
+
+COMMENT ON COLUMN "app-vdyp"."identity_provider_code"."effective_date"
+	IS 'EFFECTIVE_DATE is the date code value becomes effective.'
+;
+
+COMMENT ON COLUMN "app-vdyp"."identity_provider_code"."expiry_date"
+	IS 'EXPIRY_DATE is the date code value expires.'
+;
+
+COMMENT ON COLUMN "app-vdyp"."identity_provider_code"."revision_count"
+	IS 'REVISION_COUNT is the number of times that the row of data has been changed. The column is used for optimistic locking via application code.'
+;
+
+COMMENT ON COLUMN "app-vdyp"."identity_provider_code"."create_user"
+	IS 'CREATE_USER is an audit column that indicates the user that created the record.'
+;
+
+COMMENT ON COLUMN "app-vdyp"."identity_provider_code"."create_date"
+	IS 'CREATE_DATE is the date and time the row of data was created.'
+;
+
+COMMENT ON COLUMN "app-vdyp"."identity_provider_code"."update_user"
+	IS 'UPDATE_USER is an audit column that indicates the user that updated the record.'
+;
+
+COMMENT ON COLUMN "app-vdyp"."identity_provider_code"."update_date"
+	IS 'UPDATE_DATE is the date and time the row of data was updated.'
+;

--- a/db/liquibase/scripts/01_00_15/00/ddl/tables/app-vdyp.vdyp_user.sql
+++ b/db/liquibase/scripts/01_00_15/00/ddl/tables/app-vdyp.vdyp_user.sql
@@ -1,0 +1,19 @@
+ALTER TABLE "app-vdyp"."vdyp_user"
+    ADD COLUMN IF NOT EXISTS "identity_provider_code" VARCHAR (10);
+
+CREATE INDEX "user_idpcode_idx" ON "app-vdyp"."vdyp_user" ("identity_provider_code" ASC)
+;
+
+/* Create Foreign Key Constraints */
+
+ALTER TABLE "app-vdyp"."vdyp_user"
+    ADD CONSTRAINT "user_idpcode_fk"
+        FOREIGN KEY ("identity_provider_code") REFERENCES "app-vdyp"."identity_provider_code" ("identity_provider_code") ON DELETE No Action ON UPDATE No Action
+;
+
+/* Create Table Comments, Sequences for Autonumber Columns */
+
+COMMENT
+ON COLUMN "app-vdyp"."vdyp_user"."identity_provider_code"
+	IS 'identity_provider_code: Is a foreign key to identity_provider_code: Identity Provider Code is a code representing the identity provider used to authenticate a user profile. Values are: - IDIR - BCeID'
+;

--- a/db/liquibase/scripts/01_00_15/00/dml/app-vdyp.identity_provider_code.sql
+++ b/db/liquibase/scripts/01_00_15/00/dml/app-vdyp.identity_provider_code.sql
@@ -1,0 +1,3 @@
+INSERT INTO "app-vdyp".identity_provider_code (identity_provider_code,description,display_order,effective_date,expiry_date,revision_count,create_user,create_date,update_user,update_date) VALUES
+	 ('IDIR','IDIR',1,'2026-07-23','9999-12-31',1,'System','2026-07-23','System','2026-07-23'),
+	 ('BCEID','BCeID',2,'2026-07-23','9999-12-31',1,'System','2026-07-23','System','2026-07-23');

--- a/db/liquibase/scripts/01_00_15/01/grants/app-vdyp.ddl.apply_grants.sql
+++ b/db/liquibase/scripts/01_00_15/01/grants/app-vdyp.ddl.apply_grants.sql
@@ -1,0 +1,1 @@
+GRANT SELECT, INSERT, UPDATE, DELETE ON "app-vdyp".identity_provider_code TO "app_vdyp_rest_proxy";

--- a/db/liquibase/vdyp-changelog.json
+++ b/db/liquibase/vdyp-changelog.json
@@ -681,6 +681,75 @@
           }
         ]
       }
+    },
+    {
+      "changeSet": {
+        "id": "01_00_15_00",
+        "author": "rjeong",
+        "changes": [
+          {
+            "tagDatabase": {
+              "tag": "version_01_00_15_00"
+            }
+          },
+          {
+            "sqlFile": {
+              "dbms": "postgresql",
+              "endDelimiter": ";",
+              "path": "scripts/01_00_15/00/ddl/tables/app-vdyp.identity_provider_code.sql",
+              "relativeToChangelogFile": true
+            }
+          },
+          {
+            "sqlFile": {
+              "dbms": "postgresql",
+              "endDelimiter": ";",
+              "path": "scripts/01_00_15/00/ddl/tables/app-vdyp.vdyp_user.sql",
+              "relativeToChangelogFile": true
+            }
+          },
+          {
+            "sqlFile": {
+              "dbms": "postgresql",
+              "endDelimiter": ";",
+              "path": "scripts/01_00_15/00/dml/app-vdyp.identity_provider_code.sql",
+              "relativeToChangelogFile": true
+            }
+          }
+        ],
+        "rollback": [
+          {
+            "sql": "ALTER TABLE \"app-vdyp\".\"vdyp_user\" DROP CONSTRAINT IF EXISTS \"user_idpcode_fk\""
+          },
+          {
+            "sql": "ALTER TABLE \"app-vdyp\".\"vdyp_user\" DROP COLUMN IF EXISTS \"identity_provider_code\""
+          },
+          {
+            "sql": "DROP TABLE IF EXISTS \"app-vdyp\".\"identity_provider_code\""
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "01_00_15_01",
+        "author": "rjeong",
+        "changes": [
+          {
+            "tagDatabase": {
+              "tag": "version_01_00_15_01"
+            }
+          },
+          {
+            "sqlFile": {
+              "dbms": "postgresql",
+              "endDelimiter": ";",
+              "path": "scripts/01_00_15/01/grants/app-vdyp.ddl.apply_grants.sql",
+              "relativeToChangelogFile": true
+            }
+          }
+        ]
+      }
     }
   ]
 }


### PR DESCRIPTION
- Add identity_provider_code code table (IDIR, BCeID) via Liquibase, with a new nullable FK column on vdyp_user
- Extract the JWT identity_provider claim in VDYPUserService and map it to the code table on login/token refresh, for both new and existing users
- Expose identityProviderCode on the VDYPUserModel API response