### PR TITLE
Feature/VDYP-1263: Add admin-only endpoint to list all RUNNING projections

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -23,6 +23,7 @@
 		<quarkus.platform.version>3.10.1</quarkus.platform.version>
     <surefire-plugin.version>3.2.5</surefire-plugin.version>
 		<testcontainers.version>2.0.2</testcontainers.version>
+		<sonar.coverage.jacoco.xmlReportPaths>${project.build.directory}/site/jacoco/jacoco.xml,${project.build.directory}/jacoco-report/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -420,5 +421,15 @@
         <quarkus.native.enabled>true</quarkus.native.enabled>
       </properties>
     </profile>
+		<profile>
+			<id>coverage</id>
+			<dependencies>
+				<dependency>
+					<groupId>io.quarkus</groupId>
+					<artifactId>quarkus-jacoco</artifactId>
+					<scope>test</scope>
+				</dependency>
+			</dependencies>
+		</profile>
 	</profiles>
 </project>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -210,6 +210,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-test-security</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.instancio</groupId>
       <artifactId>instancio-junit</artifactId>
       <scope>test</scope>

--- a/backend/src/main/java/ca/bc/gov/nrs/vdyp/backend/data/repositories/ProjectionRepository.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/vdyp/backend/data/repositories/ProjectionRepository.java
@@ -18,6 +18,11 @@ public class ProjectionRepository implements PanacheRepositoryBase<ProjectionEnt
 		return list("ownerUser.vdypUserGUID = ?1", sort, vdypUserGUID);
 	}
 
