### PR TITLE
Release 1.2.0: Set the version numbers to proper fixed versions

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>ca.bc.gov.nrs.vdyp</groupId>
     <artifactId>vdyp-root</artifactId>
-    <version>1.2.0-SNAPSHOT</version>
+		<version>1.2.0</version>
   </parent>
   <artifactId>vdyp-backend</artifactId>
   <name>Variable Density Yield Project - Backend</name>

--- a/batch/pom.xml
+++ b/batch/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>ca.bc.gov.nrs.vdyp</groupId>
         <artifactId>vdyp-root</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0</version>
     </parent>
     <artifactId>vdyp-batch</artifactId>
     <name>Variable Density Yield Project - Batch</name>

--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>ca.bc.gov.nrs.vdyp</groupId>
 		<artifactId>vdyp-root</artifactId>
-		<version>1.2.0-SNAPSHOT</version>
+		<version>1.2.0</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>ca.bc.gov.nrs.vdyp</groupId>
 		<artifactId>vdyp-root</artifactId>
-		<version>1.2.0-SNAPSHOT</version>
+		<version>1.2.0</version>
 	</parent>
 
 	<properties>

--- a/lib/vdyp-back/pom.xml
+++ b/lib/vdyp-back/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>ca.bc.gov.nrs.vdyp</groupId>
 		<artifactId>vdyp-lib</artifactId>
-		<version>1.2.0-SNAPSHOT</version>
+		<version>1.2.0</version>
 	</parent>
 
 	<dependencies>

--- a/lib/vdyp-common/pom.xml
+++ b/lib/vdyp-common/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>ca.bc.gov.nrs.vdyp</groupId>
 		<artifactId>vdyp-lib</artifactId>
-		<version>1.2.0-SNAPSHOT</version>
+		<version>1.2.0</version>
 	</parent>
 
 	<dependencies>

--- a/lib/vdyp-extended-core/pom.xml
+++ b/lib/vdyp-extended-core/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>ca.bc.gov.nrs.vdyp</groupId>
 		<artifactId>vdyp-lib</artifactId>
-		<version>1.2.0-SNAPSHOT</version>
+		<version>1.2.0</version>
 	</parent>
 
 	<dependencies>

--- a/lib/vdyp-fip/pom.xml
+++ b/lib/vdyp-fip/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>ca.bc.gov.nrs.vdyp</groupId>
 		<artifactId>vdyp-lib</artifactId>
-		<version>1.2.0-SNAPSHOT</version>
+		<version>1.2.0</version>
 	</parent>
 
 	<dependencies>

--- a/lib/vdyp-forward/pom.xml
+++ b/lib/vdyp-forward/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>ca.bc.gov.nrs.vdyp</groupId>
 		<artifactId>vdyp-lib</artifactId>
-		<version>1.2.0-SNAPSHOT</version>
+		<version>1.2.0</version>
 	</parent>
 
 	<dependencies>

--- a/lib/vdyp-integration-tests/pom.xml
+++ b/lib/vdyp-integration-tests/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>ca.bc.gov.nrs.vdyp</groupId>
 		<artifactId>vdyp-lib</artifactId>
-		<version>1.2.0-SNAPSHOT</version>
+		<version>1.2.0</version>
 	</parent>
 
 	<dependencies>

--- a/lib/vdyp-si32/pom.xml
+++ b/lib/vdyp-si32/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>ca.bc.gov.nrs.vdyp</groupId>
 		<artifactId>vdyp-lib</artifactId>
-		<version>1.2.0-SNAPSHOT</version>
+		<version>1.2.0</version>
 	</parent>
 
 	<build>

--- a/lib/vdyp-sindex/pom.xml
+++ b/lib/vdyp-sindex/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>ca.bc.gov.nrs.vdyp</groupId>
 		<artifactId>vdyp-lib</artifactId>
-		<version>1.2.0-SNAPSHOT</version>
+		<version>1.2.0</version>
 	</parent>
 
 	<build>

--- a/lib/vdyp-vri/pom.xml
+++ b/lib/vdyp-vri/pom.xml
@@ -12,14 +12,14 @@
 	<parent>
 		<groupId>ca.bc.gov.nrs.vdyp</groupId>
 		<artifactId>vdyp-lib</artifactId>
-		<version>1.2.0-SNAPSHOT</version>
+		<version>1.2.0</version>
 	</parent>
 
 	<dependencies>
 		<dependency>
 			<groupId>ca.bc.gov.nrs.vdyp</groupId>
 			<artifactId>vdyp-common</artifactId>
-			<version>1.2.0-SNAPSHOT</version>
+			<version>1.2.0</version>
 		</dependency>
 
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>ca.bc.gov.nrs.vdyp</groupId>
 	<artifactId>vdyp-root</artifactId>
-	<version>1.2.0-SNAPSHOT</version>
+	<version>1.2.0</version>
 	<packaging>pom</packaging>
 
 	<name>Variable Density Yield Project - Parent</name>

--- a/report-aggregate/pom.xml
+++ b/report-aggregate/pom.xml
@@ -3,7 +3,7 @@
 
 	<groupId>ca.bc.gov.nrs.vdyp</groupId>
   <artifactId>report-aggregate</artifactId>
-	<version>1.2.0-SNAPSHOT</version>
+	<version>1.2.0</version>
   <name>Variable Density Yield Project - Report Aggregation</name>
   <description>Aggregate Coverage Report</description>
 

--- a/vdyp-test-oracle/pom.xml
+++ b/vdyp-test-oracle/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>ca.bc.gov.nrs.vdyp</groupId>
 		<artifactId>vdyp-root</artifactId>
-		<version>1.2.0-SNAPSHOT</version>
+		<version>1.2.0</version>
 	</parent>
 
 	<dependencies>


### PR DESCRIPTION
This will get merged to main, then we will have a PR to set the versions to 1.3.0-SNAPSHOT