### PR TITLE
Feature/VDYP-1288: Fix reversed Duration.between() args causing wrong Total Duration in ProgressLog.txt

### DIFF
--- a/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/configuration/BatchConfiguration.java
+++ b/batch/src/main/java/ca/bc/gov/nrs/vdyp/batch/configuration/BatchConfiguration.java
@@ -383,7 +383,7 @@ public class BatchConfiguration {
 			LocalDateTime startTime = jobExecution.getStartTime();
 			ZonedDateTime now = ZonedDateTime.now(ZoneId.systemDefault());
 			Duration duration = Duration
-					.between(now, startTime == null ? now : startTime.atZone(ZoneId.systemDefault()));
+					.between(startTime == null ? now : startTime.atZone(ZoneId.systemDefault()), now);
 
 			boolean cleanupEnabled = batchProperties.getPartition().getInterimDirsCleanupEnabled();
 


### PR DESCRIPTION
- Fixed reversed Duration.between() args in the post-processing tasklet, which produced a negative duration and caused ProgressLog.txt to show a bogus small millisecond value instead of the actual Total Duration.