+	public List<ProjectionEntity> findByStatus(String projectionStatusCode) {
+		Sort sort = Sort.by("updateDate").descending();
+		return list("projectionStatusCode.projectionStatusCode = ?1", sort, projectionStatusCode);
+	}
+
 	public long countUsesFileSet(UUID fileSetGUID) {
 		// Check for this fileSet in polygon or layer file sets in any projection
 		// Potential improvement, could remove result file set, confident we shouldn't share that one under any

--- a/backend/src/main/java/ca/bc/gov/nrs/vdyp/backend/endpoints/v1/ProjectionEndpoint.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/vdyp/backend/endpoints/v1/ProjectionEndpoint.java
@@ -202,6 +202,16 @@ public class ProjectionEndpoint implements Endpoint {
 		return Response.ok(projections).status(Response.Status.OK).build();
 	}
 
+	@GET
+	@RolesAllowed("ADMIN")
+	@Path("/all")
+	@Produces({ MediaType.APPLICATION_JSON })
+	@Tag(name = "Get Running Projections", description = "(Admin Only) Get all RUNNING projections across all users.")
+	public Response getAllRunningProjections() {
+		var projections = projectionService.getAllRunningProjections();
+		return Response.ok(projections).status(Response.Status.OK).build();
+	}
+
 	@POST
 	@RolesAllowed({ "USER", "ADMIN" })
 	@Path("/new")

--- a/backend/src/main/java/ca/bc/gov/nrs/vdyp/backend/services/ProjectionService.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/vdyp/backend/services/ProjectionService.java
@@ -456,6 +456,13 @@ public class ProjectionService {
 		return entities.stream().map(e -> toRichModel(e, batchMappings)).toList();
 	}
 
+	public List<ProjectionModel> getAllRunningProjections() {
+		List<ProjectionEntity> entities = repository.findByStatus(ProjectionStatusCodeModel.RUNNING);
+		Map<UUID, ProjectionBatchMappingModel> batchMappings = this.getBatchMappingsForProjections(entities);
+
+		return entities.stream().map(e -> toRichModel(e, batchMappings)).toList();
+	}
+
 	@Transactional
 	public ProjectionModel createNewProjection(
 			VDYPUserModel actingUser, Parameters params, ModelParameters modelParameters, String reportDescription

--- a/backend/src/test/java/ca/bc/gov/nrs/vdyp/backend/endpoints/v1/ProjectionEndpointRunningProjectionsTest.java
+++ b/backend/src/test/java/ca/bc/gov/nrs/vdyp/backend/endpoints/v1/ProjectionEndpointRunningProjectionsTest.java
@@ -1,0 +1,32 @@
+package ca.bc.gov.nrs.vdyp.backend.endpoints.v1;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+
+import ca.bc.gov.nrs.api.helpers.TestHelper;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.security.TestSecurity;
+
+@QuarkusTest
+class ProjectionEndpointRunningProjectionsTest {
+
+	@Test
+	@TestSecurity(user = "non-admin-test-user", roles = { "USER" })
+	void getAllRunningProjections_nonAdminUser_returnsForbidden() {
+		given().basePath(TestHelper.ROOT_PATH).when().get("/projection/all").then().statusCode(403);
+	}
+
+	@Test
+	@TestSecurity(user = "admin-test-user", roles = { "ADMIN" })
+	void getAllRunningProjections_adminUser_returnsOk() {
+		given().basePath(TestHelper.ROOT_PATH).when().get("/projection/all").then().statusCode(200);
+	}
+
+	@Test
+	void getAllRunningProjections_unauthenticatedUser_isRejected() {
+		given().basePath(TestHelper.ROOT_PATH).when().get("/projection/all").then().statusCode(anyOf(is(401), is(403)));
+	}
+}

--- a/backend/src/test/java/ca/bc/gov/nrs/vdyp/backend/services/ProjectionServiceTest.java
+++ b/backend/src/test/java/ca/bc/gov/nrs/vdyp/backend/services/ProjectionServiceTest.java
@@ -289,6 +289,40 @@ class ProjectionServiceTest {
 
 		verify(repository).findByOwner(doesNotExist);
 	}
+
+	@Test
+	void getAllRunningProjections_returnsEmpty_whenNoneRunning() {
+		when(repository.findByStatus(ProjectionStatusCodeModel.RUNNING)).thenReturn(Collections.emptyList());
+
+		List<ProjectionModel> results = service.getAllRunningProjections();
+
+		assertNotNull(results);
+		assertTrue(results.isEmpty());
+		verify(repository).findByStatus(ProjectionStatusCodeModel.RUNNING);
+	}
+
+	@Test
+	void getAllRunningProjections_returnsList_acrossAllOwners() {
+		ProjectionEntity entityResult = new ProjectionEntity();
+		entityResult.setProjectionGUID(UUID.randomUUID());
+		entityResult.setReportTitle("Running Projection");
+		entityResult.setReportDescription("Running Description");
+
+		when(repository.findByStatus(ProjectionStatusCodeModel.RUNNING)).thenReturn(List.of(entityResult));
+		when(expiryConfig.expiryFrom(any())).thenReturn(OffsetDateTime.now());
+
+		List<ProjectionModel> results = service.getAllRunningProjections();
+
+		assertNotNull(results);
+		assertThat(results).hasSize(1);
+
+		ProjectionModel result = results.get(0);
+		assertThat(result.getProjectionGUID()).isEqualTo(entityResult.getProjectionGUID().toString());
+		assertThat(result.getReportTitle()).isEqualTo("Running Projection");
+		assertThat(result.getReportDescription()).isEqualTo("Running Description");
+
+		verify(repository).findByStatus(ProjectionStatusCodeModel.RUNNING);
+	}
 	// ==========================================================
 	// getProjectionEntity
 	// ==========================================================
@@ -1869,6 +1903,27 @@ class ProjectionServiceTest {
 
 		assertThat(response.getStatus()).isEqualTo(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode());
 		assertThat(response.getEntity()).isEqualTo("service failed");
+	}
+
+	// ==========================================================
+	// ProjectionEndpoint - getAllRunningProjections
+	// ==========================================================
+
+	@Test
+	void endpoint_getAllRunningProjections_returnsOk_withProjectionsFromService() {
+		ProjectionService mockService = mock(ProjectionService.class);
+		CurrentVDYPUser currentVDYPUser = mock(CurrentVDYPUser.class);
+		ProjectionEndpoint endpoint = new ProjectionEndpoint(mockService, currentVDYPUser);
+
+		ProjectionModel running = new ProjectionModel();
+		running.setProjectionGUID(UUID.randomUUID().toString());
+		when(mockService.getAllRunningProjections()).thenReturn(List.of(running));
+
+		Response response = endpoint.getAllRunningProjections();
+
+		assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+		assertThat(response.getEntity()).isEqualTo(List.of(running));
+		verify(mockService).getAllRunningProjections();
 	}
 
 	// ==========================================================


### PR DESCRIPTION
- Add GET /api/v8/projection/all, restricted to ADMIN role, returning all projections currently in RUNNING status across all users
- Add ProjectionRepository.findByStatus to query projections by status without an owner restriction
- Add ProjectionService.getAllRunningProjections to assemble the response (reusing existing batch-mapping enrichment for workerCount/completedPolygonCount/polygonCount)
- Add tests confirming non-ADMIN users receive 403 and ADMIN users receive 200