### PR TITLE
Feature/VDYP-1342: Sync vdyp_user.user_type from JWT roles on every request

### DIFF
--- a/backend/src/main/java/ca/bc/gov/nrs/vdyp/backend/services/VDYPUserService.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/vdyp/backend/services/VDYPUserService.java
@@ -129,6 +129,13 @@ public class VDYPUserService {
 				existingUser
 						.setIdentityProviderCode(identityProviderLookup.requireEntity(identityProviderCode.getCode()));
 			}
+
+			Set<String> roles = identity.getRoles();
+			UserTypeCodeModel userType = userTypeLookup.getUserTypeCodeFromExternalRoles(roles);
+			if (userType != null && !userType.isSystemUser()) {
+				existingUser.setUserTypeCode(userTypeLookup.requireEntity(userType.getCode()));
+			}
+
 			return assembler.toModel(existingUser);
 		} else {
 			return null;

--- a/backend/src/main/java/ca/bc/gov/nrs/vdyp/backend/services/VDYPUserService.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/vdyp/backend/services/VDYPUserService.java
@@ -84,61 +84,64 @@ public class VDYPUserService {
 			return null;
 		}
 		Principal identityToken = identity.getPrincipal();
-		if (identityToken instanceof JsonWebToken jwt) {
-			String oidcId = jwt.getName();
-			logger.debug("Checking for user with oidcId {}", oidcId);
-			String identityProviderClaim = jwt.getClaim("identity_provider");
-			IdentityProviderCodeModel identityProviderCode = identityProviderLookup
-					.getIdentityProviderCodeFromClaim(identityProviderClaim).orElse(null);
-
-			Optional<VDYPUserEntity> userOption = userRepository.findByOIDC(oidcId);
-			if (userOption.isEmpty()) {
-				Set<String> roles = identity.getRoles();
-				UserTypeCodeModel userType = userTypeLookup.getUserTypeCodeFromExternalRoles(roles);
-				if (userType == null) {
-					logger.debug("No valid role found");
-					return null;
-				}
-				if (!userType.isSystemUser()) {
-					String firstName = jwt.getClaim("given_name");
-					String lastName = jwt.getClaim("family_name");
-					String displayName = jwt.getClaim("display_name");
-					String email = jwt.getClaim("email");
-
-					VDYPUserModel newUser = new VDYPUserModel();
-					newUser.setUserTypeCode(userType);
-					newUser.setOidcGUID(oidcId);
-					newUser.setFirstName(firstName);
-					newUser.setLastName(lastName);
-					newUser.setDisplayName(displayName);
-					newUser.setEmail(email);
-					newUser.setIdentityProviderCode(identityProviderCode);
-
-					logger.debug(
-							"Creating new user with oidcId {}, firstName {}, lastName {}, usertypeCode {}", oidcId,
-							firstName, lastName, newUser.getUserTypeCode().getCode()
-					);
-
-					return createUser(newUser);
-				} else {
-					return getSystemUser();
-				}
-			}
-			VDYPUserEntity existingUser = userOption.get();
-			if (identityProviderCode != null) {
-				existingUser
-						.setIdentityProviderCode(identityProviderLookup.requireEntity(identityProviderCode.getCode()));
-			}
-
-			Set<String> roles = identity.getRoles();
-			UserTypeCodeModel userType = userTypeLookup.getUserTypeCodeFromExternalRoles(roles);
-			if (userType != null && !userType.isSystemUser()) {
-				existingUser.setUserTypeCode(userTypeLookup.requireEntity(userType.getCode()));
-			}
-
-			return assembler.toModel(existingUser);
-		} else {
+		if (! (identityToken instanceof JsonWebToken jwt)) {
 			return null;
+		}
+
+		String oidcId = jwt.getName();
+		logger.debug("Checking for user with oidcId {}", oidcId);
+		IdentityProviderCodeModel identityProviderCode = identityProviderLookup
+				.getIdentityProviderCodeFromClaim(jwt.getClaim("identity_provider")).orElse(null);
+
+		Optional<VDYPUserEntity> userOption = userRepository.findByOIDC(oidcId);
+		if (userOption.isEmpty()) {
+			return createUserFromJwt(jwt, oidcId, identity.getRoles(), identityProviderCode);
+		}
+
+		VDYPUserEntity existingUser = userOption.get();
+		syncExistingUser(existingUser, identity.getRoles(), identityProviderCode);
+		return assembler.toModel(existingUser);
+	}
+
+	private VDYPUserModel createUserFromJwt(
+			JsonWebToken jwt, String oidcId, Set<String> roles, IdentityProviderCodeModel identityProviderCode
+	) {
+		UserTypeCodeModel userType = userTypeLookup.getUserTypeCodeFromExternalRoles(roles);
+		if (userType == null) {
+			logger.debug("No valid role found");
+			return null;
+		}
+		if (userType.isSystemUser()) {
+			return getSystemUser();
+		}
+
+		VDYPUserModel newUser = new VDYPUserModel();
+		newUser.setUserTypeCode(userType);
+		newUser.setOidcGUID(oidcId);
+		newUser.setFirstName(jwt.getClaim("given_name"));
+		newUser.setLastName(jwt.getClaim("family_name"));
+		newUser.setDisplayName(jwt.getClaim("display_name"));
+		newUser.setEmail(jwt.getClaim("email"));
+		newUser.setIdentityProviderCode(identityProviderCode);
+
+		logger.debug(
+				"Creating new user with oidcId {}, firstName {}, lastName {}, usertypeCode {}", oidcId,
+				newUser.getFirstName(), newUser.getLastName(), newUser.getUserTypeCode().getCode()
+		);
+
+		return createUser(newUser);
+	}
+
+	private void syncExistingUser(
+			VDYPUserEntity existingUser, Set<String> roles, IdentityProviderCodeModel identityProviderCode
+	) {
+		if (identityProviderCode != null) {
+			existingUser.setIdentityProviderCode(identityProviderLookup.requireEntity(identityProviderCode.getCode()));
+		}
+
+		UserTypeCodeModel userType = userTypeLookup.getUserTypeCodeFromExternalRoles(roles);
+		if (userType != null && !userType.isSystemUser()) {
+			existingUser.setUserTypeCode(userTypeLookup.requireEntity(userType.getCode()));
 		}
 	}
 

--- a/backend/src/test/java/ca/bc/gov/nrs/vdyp/backend/services/VDYPUserServiceTest.java
+++ b/backend/src/test/java/ca/bc/gov/nrs/vdyp/backend/services/VDYPUserServiceTest.java
@@ -103,12 +103,94 @@ class VDYPUserServiceTest {
 		entity.setVdypUserGUID(internalID);
 		when(userRepository.findByOIDC("1234567890@fakeid")).thenReturn(Optional.of(entity));
 
+		Set<String> roles = Set.of("User");
+		when(identity.getRoles()).thenReturn(roles);
+		when(userTypeLookup.getUserTypeCodeFromExternalRoles(roles)).thenReturn(null);
+
 		VDYPUserModel result = service.ensureVDYPUserFromSecurityIdentity(identity);
 
 		assertThat(result.getVdypUserGUID()).isEqualTo(internalID.toString());
 
 		verify(userRepository).findByOIDC("1234567890@fakeid");
-		verifyNoInteractions(userTypeLookup);
+	}
+
+	@Test
+	void ensureVDYPUserFromSecurityIdentity_updatesUserTypeCode_onExistingUser_whenRoleChanged() {
+		when(identity.isAnonymous()).thenReturn(false);
+		when(identity.getPrincipal()).thenReturn(jwt);
+		when(jwt.getName()).thenReturn("1234567890@fakeid");
+		when(jwt.getClaim("identity_provider")).thenReturn(null);
+
+		VDYPUserEntity entity = new VDYPUserEntity();
+		UUID internalID = UUID.randomUUID();
+		entity.setVdypUserGUID(internalID);
+		when(userRepository.findByOIDC("1234567890@fakeid")).thenReturn(Optional.of(entity));
+
+		Set<String> roles = Set.of("Admin");
+		when(identity.getRoles()).thenReturn(roles);
+
+		UserTypeCodeModel adminType = new UserTypeCodeModel();
+		adminType.setCode(UserTypeCodeModel.ADMIN);
+		when(userTypeLookup.getUserTypeCodeFromExternalRoles(roles)).thenReturn(adminType);
+
+		var adminEntity = new ca.bc.gov.nrs.vdyp.backend.data.entities.UserTypeCodeEntity();
+		adminEntity.setCode(UserTypeCodeModel.ADMIN);
+		when(userTypeLookup.requireEntity(UserTypeCodeModel.ADMIN)).thenReturn(adminEntity);
+
+		VDYPUserModel result = service.ensureVDYPUserFromSecurityIdentity(identity);
+
+		assertThat(result.getUserTypeCode().getCode()).isEqualTo(UserTypeCodeModel.ADMIN);
+	}
+
+	@Test
+	void ensureVDYPUserFromSecurityIdentity_doesNotUpdateUserTypeCode_onExistingUser_whenNoValidRole() {
+		when(identity.isAnonymous()).thenReturn(false);
+		when(identity.getPrincipal()).thenReturn(jwt);
+		when(jwt.getName()).thenReturn("1234567890@fakeid");
+		when(jwt.getClaim("identity_provider")).thenReturn(null);
+
+		VDYPUserEntity entity = new VDYPUserEntity();
+		UUID internalID = UUID.randomUUID();
+		entity.setVdypUserGUID(internalID);
+		var existingType = new ca.bc.gov.nrs.vdyp.backend.data.entities.UserTypeCodeEntity();
+		existingType.setCode(UserTypeCodeModel.USER);
+		entity.setUserTypeCode(existingType);
+		when(userRepository.findByOIDC("1234567890@fakeid")).thenReturn(Optional.of(entity));
+
+		Set<String> roles = Set.of("UnknownRole");
+		when(identity.getRoles()).thenReturn(roles);
+		when(userTypeLookup.getUserTypeCodeFromExternalRoles(roles)).thenReturn(null);
+
+		VDYPUserModel result = service.ensureVDYPUserFromSecurityIdentity(identity);
+
+		assertThat(result.getUserTypeCode().getCode()).isEqualTo(UserTypeCodeModel.USER);
+	}
+
+	@Test
+	void ensureVDYPUserFromSecurityIdentity_doesNotUpdateUserTypeCode_onExistingUser_whenSystemRole() {
+		when(identity.isAnonymous()).thenReturn(false);
+		when(identity.getPrincipal()).thenReturn(jwt);
+		when(jwt.getName()).thenReturn("1234567890@fakeid");
+		when(jwt.getClaim("identity_provider")).thenReturn(null);
+
+		VDYPUserEntity entity = new VDYPUserEntity();
+		UUID internalID = UUID.randomUUID();
+		entity.setVdypUserGUID(internalID);
+		var existingType = new ca.bc.gov.nrs.vdyp.backend.data.entities.UserTypeCodeEntity();
+		existingType.setCode(UserTypeCodeModel.USER);
+		entity.setUserTypeCode(existingType);
+		when(userRepository.findByOIDC("1234567890@fakeid")).thenReturn(Optional.of(entity));
+
+		Set<String> roles = Set.of("System");
+		when(identity.getRoles()).thenReturn(roles);
+
+		UserTypeCodeModel systemType = new UserTypeCodeModel();
+		systemType.setCode(UserTypeCodeModel.SYSTEM);
+		when(userTypeLookup.getUserTypeCodeFromExternalRoles(roles)).thenReturn(systemType);
+
+		VDYPUserModel result = service.ensureVDYPUserFromSecurityIdentity(identity);
+
+		assertThat(result.getUserTypeCode().getCode()).isEqualTo(UserTypeCodeModel.USER);
 	}
 
 	@Test


### PR DESCRIPTION
vdyp_user.user_type was only set on first login and never refreshed afterward, so a CSS role change never reached the DB. This caused admin cancellations to silently save as Draft instead of Cancelled By Administrator. Now user_type is refreshed from JWT roles, same as identity_provider_code.